### PR TITLE
fix: Reject allow-all policy protobufs

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 6c ready for review
+**Status:** Slice 7 ready for review
 **Last reviewed:** 2026-05-28
 
 ## Summary
@@ -226,6 +226,22 @@ Focused validation run on 2026-05-28:
 
 ```text
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise exec -- go test ./internal/gateway
+```
+
+Result: passed.
+
+Slice 7 is implemented and ready for review. Client-supplied policy protobufs
+for sandbox creation can no longer set `network_default=allow`. The
+`--dangerously-allow-all` path now sends an explicit sandbox creation option,
+and the control service applies allow-all egress server-side after validating
+the policy protobuf as deny-only. Stored compiled policies still round-trip
+allow-default records so existing snapshots and caches created through the
+explicit dangerous option remain readable.
+
+Focused validation run on 2026-05-28:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise exec -- go test ./internal/policy ./internal/controlservice ./internal/cli
 ```
 
 Result: passed.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -166,9 +166,9 @@ explicit request-time changeset input.
   override paths may resolve tags or local images before building the compiled
   policy, but repository policy files should be pinned.
 - `sandbox.network.default` defaults to `deny` when omitted. Repository policy
-  files currently accept only `deny`; `allow` is reserved for compiled policies
-  produced by CLI `--dangerously-allow-all` paths when creating a new sandbox
-  and is not valid in `cleanroom.yaml`.
+  files and policy protobuf requests accept only `deny`; allow-by-default egress
+  is available only through the explicit sandbox creation option used by CLI
+  `--dangerously-allow-all`.
 - If `repository` is omitted, top-level commands default to the current repo with `remote: origin`, `path: /workspace`, and `submodules: false`.
 - `repository.enabled` defaults to `true`; `false` disables repo-aware bootstrap for top-level commands.
 - `repository.mode` is optional and, when set, may be `none` or `current-repo`.
@@ -260,10 +260,10 @@ explicit request-time changeset input.
 - Any destination not matched by an exact allow entry is denied.
 - IP literals are treated as exact host values. CIDR matching is not currently
   implemented.
-- Repository policy files cannot request allow-by-default behavior. The only
-  allow-by-default mode is the internal compiled policy produced by
-  `--dangerously-allow-all` on new-sandbox CLI paths, including repo-aware
-  top-level commands and repo-agnostic `cleanroom sandbox create`.
+- Repository policy files and policy protobufs cannot request allow-by-default
+  behavior. The only allow-by-default mode is the explicit sandbox creation
+  option used by `--dangerously-allow-all` on new-sandbox CLI paths, including
+  repo-aware top-level commands and repo-agnostic `cleanroom sandbox create`.
 
 ### 5.2.2 Future schema ideas (non-normative)
 

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -389,11 +389,11 @@ func runSandboxCreate(ctx *runtimeContext, cwd string, connectFlags clientFlags,
 		}
 		sandbox = resp.GetSandbox()
 	} else {
-		compiled, err := defaultSandboxCreatePolicy(resolvedHost, imageRefOverride, requireDockerService, dangerouslyAllowAll)
+		compiled, err := defaultSandboxCreatePolicy(resolvedHost, imageRefOverride, requireDockerService)
 		if err != nil {
 			return err
 		}
-		_, sandbox, err = createSandboxWithPolicy(context.Background(), client, compiled, backend, launchSeconds, nil, repositoryLocalChanges{})
+		_, sandbox, err = createSandboxWithPolicy(context.Background(), client, compiled, backend, launchSeconds, dangerouslyAllowAll, nil, repositoryLocalChanges{})
 		if err != nil {
 			return err
 		}
@@ -527,25 +527,7 @@ func createTopLevelSandbox(
 	if err != nil {
 		return "", nil, err
 	}
-	compiled, err = overrideCompiledPolicyNetworkDefault(compiled, dangerouslyAllowAll)
-	if err != nil {
-		return "", nil, err
-	}
-
-	return createSandboxWithPolicy(callCtx, client, compiled, backendName, launchSeconds, repository, localChanges)
-}
-
-func overrideCompiledPolicyNetworkDefault(compiled *policy.CompiledPolicy, dangerouslyAllowAll bool) (*policy.CompiledPolicy, error) {
-	if !dangerouslyAllowAll {
-		return compiled, nil
-	}
-	if compiled == nil {
-		return nil, errors.New("create sandbox: missing compiled policy")
-	}
-	pb := compiled.ToProto()
-	pb.NetworkDefault = "allow"
-	pb.Hash = ""
-	return policy.FromProto(pb)
+	return createSandboxWithPolicy(callCtx, client, compiled, backendName, launchSeconds, dangerouslyAllowAll, repository, localChanges)
 }
 
 func createSandboxWithProgress(
@@ -632,6 +614,7 @@ func createSandboxWithPolicy(
 	compiled *policy.CompiledPolicy,
 	backendName string,
 	launchSeconds int64,
+	dangerouslyAllowAll bool,
 	repository *resolvedRepositoryCheckout,
 	localChanges repositoryLocalChanges,
 ) (string, *cleanroomv1.Sandbox, error) {
@@ -642,7 +625,8 @@ func createSandboxWithPolicy(
 	createSandboxResp, sandboxID, err := createSandboxWithProgress(callCtx, os.Stderr, client, &cleanroomv1.CreateSandboxRequest{
 		Backend: backendName,
 		Options: &cleanroomv1.SandboxOptions{
-			LaunchSeconds: launchSeconds,
+			LaunchSeconds:             launchSeconds,
+			DangerouslyAllowAllEgress: dangerouslyAllowAll,
 		},
 		Policy:                 compiled.ToProto(),
 		RepositoryCheckout:     repositoryCheckoutProto(repository),
@@ -657,7 +641,7 @@ func createSandboxWithPolicy(
 	return sandboxID, sandbox, nil
 }
 
-func defaultSandboxCreatePolicy(host, imageRefOverride string, requireDockerService, dangerouslyAllowAll bool) (*policy.CompiledPolicy, error) {
+func defaultSandboxCreatePolicy(host, imageRefOverride string, requireDockerService bool) (*policy.CompiledPolicy, error) {
 	imageRefOverride = strings.TrimSpace(imageRefOverride)
 	resolvedRef := ""
 	if imageRefOverride == "" {
@@ -678,15 +662,10 @@ func defaultSandboxCreatePolicy(host, imageRefOverride string, requireDockerServ
 		resolvedRef = ref
 	}
 
-	networkDefault := "deny"
-	if dangerouslyAllowAll {
-		networkDefault = "allow"
-	}
-
 	compiled, err := policy.FromProto(&cleanroomv1.Policy{
 		Version:        1,
 		ImageRef:       resolvedRef,
-		NetworkDefault: networkDefault,
+		NetworkDefault: "deny",
 		Docker: &cleanroomv1.PolicyDocker{
 			Required: requireDockerService,
 		},

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -413,6 +413,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	}
 	createStarted := s.clock().Now()
 	snapshotID := strings.TrimSpace(req.GetSnapshotId())
+	opts := req.GetOptions()
 	metricSourceKind := ""
 	changeset := repositoryChangesetFromProto(req.GetRepositoryChangeset())
 	commitBundle := repositoryCommitBundleFromProto(req.GetRepositoryCommitBundle())
@@ -458,6 +459,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	}()
 
 	if snapshotID != "" {
+		if opts.GetDangerouslyAllowAllEgress() {
+			return nil, errors.New("snapshot-backed sandbox creation cannot request dangerously allow-all egress")
+		}
 		if req.GetPolicy() != nil {
 			return nil, errors.New("snapshot-backed sandbox creation cannot include policy")
 		}
@@ -476,9 +480,15 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		return nil, errors.New("missing policy")
 	}
 
-	compiled, err := policy.FromProto(req.GetPolicy())
+	compiled, err := policy.FromCreateRequestProto(req.GetPolicy())
 	if err != nil {
 		return nil, fmt.Errorf("invalid policy: %w", err)
+	}
+	if opts.GetDangerouslyAllowAllEgress() {
+		compiled, err = policy.DangerouslyAllowAllEgress(compiled)
+		if err != nil {
+			return nil, fmt.Errorf("apply dangerously allow-all egress: %w", err)
+		}
 	}
 	repository := repositorycheckout.FromProto(req.GetRepositoryCheckout())
 	if err := validateRepositoryScopedCreatePolicy(compiled, repository); err != nil {
@@ -506,7 +516,6 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	if err := validateRepositoryCommitBundleForCheckout(repository, commitBundle); err != nil {
 		return nil, err
 	}
-	opts := req.GetOptions()
 	execOpts := executionOptions{}
 	if opts != nil {
 		execOpts.LaunchSeconds = opts.GetLaunchSeconds()

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -609,6 +609,52 @@ func newTestServiceWithSnapshotStore(adapter backend.Adapter, store snapshotMeta
 	}
 }
 
+func TestCreateSandboxRejectsAllowDefaultPolicyProto(t *testing.T) {
+	t.Parallel()
+
+	policyProto := testPolicy()
+	policyProto.NetworkDefault = "allow"
+	svc := newTestService(&stubAdapter{})
+
+	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy: policyProto,
+	})
+	if err == nil {
+		t.Fatal("expected CreateSandbox to reject allow-default policy protobuf")
+	}
+	if !strings.Contains(err.Error(), "network_default=allow") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateSandboxDangerouslyAllowAllOptionAppliesServerSide(t *testing.T) {
+	t.Parallel()
+
+	adapter := &stubAdapter{}
+	svc := newTestService(adapter)
+	policyProto := testPolicy()
+	policyProto.Allow = []*cleanroomv1.PolicyAllowRule{{Host: "api.github.com", Ports: []int32{443}}}
+
+	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		Policy: policyProto,
+		Options: &cleanroomv1.SandboxOptions{
+			DangerouslyAllowAllEgress: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if adapter.provisionReq.Policy == nil {
+		t.Fatal("expected provisioned policy")
+	}
+	if got, want := adapter.provisionReq.Policy.NetworkDefault, "allow"; got != want {
+		t.Fatalf("unexpected provisioned network default: got %q want %q", got, want)
+	}
+	if len(adapter.provisionReq.Policy.Allow) != 0 {
+		t.Fatalf("expected allow rules to be cleared, got %v", adapter.provisionReq.Policy.Allow)
+	}
+}
+
 func TestDialSandboxPortUsesReadySandboxBackendDialer(t *testing.T) {
 	serverConn, clientConn := net.Pipe()
 	defer serverConn.Close()

--- a/internal/gen/cleanroom/v1/control.pb.go
+++ b/internal/gen/cleanroom/v1/control.pb.go
@@ -1611,8 +1611,12 @@ func (x *Policy) GetDocker() *PolicyDocker {
 type SandboxOptions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	LaunchSeconds int64                  `protobuf:"varint,3,opt,name=launch_seconds,json=launchSeconds,proto3" json:"launch_seconds,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Explicitly request allow-all egress for a newly created sandbox. Policy
