### PR TITLE
feat: Inline auth policy config

### DIFF
--- a/docs/plans/multi-principal-control-server.md
+++ b/docs/plans/multi-principal-control-server.md
@@ -1,7 +1,7 @@
 # Multi-Principal Control Server Authorization Plan
 
 **Spec reference:** `docs/spec.md` sections 5.4, 6.1, and 6.2; `docs/api.md`; `docs/tls.md`
-**Status:** Slice 3 implemented; controlled sharing follow-ups next
+**Status:** Slice 3B implemented; controlled sharing follow-ups next
 **Last reviewed:** 2026-05-28
 
 ## Summary
@@ -61,6 +61,11 @@ Slice 2 is split into PR-sized enforcement work:
   structured denials, server bearer-token failures emit redacted audit logs, and
   control-service authorization denials emit audit logs with reason, action,
   resource, principal, binding, and grant fields.
+- Slice 3B now makes inline `auth.policy.bindings` the default config path,
+  keeps `auth.policy_file` as a mutually exclusive escape hatch, enforces
+  issuer-level `required_claims` during OIDC validation, and updates examples
+  to derive owner principal IDs from immutable provider claim IDs instead of
+  reusable subject or slug strings.
 
 Focused validation run on 2026-05-25:
 
@@ -121,6 +126,22 @@ mise exec -- go test ./internal/authz ./internal/cli ./internal/controlserver ./
 Result: passed.
 
 Slice 3 repository validation run on 2026-05-28:
+
+```text
+mise run check
+```
+
+Result: passed.
+
+Slice 3B focused validation run on 2026-05-28:
+
+```text
+mise exec -- go test ./internal/runtimeconfig ./internal/authz ./internal/cli ./internal/controlserver
+```
+
+Result: passed.
+
+Slice 3B repository validation run on 2026-05-28:
 
 ```text
 mise run check
@@ -216,14 +237,17 @@ type Principal struct {
 ```
 
 The principal ID should be stable across server restarts and should include the
-issuer identity. A safe default is `oidc:<issuer-name>:<sub>`, after canonical
-normalization. Do not use the raw `sub` alone because different issuers can reuse
-subject strings.
+issuer identity plus provider claims that are not reusable by another org,
+repository, pipeline, or bot. Do not use raw slug claims as ownership identity.
+`sub` is acceptable only for issuers that guarantee it is stable and
+non-reassignable for the lifetime of retained Cleanroom resources.
 
 ### Runtime Config
 
-The main runtime config should define trust roots and point to authorization
-bindings. It should not require listing every principal for dynamic bot fleets.
+The main runtime config should define trust roots and authorization bindings
+together. It should not require listing every principal for dynamic bot fleets.
+External policy files are useful once policies are generated or large, but they
+should be an escape hatch rather than the default.
 
 ```yaml
 auth:
@@ -235,45 +259,42 @@ auth:
         audiences:
           - cleanroom
         jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
-  policy_file: ~/.config/cleanroom/auth-policy.yaml
-```
-
-The policy file maps trusted claims to derived principals and grants:
-
-```yaml
-bindings:
-  - name: cleanroom-repo-bots
-    when: >
-      token.issuer == "github-actions" &&
-      claims.repository == "buildkite/cleanroom"
-    principal:
-      id: 'oidc:${token.issuer}:${claims.sub}'
-      scope: 'repo:${claims.repository}'
-    grants:
-      - name: create-cleanroom-sandboxes
-        actions:
-          - sandbox.create
-        resources:
-          - sandbox
-        condition: >
-          request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" &&
-          request.backend in ["darwin-vz"] &&
-          request.policy.resources.vcpus <= 4 &&
-          request.policy.resources.memory_bytes <= 8589934592 &&
-          request.policy.docker.required == false &&
-          request.policy.network_default == "deny"
-      - name: manage-owned-resources
-        actions:
-          - sandbox.get
-          - sandbox.list
-          - sandbox.terminate
-          - execution.create
-          - execution.get
-          - execution.list
-          - execution.stream
-        resources:
-          - sandbox
-          - execution
+        required_claims:
+          repository_owner_id: "123456"
+  policy:
+    bindings:
+      - name: cleanroom-repo-bots
+        when: >
+          token.issuer == "github-actions" &&
+          claims.repository_id == "987654"
+        principal:
+          id: 'oidc:${token.issuer}:owner:${claims.repository_owner_id}:repo:${claims.repository_id}'
+          scope: 'owner:${claims.repository_owner_id}'
+        grants:
+          - name: create-cleanroom-sandboxes
+            actions:
+              - sandbox.create
+            resources:
+              - sandbox
+            condition: >
+              request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" &&
+              request.backend in ["darwin-vz"] &&
+              request.policy.resources.vcpus <= 4 &&
+              request.policy.resources.memory_bytes <= 8589934592 &&
+              request.policy.docker.required == false &&
+              request.policy.network_default == "deny"
+          - name: manage-owned-resources
+            actions:
+              - sandbox.get
+              - sandbox.list
+              - sandbox.terminate
+              - execution.create
+              - execution.get
+              - execution.list
+              - execution.stream
+            resources:
+              - sandbox
+              - execution
 ```
 
 The exact schema can change during implementation, but the ownership boundary
@@ -753,6 +774,35 @@ Definition of done: auth failures are observable without leaking token material,
 transport behavior is fail-closed for bearer tokens, and every deny path returns
 stable reason codes that can be explained by `cleanroom auth check`.
 
+### Slice 3B: Inline Auth Config And Stable Principal IDs
+
+Scope:
+
+- Make inline `auth.policy.bindings` the default config shape.
+- Keep `auth.policy_file` as a mutually exclusive escape hatch for generated or
+  large policies.
+- Add issuer-level `required_claims` so immutable org or tenant fences are
+  enforced before policy binding.
+- Update examples away from `oidc:<issuer>:<sub>` as the default ownership
+  identity and toward immutable provider claim IDs.
+- Use immutable claim IDs in binding conditions when grants are meant for one
+  org, repository, pipeline, or bot; slug claims are only for readability.
+
+Definition of done: a shared-server operator can configure trust roots,
+immutable claim fences, principal derivation, and grants in one runtime config
+file, while existing external policy files still work when explicitly selected.
+
+Progress:
+
+- `auth.policy.bindings` is parsed directly from runtime config and compiled
+  through the same authz policy engine as external policy files.
+- `auth.policy_file` remains supported but is mutually exclusive with inline
+  policy in runtime config.
+- OIDC issuer config supports `required_claims`, enforced before policy binding.
+- `cleanroom auth check` and `cleanroom serve` both use inline policy by
+  default, with `--policy-file` still available as an explicit diagnostic
+  override for `auth check`.
+
 ### Slice 4: Controlled Sharing
 
 Scope:
@@ -820,6 +870,10 @@ Runtime smoke test:
 - Enforce exact-principal ownership before adding scope-level sharing.
 - Partition stage-cache records by owner in the first auth-enabled version.
 - Treat missing owner metadata as deny when auth is enabled.
+- Prefer inline `auth.policy` for the first auth-enabled version; keep
+  `auth.policy_file` only as an escape hatch for generated or large policies.
+- Require examples to derive owner principal IDs from immutable provider claim
+  IDs where the issuer exposes them.
 
 ## Deferred Work
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -38,44 +38,46 @@ auth:
         audiences:
           - cleanroom
         jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