+	// protobufs remain deny-by-default; this option is the only API surface for
+	// the dangerous escape hatch used by CLI --dangerously-allow-all.
+	DangerouslyAllowAllEgress bool `protobuf:"varint,4,opt,name=dangerously_allow_all_egress,json=dangerouslyAllowAllEgress,proto3" json:"dangerously_allow_all_egress,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
 }
 
 func (x *SandboxOptions) Reset() {
@@ -1650,6 +1654,13 @@ func (x *SandboxOptions) GetLaunchSeconds() int64 {
 		return x.LaunchSeconds
 	}
 	return 0
+}
+
+func (x *SandboxOptions) GetDangerouslyAllowAllEgress() bool {
+	if x != nil {
+		return x.DangerouslyAllowAllEgress
+	}
+	return false
 }
 
 type RepositoryCheckout struct {
@@ -6491,9 +6502,10 @@ const file_proto_cleanroom_v1_control_proto_rawDesc = "" +
 	" \x01(\v2\x17.cleanroom.v1.PolicyRunR\x03run\x12;\n" +
 	"\tresources\x18\v \x01(\v2\x1d.cleanroom.v1.PolicyResourcesR\tresources\x12H\n" +
 	"\x0enetwork_stages\x18\f \x01(\v2!.cleanroom.v1.PolicyNetworkStagesR\rnetworkStages\x122\n" +
-	"\x06docker\x18\r \x01(\v2\x1a.cleanroom.v1.PolicyDockerR\x06docker\"R\n" +
+	"\x06docker\x18\r \x01(\v2\x1a.cleanroom.v1.PolicyDockerR\x06docker\"\x93\x01\n" +
 	"\x0eSandboxOptions\x12%\n" +
-	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSecondsJ\x04\b\x02\x10\x03R\x13read_only_workspace\"\xe1\x01\n" +
+	"\x0elaunch_seconds\x18\x03 \x01(\x03R\rlaunchSeconds\x12?\n" +
+	"\x1cdangerously_allow_all_egress\x18\x04 \x01(\bR\x19dangerouslyAllowAllEgressJ\x04\b\x02\x10\x03R\x13read_only_workspace\"\xe1\x01\n" +
 	"\x12RepositoryCheckout\x12\x1d\n" +
 	"\n" +
 	"remote_url\x18\x01 \x01(\tR\tremoteUrl\x12\x1d\n" +

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1257,6 +1257,40 @@ func FromProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
 	return compiled, nil
 }
 
+// FromCreateRequestProto converts a client-supplied policy request into a
+// CompiledPolicy. Create requests must use SandboxOptions for allow-all egress
+// so the dangerous mode is explicit at the API boundary instead of hidden in
+// the policy payload.
+func FromCreateRequestProto(pb *cleanroomv1.Policy) (*CompiledPolicy, error) {
+	networkDefault := strings.TrimSpace(strings.ToLower(pb.GetNetworkDefault()))
+	if networkDefault == "" {
+		networkDefault = "deny"
+	}
+	if networkDefault == "allow" {
+		return nil, errors.New("policy network_default=allow is not accepted in create requests; use sandbox options for dangerously allow-all egress")
+	}
+	return FromProto(pb)
+}
+
+// DangerouslyAllowAllEgress returns a copy of compiled with outbound network
+// filtering disabled. This is intentionally separate from FromProto so callers
+// cannot smuggle allow-all egress through the policy payload.
+func DangerouslyAllowAllEgress(compiled *CompiledPolicy) (*CompiledPolicy, error) {
+	if compiled == nil {
+		return nil, errors.New("missing policy")
+	}
+	out := *compiled
+	out.NetworkDefault = "allow"
+	out.Allow = nil
+	out.NetworkStages = nil
+	hash, err := hashPolicy(&out)
+	if err != nil {
+		return nil, err
+	}
+	out.Hash = hash
+	return &out, nil
+}
+
 func normalizeDocker(raw rawDockerConfig) DockerService {
 	return DockerService{Required: raw.Required}
 }

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1680,7 +1680,7 @@ func TestFromProtoRejectsOverlappingDependencyAndServiceOutputs(t *testing.T) {
 	}
 }
 
-func TestFromProtoAcceptsAllowDefault(t *testing.T) {
+func TestFromProtoAcceptsStoredAllowDefault(t *testing.T) {
 	t.Parallel()
 
 	compiled, err := FromProto(&cleanroomv1.Policy{
@@ -1695,7 +1695,59 @@ func TestFromProtoAcceptsAllowDefault(t *testing.T) {
 		t.Fatalf("unexpected network default: got %q want %q", got, want)
 	}
 	if !compiled.Allows("example.com", 443) {
+		t.Fatal("expected stored allow-default policy to allow arbitrary host:port")
+	}
+}
+
+func TestFromCreateRequestProtoRejectsAllowDefault(t *testing.T) {
+	t.Parallel()
+
+	_, err := FromCreateRequestProto(&cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       validImageRef,
+		NetworkDefault: "allow",
+	})
+	if err == nil {
+		t.Fatal("expected FromCreateRequestProto to reject allow-default policy protobuf")
+	}
+	if !strings.Contains(err.Error(), "network_default=allow") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDangerouslyAllowAllEgressReturnsAllowDefaultCopy(t *testing.T) {
+	t.Parallel()
+
+	compiled, err := FromProto(&cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       validImageRef,
+		NetworkDefault: "deny",
+		NetworkStages: &cleanroomv1.PolicyNetworkStages{
+			Execution: &cleanroomv1.PolicyNetwork{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	compiled.Allow = []AllowRule{{Host: "api.github.com", Ports: []int{443}}}
+	allowAll, err := DangerouslyAllowAllEgress(compiled)
+	if err != nil {
+		t.Fatalf("DangerouslyAllowAllEgress returned error: %v", err)
+	}
+	if got, want := allowAll.NetworkDefault, "allow"; got != want {
+		t.Fatalf("unexpected network default: got %q want %q", got, want)
+	}
+	if len(allowAll.Allow) != 0 {
+		t.Fatalf("expected allow rules to be cleared, got %v", allowAll.Allow)
+	}
+	if allowAll.NetworkStages != nil {
+		t.Fatalf("expected stage-local policy to be cleared, got %#v", allowAll.NetworkStages)
+	}
+	if !allowAll.Allows("example.com", 443) {
 		t.Fatal("expected allow-default policy to allow arbitrary host:port")
+	}
+	if compiled.NetworkDefault != "deny" || compiled.NetworkStages == nil {
+		t.Fatalf("expected original policy to stay deny with stage network, got %#v", compiled)
 	}
 }
 

--- a/proto/cleanroom/v1/control.proto
+++ b/proto/cleanroom/v1/control.proto
@@ -204,6 +204,10 @@ message SandboxOptions {
   reserved 2;
   reserved "read_only_workspace";
   int64 launch_seconds = 3;
+  // Explicitly request allow-all egress for a newly created sandbox. Policy
+  // protobufs remain deny-by-default; this option is the only API surface for
+  // the dangerous escape hatch used by CLI --dangerously-allow-all.
+  bool dangerously_allow_all_egress = 4;
 }
 
 message RepositoryCheckout {


### PR DESCRIPTION
CreateSandbox accepted `policy.network_default=allow`, even though repository policy compilation rejects allow-by-default egress. That made allow-all networking a hidden policy-protobuf value instead of an explicit dangerous create request.

This moves the dangerous escape hatch onto `SandboxOptions.dangerously_allow_all_egress`. The server now validates client-supplied policy protobufs as deny-only, then applies allow-all egress server-side only when the explicit option is set. The CLI `--dangerously-allow-all` paths keep working, while stored compiled policies still read allow-default records so existing snapshots and caches remain usable.

For example, a direct CreateSandbox request with `policy.network_default=allow` is rejected; `cleanroom sandbox create --dangerously-allow-all` sends a deny policy plus the explicit sandbox option.