-  policy_file: auth-policy.yaml
+        required_claims:
+          repository_owner_id: "123456"
+  policy:
+    bindings:
+      - name: repo-bots
+        when: claims.repository_id == "987654"
+        principal:
+          id: "oidc:${token.issuer}:owner:${claims.repository_owner_id}:repo:${claims.repository_id}"
+          scope: "owner:${claims.repository_owner_id}"
+        grants:
+          - name: create-cleanroom-sandboxes
+            actions:
+              - sandbox.create
+            resources:
+              - sandbox
+            condition: >
+              request.backend == "darwin-vz" &&
+              request.repository.remote_url == "https://github.com/buildkite/cleanroom.git"
+          - name: manage-owned-resources
+            actions:
+              - sandbox.get
+              - sandbox.list
+              - execution.create
+              - execution.get
+              - execution.list
+              - snapshot.create
+              - snapshot.get
+              - snapshot.list
+              - snapshot.restore
+            resources:
+              - sandbox
+              - execution
+              - snapshot
 ```
 
-The policy file maps trusted token claims to Cleanroom principals and grants.
-Principals are not listed in the main server config:
-
-```yaml
-bindings:
-  - name: repo-bots
-    when: claims.repository == "buildkite/cleanroom"
-    principal:
-      id: "oidc:${token.issuer}:${token.subject}"
-      scope: "repo:${claims.repository}"
-    grants:
-      - name: create-cleanroom-sandboxes
-        actions:
-          - sandbox.create
-        resources:
-          - sandbox
-        condition: >
-          request.backend == "darwin-vz" &&
-          request.repository.remote_url == "https://github.com/buildkite/cleanroom.git"
-      - name: manage-owned-resources
-        actions:
-          - sandbox.get
-          - sandbox.list
-          - execution.create
-          - execution.get
-          - execution.list
-          - snapshot.create
-          - snapshot.get
-          - snapshot.list
-          - snapshot.restore
-        resources:
-          - sandbox
-          - execution
-          - snapshot
-```
+The inline policy maps trusted token claims to Cleanroom principals and grants.
+Use immutable provider claim IDs, not reusable slugs, for principal IDs. For
+large or generated policies, `auth.policy_file` can point at a separate YAML
+file with the same `bindings` shape; it is mutually exclusive with
+`auth.policy`.
 
 Clients send the token with either `CLEANROOM_AUTH_TOKEN`,
 `--auth-token-env`, or `--auth-token-file`:

--- a/internal/authconfig/config.go
+++ b/internal/authconfig/config.go
@@ -1,0 +1,48 @@
+package authconfig
+
+const (
+	DefaultOIDCClockSkewSeconds        int64 = 60
+	DefaultOIDCMaxTokenLifetimeSeconds int64 = 3600
+)
+
+type OIDCConfig struct {
+	Issuers []OIDCIssuerConfig `yaml:"issuers,omitempty"`
+}
+
+type OIDCIssuerConfig struct {
+	Name                    string            `yaml:"name,omitempty"`
+	Issuer                  string            `yaml:"issuer"`
+	Audiences               []string          `yaml:"audiences,omitempty"`
+	JWKSURL                 string            `yaml:"jwks_url,omitempty"`
+	RequiredClaims          map[string]string `yaml:"required_claims,omitempty"`
+	AllowedAlgorithms       []string          `yaml:"allowed_algorithms,omitempty"`
+	ClockSkewSeconds        int64             `yaml:"clock_skew_seconds,omitempty"`
+	MaxTokenLifetimeSeconds int64             `yaml:"max_token_lifetime_seconds,omitempty"`
+}
+
+type Policy struct {
+	Bindings []PolicyBinding `yaml:"bindings,omitempty"`
+}
+
+func (p Policy) Configured() bool {
+	return len(p.Bindings) > 0
+}
+
+type PolicyBinding struct {
+	Name      string            `yaml:"name"`
+	When      string            `yaml:"when,omitempty"`
+	Principal PrincipalTemplate `yaml:"principal"`
+	Grants    []PolicyGrant     `yaml:"grants"`
+}
+
+type PrincipalTemplate struct {
+	ID    string `yaml:"id"`
+	Scope string `yaml:"scope,omitempty"`
+}
+
+type PolicyGrant struct {
+	Name      string   `yaml:"name,omitempty"`
+	Actions   []string `yaml:"actions"`
+	Resources []string `yaml:"resources"`
+	Condition string   `yaml:"condition,omitempty"`
+}

--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/authconfig"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -46,6 +46,68 @@ func TestOIDCValidatorAcceptsValidToken(t *testing.T) {
 	}
 	if got, want := validated.Claims["repository"], "buildkite/cleanroom"; got != want {
 		t.Fatalf("unexpected repository claim: got %v want %v", got, want)
+	}
+}
+
+func TestOIDCValidatorEnforcesRequiredClaims(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0).UTC()
+	key := mustRSAKey(t)
+	jwks := jwksServer(t, "kid-1", key)
+	validator, err := NewOIDCValidator([]authconfig.OIDCIssuerConfig{
+		{
+			Name:                    "issuer",
+			Issuer:                  "https://issuer.example",
+			Audiences:               []string{"cleanroom"},
+			JWKSURL:                 jwks.URL,
+			AllowedAlgorithms:       []string{"RS256"},
+			ClockSkewSeconds:        60,
+			MaxTokenLifetimeSeconds: 3600,
+			RequiredClaims:          map[string]string{"organization_id": "org_123"},
+		},
+	}, WithNow(func() time.Time { return now }))
+	if err != nil {
+		t.Fatalf("NewOIDCValidator returned error: %v", err)
+	}
+	baseClaims := jwt.MapClaims{
+		"iss": "https://issuer.example",
+		"sub": "bot-123",
+		"aud": []string{"cleanroom"},
+		"iat": jwt.NewNumericDate(now.Add(-time.Minute)),
+		"nbf": jwt.NewNumericDate(now.Add(-time.Minute)),
+		"exp": jwt.NewNumericDate(now.Add(time.Minute)),
+	}
+	if _, err := validator.Validate(context.Background(), signTestToken(t, key, "kid-1", baseClaims)); err == nil || !strings.Contains(err.Error(), `required claim "organization_id" is missing`) {
+		t.Fatalf("expected missing required claim error, got %v", err)
+	}
+	if _, err := validator.Validate(context.Background(), signTestToken(t, key, "kid-1", withClaim(baseClaims, "organization_id", "other"))); err == nil || !strings.Contains(err.Error(), `required claim "organization_id" does not match`) {
+		t.Fatalf("expected required claim mismatch error, got %v", err)
+	}
+	if _, err := validator.Validate(context.Background(), signTestToken(t, key, "kid-1", withClaim(baseClaims, "organization_id", "org_123"))); err != nil {
+		t.Fatalf("Validate with required claim returned error: %v", err)
+	}
+}
+
+func TestOIDCValidatorRejectsDuplicateNormalizedRequiredClaims(t *testing.T) {
+	_, err := NewOIDCValidator([]authconfig.OIDCIssuerConfig{
+		{
+			Name:                    "issuer",
+			Issuer:                  "https://issuer.example",
+			Audiences:               []string{"cleanroom"},
+			JWKSURL:                 "https://issuer.example/jwks",
+			AllowedAlgorithms:       []string{"RS256"},
+			ClockSkewSeconds:        60,
+			MaxTokenLifetimeSeconds: 3600,
+			RequiredClaims: map[string]string{
+				"repository_owner_id":  "123456",
+				" repository_owner_id": "654321",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate required claim error")
+	}
+	if got, want := err.Error(), `issuer[0].required_claims contains duplicate claim name "repository_owner_id" after trimming whitespace`; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %v", want, err)
 	}
 }
 
@@ -141,7 +203,7 @@ func TestOIDCValidatorExpiresJWKSCache(t *testing.T) {
 		}
 	}))
 	t.Cleanup(jwks.Close)
-	validator, err := NewOIDCValidator([]runtimeconfig.AuthOIDCIssuerConfig{
+	validator, err := NewOIDCValidator([]authconfig.OIDCIssuerConfig{
 		{
 			Name:                    "issuer",
 			Issuer:                  "https://issuer.example",
@@ -587,7 +649,7 @@ func TestPolicyReportsNoBinding(t *testing.T) {
 
 func newTestOIDCValidator(t *testing.T, jwksURL string, now time.Time) *OIDCValidator {
 	t.Helper()
-	validator, err := NewOIDCValidator([]runtimeconfig.AuthOIDCIssuerConfig{
+	validator, err := NewOIDCValidator([]authconfig.OIDCIssuerConfig{
 		{
 			Name:                    "issuer",
 			Issuer:                  "https://issuer.example",

--- a/internal/authz/oidc.go
+++ b/internal/authz/oidc.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/buildkite/cleanroom/internal/runtimeconfig"
+	"github.com/buildkite/cleanroom/internal/authconfig"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -32,6 +32,7 @@ type trustedOIDCIssuer struct {
 	Issuer           string
 	Audiences        []string
 	JWKSURL          string
+	RequiredClaims   map[string]string
 	AllowedAlgs      []string
 	ClockSkew        time.Duration
 	MaxTokenLifetime time.Duration
@@ -56,7 +57,7 @@ func WithNow(now func() time.Time) OIDCValidatorOption {
 	}
 }
 
-func NewOIDCValidator(issuers []runtimeconfig.AuthOIDCIssuerConfig, opts ...OIDCValidatorOption) (*OIDCValidator, error) {
+func NewOIDCValidator(issuers []authconfig.OIDCIssuerConfig, opts ...OIDCValidatorOption) (*OIDCValidator, error) {
 	v := &OIDCValidator{
 		issuersByURL: map[string]*trustedOIDCIssuer{},
 		httpClient: &http.Client{
@@ -93,25 +94,30 @@ func NewOIDCValidator(issuers []runtimeconfig.AuthOIDCIssuerConfig, opts ...OIDC
 		if len(audiences) == 0 {
 			return nil, fmt.Errorf("issuer[%d].audiences must contain at least one audience", i)
 		}
+		requiredClaims, err := normalizeRequiredClaims(cfg.RequiredClaims, fmt.Sprintf("issuer[%d].required_claims", i))
+		if err != nil {
+			return nil, err
+		}
 		clockSkew := time.Duration(cfg.ClockSkewSeconds) * time.Second
 		if clockSkew < 0 {
 			return nil, fmt.Errorf("issuer[%d].clock_skew_seconds must be non-negative", i)
 		}
 		if clockSkew == 0 {
-			clockSkew = time.Duration(runtimeconfig.DefaultAuthOIDCClockSkewSeconds) * time.Second
+			clockSkew = time.Duration(authconfig.DefaultOIDCClockSkewSeconds) * time.Second
 		}
 		maxLifetime := time.Duration(cfg.MaxTokenLifetimeSeconds) * time.Second
 		if maxLifetime < 0 {
 			return nil, fmt.Errorf("issuer[%d].max_token_lifetime_seconds must be non-negative", i)
 		}
 		if maxLifetime == 0 {
-			maxLifetime = time.Duration(runtimeconfig.DefaultAuthOIDCMaxTokenLifetimeSeconds) * time.Second
+			maxLifetime = time.Duration(authconfig.DefaultOIDCMaxTokenLifetimeSeconds) * time.Second
 		}
 		trusted := &trustedOIDCIssuer{
 			Name:             name,
 			Issuer:           issuer,
 			Audiences:        audiences,
 			JWKSURL:          strings.TrimSpace(cfg.JWKSURL),
+			RequiredClaims:   requiredClaims,
 			AllowedAlgs:      allowedAlgs,
 			ClockSkew:        clockSkew,
 			MaxTokenLifetime: maxLifetime,
@@ -178,6 +184,9 @@ func (v *OIDCValidator) Validate(ctx context.Context, tokenString string) (Valid
 	if exp.Time.Sub(iat.Time) > trusted.MaxTokenLifetime {
 		return ValidatedToken{}, fmt.Errorf("token lifetime %s exceeds maximum %s", exp.Time.Sub(iat.Time), trusted.MaxTokenLifetime)
 	}
+	if err := validateRequiredClaims(claims, trusted.RequiredClaims); err != nil {
+		return ValidatedToken{}, err
+	}
 
 	return ValidatedToken{
 		IssuerName: trusted.Name,
@@ -209,6 +218,20 @@ func (v *OIDCValidator) parseToken(ctx context.Context, tokenString string, trus
 		return trusted.keys.key(ctx, kid)
 	})
 	return parsedToken, claims, err
+}
+
+func validateRequiredClaims(claims jwt.MapClaims, required map[string]string) error {
+	for name, want := range required {
+		got, ok := claims[name]
+		if !ok {
+			return fmt.Errorf("required claim %q is missing", name)
+		}
+		gotString, ok := got.(string)
+		if !ok || gotString != want {
+			return fmt.Errorf("required claim %q does not match", name)
+		}
+	}
+	return nil
 }
 
 type jwksCache struct {
@@ -344,6 +367,31 @@ func trimStrings(values []string) []string {
 		}
 	}
 	return out
+}
+
+func normalizeRequiredClaims(values map[string]string, label string) (map[string]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("%s contains an empty claim name", label)
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil, fmt.Errorf("%s[%q] must not be empty", label, key)
+		}
+		if _, ok := out[key]; ok {
+			return nil, fmt.Errorf("%s contains duplicate claim name %q after trimming whitespace", label, key)
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
 }
 
 func copyMapStringAny(in map[string]any) map[string]any {

--- a/internal/authz/policy.go
+++ b/internal/authz/policy.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/buildkite/cleanroom/internal/authconfig"
 	"gopkg.in/yaml.v3"
 )
 
@@ -85,6 +86,35 @@ func ParsePolicy(raw []byte) (*CompiledPolicy, error) {
 		return nil, err
 	}
 	return CompilePolicy(spec)
+}
+
+func CompileRuntimePolicy(spec authconfig.Policy) (*CompiledPolicy, error) {
+	return CompilePolicy(policyFromRuntimeConfig(spec))
+}
+
+func policyFromRuntimeConfig(spec authconfig.Policy) Policy {
+	bindings := make([]Binding, 0, len(spec.Bindings))
+	for _, binding := range spec.Bindings {
+		grants := make([]Grant, 0, len(binding.Grants))
+		for _, grant := range binding.Grants {
+			grants = append(grants, Grant{
+				Name:      grant.Name,
+				Actions:   append([]string(nil), grant.Actions...),
+				Resources: append([]string(nil), grant.Resources...),
+				Condition: grant.Condition,
+			})
+		}
+		bindings = append(bindings, Binding{
+			Name: binding.Name,
+			When: binding.When,
+			Principal: PrincipalTemplate{
+				ID:    binding.Principal.ID,
+				Scope: binding.Principal.Scope,
+			},
+			Grants: grants,
+		})
+	}
+	return Policy{Bindings: bindings}
 }
 
 func CompilePolicy(spec Policy) (*CompiledPolicy, error) {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -21,7 +21,7 @@ type AuthCommand struct {
 
 type AuthCheckCommand struct {
 	Config           string `help:"Runtime config path (default: $XDG_CONFIG_HOME/cleanroom/config.yaml)"`
-	PolicyFile       string `name:"policy-file" help:"Auth policy path (default: auth.policy_file from runtime config)"`
+	PolicyFile       string `name:"policy-file" help:"Auth policy path (default: inline auth.policy or auth.policy_file from runtime config)"`
 	TokenFile        string `name:"token-file" required:"" help:"Path to OIDC JWT token file, or '-' for stdin"`
 	Action           string `required:"" help:"Cleanroom action to check, for example sandbox.create"`
 	Resource         string `help:"Resource kind (default: derived from action prefix)"`
@@ -53,11 +53,7 @@ func (c *AuthCheckCommand) Run(ctx *runtimeContext) error {
 	if err != nil {
 		return err
 	}
-	policyPath, err := resolveAuthPolicyPath(ctx.CWD, resolvedConfigPath, c.PolicyFile, cfg.Auth.PolicyFile)
-	if err != nil {
-		return err
-	}
-	policy, err := authz.LoadPolicyFile(policyPath)
+	policy, err := loadAuthPolicy(ctx.CWD, resolvedConfigPath, c.PolicyFile, cfg.Auth)
 	if err != nil {
 		return err
 	}
@@ -110,6 +106,20 @@ func (c *AuthCheckCommand) Run(ctx *runtimeContext) error {
 		Request: request,
 	})
 	return writeAuthCheckDecision(ctx, decision, c.JSON)
+}
+
+func loadAuthPolicy(cwd, configPath, explicitPolicyFile string, cfg runtimeconfig.AuthConfig) (*authz.CompiledPolicy, error) {
+	if strings.TrimSpace(explicitPolicyFile) != "" || strings.TrimSpace(cfg.PolicyFile) != "" {
+		policyPath, err := resolveAuthPolicyPath(cwd, configPath, explicitPolicyFile, cfg.PolicyFile)
+		if err != nil {
+			return nil, err
+		}
+		return authz.LoadPolicyFile(policyPath)
+	}
+	if cfg.Policy.Configured() {
+		return authz.CompileRuntimePolicy(cfg.Policy)
+	}
+	return nil, errors.New("auth policy is required (set auth.policy, auth.policy_file, or --policy-file)")
 }
 
 func completeAuthCheckDecision(decision authz.Decision, c *AuthCheckCommand) authz.Decision {

--- a/internal/cli/auth_check_test.go
+++ b/internal/cli/auth_check_test.go
@@ -41,11 +41,75 @@ func TestAuthCheckCommandReportsAllowedDecision(t *testing.T) {
 	if !decision.Allowed {
 		t.Fatalf("expected allowed decision, got %#v", decision)
 	}
-	if got, want := decision.Principal.ID, "oidc:github-actions:repo:buildkite/cleanroom:ref:refs/heads/main"; got != want {
+	if got, want := decision.Principal.ID, "oidc:github-actions:owner:123456:repo:987654"; got != want {
 		t.Fatalf("unexpected principal ID: got %q want %q", got, want)
 	}
 	if got, want := decision.Binding, "cleanroom-repo-bots"; got != want {
 		t.Fatalf("unexpected binding: got %q want %q", got, want)
+	}
+}
+
+func TestAuthCheckCommandUsesInlineRuntimePolicy(t *testing.T) {
+	fixture := newAuthCheckFixture(t)
+	config := `default_backend: firecracker
+auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        audiences: [cleanroom]
+        jwks_url: ` + fixture.jwksURL + `
+        required_claims:
+          repository_owner_id: "123456"
+        clock_skew_seconds: 60
+        max_token_lifetime_seconds: 3600
+  policy:
+    bindings:
+      - name: cleanroom-repo-bots
+        when: >
+          token.issuer == "github-actions" &&
+          claims.repository_id == "987654"
+        principal:
+          id: 'oidc:${token.issuer}:owner:${claims.repository_owner_id}:repo:${claims.repository_id}'
+          scope: 'owner:${claims.repository_owner_id}'
+        grants:
+          - name: create-cleanroom-sandbox
+            actions: [sandbox.create]
+            resources: [sandbox]
+            condition: >
+              request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" &&
+              request.backend in ["darwin-vz"] &&
+              request.policy.resources.vcpus <= 4 &&
+              request.policy.resources.memory_bytes <= 8589934592 &&
+              request.policy.docker.required == false &&
+              request.policy.network_default == "deny"
+`
+	if err := os.WriteFile(fixture.configPath, []byte(config), 0o644); err != nil {
+		t.Fatalf("write inline config: %v", err)
+	}
+
+	stdout, readStdout := makeStdoutCapture(t)
+	err := (&AuthCheckCommand{
+		Config:    fixture.configPath,
+		TokenFile: fixture.tokenPath,
+		Action:    "sandbox.create",
+		Request:   fixture.requestPath,
+		JSON:      true,
+	}).Run(&runtimeContext{CWD: fixture.dir, Stdout: stdout})
+	if err != nil {
+		t.Fatalf("AuthCheckCommand.Run returned error: %v", err)
+	}
+
+	var decision authz.Decision
+	if err := json.Unmarshal([]byte(readStdout()), &decision); err != nil {
+		t.Fatalf("decode auth check json: %v", err)
+	}
+	if !decision.Allowed {
+		t.Fatalf("expected allowed decision, got %#v", decision)
+	}
+	if got, want := decision.Principal.ID, "oidc:github-actions:owner:123456:repo:987654"; got != want {
+		t.Fatalf("unexpected principal ID: got %q want %q", got, want)
 	}
 }
 
@@ -164,6 +228,7 @@ type authCheckFixture struct {
 	policyPath  string
 	tokenPath   string
 	requestPath string
+	jwksURL     string
 }
 
 func newAuthCheckFixture(t *testing.T) authCheckFixture {
@@ -187,6 +252,8 @@ auth:
         issuer: https://token.actions.githubusercontent.com
         audiences: [cleanroom]
         jwks_url: ` + jwks.URL + `
+        required_claims:
+          repository_owner_id: "123456"
         clock_skew_seconds: 60
         max_token_lifetime_seconds: 3600
   policy_file: auth-policy.yaml
@@ -196,13 +263,15 @@ auth:
 	}
 	tokenPath := filepath.Join(dir, "token.jwt")
 	token := cliAuthSignToken(t, key, "kid-1", jwt.MapClaims{
-		"iss":        "https://token.actions.githubusercontent.com",
-		"sub":        "repo:buildkite/cleanroom:ref:refs/heads/main",
-		"aud":        []string{"cleanroom"},
-		"iat":        jwt.NewNumericDate(now.Add(-time.Minute)),
-		"nbf":        jwt.NewNumericDate(now.Add(-time.Minute)),
-		"exp":        jwt.NewNumericDate(now.Add(time.Minute)),
-		"repository": "buildkite/cleanroom",
+		"iss":                 "https://token.actions.githubusercontent.com",
+		"sub":                 "repo:buildkite/cleanroom:ref:refs/heads/main",
+		"aud":                 []string{"cleanroom"},
+		"iat":                 jwt.NewNumericDate(now.Add(-time.Minute)),
+		"nbf":                 jwt.NewNumericDate(now.Add(-time.Minute)),
+		"exp":                 jwt.NewNumericDate(now.Add(time.Minute)),
+		"repository":          "buildkite/cleanroom",
+		"repository_owner_id": "123456",
+		"repository_id":       "987654",
 	})
 	if err := os.WriteFile(tokenPath, []byte(token+"\n"), 0o600); err != nil {
 		t.Fatalf("write token: %v", err)
@@ -225,6 +294,7 @@ auth:
 		policyPath:  policyPath,
 		tokenPath:   tokenPath,
 		requestPath: requestPath,
+		jwksURL:     jwks.URL,
 	}
 }
 
@@ -277,10 +347,10 @@ func cliAuthPolicyYAML() string {
   - name: cleanroom-repo-bots
     when: >
       token.issuer == "github-actions" &&
-      claims.repository == "buildkite/cleanroom"
+      claims.repository_id == "987654"
     principal:
-      id: 'oidc:${token.issuer}:${claims.sub}'
-      scope: 'repo:${claims.repository}'
+      id: 'oidc:${token.issuer}:owner:${claims.repository_owner_id}:repo:${claims.repository_id}'
+      scope: 'owner:${claims.repository_owner_id}'
     grants:
       - name: create-cleanroom-sandbox
         actions: [sandbox.create]

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -258,11 +258,7 @@ func (s *ServeCommand) authInterceptor(ctx *runtimeContext, ep endpoint.Endpoint
 	if err := validateBearerAuthListenEndpoint(ep); err != nil {
 		return nil, err
 	}
-	policyPath, err := resolveAuthPolicyPath(ctx.CWD, ctx.ConfigPath, "", ctx.Config.Auth.PolicyFile)
-	if err != nil {
-		return nil, err
-	}
-	policy, err := authz.LoadPolicyFile(policyPath)
+	policy, err := loadAuthPolicy(ctx.CWD, ctx.ConfigPath, "", ctx.Config.Auth)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtimeconfig/config.go
+++ b/internal/runtimeconfig/config.go
@@ -14,6 +14,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/buildkite/cleanroom/internal/authconfig"
+	"github.com/buildkite/cleanroom/internal/authz"
 	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/bytesize"
 	"github.com/buildkite/cleanroom/internal/endpoint"
@@ -32,29 +34,23 @@ type Config struct {
 }
 
 const (
-	DefaultAuthOIDCClockSkewSeconds        int64 = 60
-	DefaultAuthOIDCMaxTokenLifetimeSeconds int64 = 3600
+	DefaultAuthOIDCClockSkewSeconds        = authconfig.DefaultOIDCClockSkewSeconds
+	DefaultAuthOIDCMaxTokenLifetimeSeconds = authconfig.DefaultOIDCMaxTokenLifetimeSeconds
 )
+
+type AuthOIDCConfig = authconfig.OIDCConfig
+type AuthOIDCIssuerConfig = authconfig.OIDCIssuerConfig
+type AuthPolicy = authconfig.Policy
+type AuthPolicyBinding = authconfig.PolicyBinding
+type AuthPrincipalTemplate = authconfig.PrincipalTemplate
+type AuthPolicyGrant = authconfig.PolicyGrant
 
 // AuthConfig configures control-plane caller authentication.
 type AuthConfig struct {
 	Required   bool           `yaml:"required,omitempty"`
 	OIDC       AuthOIDCConfig `yaml:"oidc,omitempty"`
+	Policy     AuthPolicy     `yaml:"policy,omitempty"`
 	PolicyFile string         `yaml:"policy_file,omitempty"`
-}
-
-type AuthOIDCConfig struct {
-	Issuers []AuthOIDCIssuerConfig `yaml:"issuers,omitempty"`
-}
-
-type AuthOIDCIssuerConfig struct {
-	Name                    string   `yaml:"name,omitempty"`
-	Issuer                  string   `yaml:"issuer"`
-	Audiences               []string `yaml:"audiences,omitempty"`
-	JWKSURL                 string   `yaml:"jwks_url,omitempty"`
-	AllowedAlgorithms       []string `yaml:"allowed_algorithms,omitempty"`
-	ClockSkewSeconds        int64    `yaml:"clock_skew_seconds,omitempty"`
-	MaxTokenLifetimeSeconds int64    `yaml:"max_token_lifetime_seconds,omitempty"`
 }
 
 // CacheConfig configures host-to-host cache reuse.
@@ -454,20 +450,28 @@ func parseConfig(path string, raw []byte) (Config, error) {
 		cfg.Backends.DarwinVZ.MinimumCacheOutputVolumeBytes = darwinVZMinCacheOutputVolumeBytes
 	}
 
-	cfg = normalizeConfig(cfg, inferredDefaultBackend(backendPresence.Backends.Firecracker != nil, backendPresence.Backends.DarwinVZ != nil || backendPresence.Backends.LegacyDarwinVZ != nil))
+	normalizedCfg, err := normalizeConfig(cfg, inferredDefaultBackend(backendPresence.Backends.Firecracker != nil, backendPresence.Backends.DarwinVZ != nil || backendPresence.Backends.LegacyDarwinVZ != nil))
+	if err != nil {
+		return Config{}, err
+	}
+	cfg = normalizedCfg
 	if err := validateConfig(cfg); err != nil {
 		return Config{}, err
 	}
 	return cfg, nil
 }
 
-func normalizeConfig(cfg Config, inferredDefaultBackend string) Config {
+func normalizeConfig(cfg Config, inferredDefaultBackend string) (Config, error) {
 	cfg.DefaultBackend = strings.TrimSpace(cfg.DefaultBackend)
 	if cfg.DefaultBackend == "" {
 		cfg.DefaultBackend = inferredDefaultBackend
 	}
 	cfg.ControlHost = strings.TrimSpace(cfg.ControlHost)
-	cfg.Auth = normalizeAuthConfig(cfg.Auth)
+	authCfg, err := normalizeAuthConfig(cfg.Auth)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.Auth = authCfg
 	cfg.Cache.Peers = normalizeCachePeers(cfg.Cache.Peers)
 	cfg.Gateway.Git.CacheHosts = trimStringSlice(cfg.Gateway.Git.CacheHosts)
 	cfg.Gateway.OCI.Registries = trimStringMap(cfg.Gateway.OCI.Registries)
@@ -483,7 +487,7 @@ func normalizeConfig(cfg Config, inferredDefaultBackend string) Config {
 	cfg.Observability.Traces.Exporter = strings.TrimSpace(cfg.Observability.Traces.Exporter)
 	cfg.Observability.Traces.Sampling.Mode = strings.TrimSpace(cfg.Observability.Traces.Sampling.Mode)
 	cfg.Observability.Traces.URLTemplate = strings.TrimSpace(cfg.Observability.Traces.URLTemplate)
-	return cfg
+	return cfg, nil
 }
 
 func inferredDefaultBackend(hasFirecracker, hasDarwinVZ bool) string {
@@ -549,7 +553,7 @@ func validateDurationSeconds(name string, seconds int64) error {
 	return nil
 }
 
-func normalizeAuthConfig(cfg AuthConfig) AuthConfig {
+func normalizeAuthConfig(cfg AuthConfig) (AuthConfig, error) {
 	cfg.PolicyFile = strings.TrimSpace(cfg.PolicyFile)
 	for i := range cfg.OIDC.Issuers {
 		issuer := &cfg.OIDC.Issuers[i]
@@ -557,6 +561,11 @@ func normalizeAuthConfig(cfg AuthConfig) AuthConfig {
 		issuer.Issuer = strings.TrimRight(strings.TrimSpace(issuer.Issuer), "/")
 		issuer.JWKSURL = strings.TrimSpace(issuer.JWKSURL)
 		issuer.Audiences = trimStringSlice(issuer.Audiences)
+		requiredClaims, err := trimRequiredClaimsMap(issuer.RequiredClaims, fmt.Sprintf("auth.oidc.issuers[%d].required_claims", i))
+		if err != nil {
+			return AuthConfig{}, err
+		}
+		issuer.RequiredClaims = requiredClaims
 		issuer.AllowedAlgorithms = trimStringSlice(issuer.AllowedAlgorithms)
 		if len(issuer.AllowedAlgorithms) == 0 && issuerConfigHasValues(*issuer) {
 			issuer.AllowedAlgorithms = []string{"RS256"}
@@ -568,7 +577,7 @@ func normalizeAuthConfig(cfg AuthConfig) AuthConfig {
 			issuer.MaxTokenLifetimeSeconds = DefaultAuthOIDCMaxTokenLifetimeSeconds
 		}
 	}
-	return cfg
+	return cfg, nil
 }
 
 func issuerConfigHasValues(cfg AuthOIDCIssuerConfig) bool {
@@ -576,21 +585,30 @@ func issuerConfigHasValues(cfg AuthOIDCIssuerConfig) bool {
 		strings.TrimSpace(cfg.Issuer) != "" ||
 		strings.TrimSpace(cfg.JWKSURL) != "" ||
 		len(cfg.Audiences) > 0 ||
+		len(cfg.RequiredClaims) > 0 ||
 		len(cfg.AllowedAlgorithms) > 0 ||
 		cfg.ClockSkewSeconds != 0 ||
 		cfg.MaxTokenLifetimeSeconds != 0
 }
 
 func validateAuthConfig(cfg AuthConfig) error {
-	configured := cfg.Required || strings.TrimSpace(cfg.PolicyFile) != "" || len(cfg.OIDC.Issuers) > 0
+	configured := cfg.Required || strings.TrimSpace(cfg.PolicyFile) != "" || cfg.Policy.Configured() || len(cfg.OIDC.Issuers) > 0
 	if !configured {
 		return nil
 	}
 	if len(cfg.OIDC.Issuers) == 0 {
 		return errors.New("auth.oidc.issuers must contain at least one issuer when auth is configured")
 	}
-	if strings.TrimSpace(cfg.PolicyFile) == "" {
-		return errors.New("auth.policy_file is required when auth is configured")
+	if strings.TrimSpace(cfg.PolicyFile) != "" && cfg.Policy.Configured() {
+		return errors.New("auth.policy and auth.policy_file are mutually exclusive")
+	}
+	if strings.TrimSpace(cfg.PolicyFile) == "" && !cfg.Policy.Configured() {
+		return errors.New("auth.policy or auth.policy_file is required when auth is configured")
+	}
+	if cfg.Policy.Configured() {
+		if _, err := authz.CompileRuntimePolicy(cfg.Policy); err != nil {
+			return fmt.Errorf("auth.policy: %w", err)
+		}
 	}
 
 	seenNames := map[string]struct{}{}
@@ -620,6 +638,14 @@ func validateAuthConfig(cfg AuthConfig) error {
 
 		if len(issuer.Audiences) == 0 {
 			return fmt.Errorf("auth.oidc.issuers[%d].audiences must contain at least one audience", i)
+		}
+		for claim, value := range issuer.RequiredClaims {
+			if strings.TrimSpace(claim) == "" {
+				return fmt.Errorf("auth.oidc.issuers[%d].required_claims contains an empty claim name", i)
+			}
+			if strings.TrimSpace(value) == "" {
+				return fmt.Errorf("auth.oidc.issuers[%d].required_claims[%q] must not be empty", i, claim)
+			}
 		}
 		if strings.TrimSpace(issuer.JWKSURL) == "" {
 			return fmt.Errorf("auth.oidc.issuers[%d].jwks_url is required", i)
@@ -1015,6 +1041,25 @@ func trimStringMap(input map[string]string) map[string]string {
 		return nil
 	}
 	return out
+}
+
+func trimRequiredClaimsMap(input map[string]string, label string) (map[string]string, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+
+	out := make(map[string]string, len(input))
+	for key, value := range input {
+		trimmedKey := strings.TrimSpace(key)
+		if _, ok := out[trimmedKey]; ok {
+			return nil, fmt.Errorf("%s contains duplicate claim name %q after trimming whitespace", label, trimmedKey)
+		}
+		out[trimmedKey] = strings.TrimSpace(value)
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
 }
 
 func trimStringSlice(input []string) []string {

--- a/internal/runtimeconfig/config_test.go
+++ b/internal/runtimeconfig/config_test.go
@@ -158,6 +158,8 @@ auth:
         audiences:
           - " cleanroom "
         jwks_url: " https://token.actions.githubusercontent.com/.well-known/jwks "
+        required_claims:
+          repository_owner_id: " 123456 "
   policy_file: " ~/.config/cleanroom/auth-policy.yaml "
 `)
 	if err != nil {
@@ -182,6 +184,9 @@ auth:
 	if got, want := issuer.Audiences, []string{"cleanroom"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected audiences: got %v want %v", got, want)
 	}
+	if got, want := issuer.RequiredClaims, map[string]string{"repository_owner_id": "123456"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected required claims: got %v want %v", got, want)
+	}
 	if got, want := issuer.AllowedAlgorithms, []string{"RS256"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected allowed algorithms: got %v want %v", got, want)
 	}
@@ -190,6 +195,47 @@ auth:
 	}
 	if got, want := issuer.MaxTokenLifetimeSeconds, DefaultAuthOIDCMaxTokenLifetimeSeconds; got != want {
 		t.Fatalf("unexpected max token lifetime: got %d want %d", got, want)
+	}
+}
+
+func TestLoadParsesInlineAuthPolicy(t *testing.T) {
+	cfg, err := loadConfigFromContent(t, `default_backend: firecracker
+auth:
+  required: true
+  oidc:
+    issuers:
+      - name: buildkite-prod
+        issuer: https://issuer.example
+        audiences: [cleanroom]
+        jwks_url: https://issuer.example/jwks
+        required_claims:
+          organization_id: org_123
+  policy:
+    bindings:
+      - name: pipeline-bots
+        when: claims.pipeline_id == "pipe_456"
+        principal:
+          id: 'oidc:${token.issuer}:org:${claims.organization_id}:pipeline:${claims.pipeline_id}'
+          scope: 'org:${claims.organization_id}'
+        grants:
+          - actions: [sandbox.create]
+            resources: [sandbox]
+`)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.Auth.PolicyFile != "" {
+		t.Fatalf("expected inline policy without policy file, got %q", cfg.Auth.PolicyFile)
+	}
+	if !cfg.Auth.Policy.Configured() {
+		t.Fatal("expected inline auth policy to be configured")
+	}
+	binding := cfg.Auth.Policy.Bindings[0]
+	if got, want := binding.Name, "pipeline-bots"; got != want {
+		t.Fatalf("unexpected binding name: got %q want %q", got, want)
+	}
+	if got, want := binding.Principal.ID, "oidc:${token.issuer}:org:${claims.organization_id}:pipeline:${claims.pipeline_id}"; got != want {
+		t.Fatalf("unexpected principal template: got %q want %q", got, want)
 	}
 }
 
@@ -208,7 +254,7 @@ func TestLoadRejectsInvalidAuthOIDCConfig(t *testing.T) {
 			wantErr: "auth.oidc.issuers must contain at least one issuer",
 		},
 		{
-			name: "missing policy file",
+			name: "missing policy",
 			auth: `auth:
   required: true
   oidc:
@@ -218,7 +264,114 @@ func TestLoadRejectsInvalidAuthOIDCConfig(t *testing.T) {
         audiences: [cleanroom]
         jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
 `,
-			wantErr: "auth.policy_file is required",
+			wantErr: "auth.policy or auth.policy_file is required",
+		},
+		{
+			name: "inline policy and policy file",
+			auth: `auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        audiences: [cleanroom]
+        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+  policy_file: ./auth-policy.yaml
+  policy:
+    bindings:
+      - name: bad
+        principal:
+          id: 'oidc:${token.issuer}:${token.subject}'
+        grants:
+          - actions: [sandbox.create]
+            resources: [sandbox]`,
+			wantErr: "auth.policy and auth.policy_file are mutually exclusive",
+		},
+		{
+			name: "inline policy invalid binding cel",
+			auth: `auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        audiences: [cleanroom]
+        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+  policy:
+    bindings:
+      - name: bad
+        when: request.backend == "darwin-vz"
+        principal:
+          id: 'oidc:${token.issuer}:${token.subject}'
+        grants:
+          - actions: [sandbox.create]
+            resources: [sandbox]`,
+			wantErr: `auth.policy: bindings[0].when: unknown CEL field "request.backend"`,
+		},
+		{
+			name: "inline policy missing principal id",
+			auth: `auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        audiences: [cleanroom]
+        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+  policy:
+    bindings:
+      - name: bad
+        grants:
+          - actions: [sandbox.create]
+            resources: [sandbox]`,
+			wantErr: "auth.policy: bindings[0].principal.id is required",
+		},
+		{
+			name: "empty required claim",
+			auth: `auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        audiences: [cleanroom]
+        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+        required_claims:
+          repository_owner_id: " "
+  policy_file: ./auth-policy.yaml
+`,
+			wantErr: `auth.oidc.issuers[0].required_claims["repository_owner_id"] must not be empty`,
+		},
+		{
+			name: "empty required claim name",
+			auth: `auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        audiences: [cleanroom]
+        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+        required_claims:
+          " ": "123456"
+  policy_file: ./auth-policy.yaml`,
+			wantErr: "auth.oidc.issuers[0].required_claims contains an empty claim name",
+		},
+		{
+			name: "duplicate required claim after trimming",
+			auth: `auth:
+  required: true
+  oidc:
+    issuers:
+      - name: github-actions
+        issuer: https://token.actions.githubusercontent.com
+        audiences: [cleanroom]
+        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+        required_claims:
+          repository_owner_id: "123456"
+          " repository_owner_id ": "654321"
+  policy_file: ./auth-policy.yaml`,
+			wantErr: `auth.oidc.issuers[0].required_claims contains duplicate claim name "repository_owner_id" after trimming whitespace`,
 		},
 		{
 			name: "missing audience",


### PR DESCRIPTION
Sean's review exposed two sharp edges in the first auth config shape: the default pointed operators at a separate policy file, and the example principal identity was too easy to base on reusable subject or slug claims.

This keeps the auth setup as one runtime-config review unit by adding inline `auth.policy.bindings` and making `auth.policy_file` a mutually exclusive escape hatch for larger or generated policies. Issuer config now supports `required_claims`, which are enforced during OIDC validation before policy binding.

The docs and auth-check fixtures now derive owner principal IDs from immutable provider claim IDs, and binding examples use immutable repository IDs rather than repository slugs for repo-specific access.