### PR TITLE
fix: Bound image extraction and boot asset paths

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 7 ready for review
+**Status:** Slice 8 ready for review
 **Last reviewed:** 2026-05-28
 
 ## Summary
@@ -242,6 +242,30 @@ Focused validation run on 2026-05-28:
 
 ```text
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise exec -- go test ./internal/policy ./internal/controlservice ./internal/cli
+```
+
+Result: passed.
+
+Slice 8 is implemented and ready for review. OCI image rootfs materialization
+now rejects archives before extraction when regular file payload exceeds 32 GiB
+or archive entries exceed 1,000,000, preventing registry or import tar streams
+from growing an unbounded temporary rootfs tree on the host. Managed kernel
+asset cache paths now validate static specs and release-manifest `id` and asset
+names as single safe path components before joining them under the Cleanroom
+asset cache.
+
+Focused validation run on 2026-05-28:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise exec -- go test ./internal/imagemgr ./internal/bootassets
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-28:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise run check
 ```
 
 Result: passed.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -47,6 +47,10 @@ This artifact is not sized from `minimum_rootfs_bytes` or
 `sandbox.resources.disk`. It only needs enough space for image contents and
 materialization headroom.
 
+Image rootfs materialization rejects archives with more than 32 GiB of regular
+file payload or more than 1,000,000 archive entries. These bounds apply before
+the host extracts the rootfs tar into temporary storage.
+
 ### Prepared Runtime RootFS
 
 The prepared runtime rootfs is a shared immutable image-derived artifact. On

--- a/internal/bootassets/manager.go
+++ b/internal/bootassets/manager.go
@@ -23,6 +23,7 @@ import (
 var ErrNoManagedKernelAsset = errors.New("no managed kernel asset")
 
 var errKernelReleaseUnavailable = errors.New("kernel release manifest unavailable")
+var errDownloadedJSONInvalid = errors.New("downloaded JSON invalid")
 
 const (
 	defaultGitHubAPIBase                 = "https://api.github.com"
@@ -378,6 +379,9 @@ func (m *Manager) fetchDarwinVZReleaseKernelSpec(ctx context.Context, releaseSel
 
 	var manifest kernelReleaseManifest
 	if err := m.downloadJSON(metadataCtx, manifestAsset.BrowserDownloadURL, &manifest); err != nil {
+		if errors.Is(err, errDownloadedJSONInvalid) {
+			return KernelSpec{}, fmt.Errorf("invalid darwin-vz kernel manifest %q: %w", manifestAsset.Name, err)
+		}
 		return KernelSpec{}, fmt.Errorf("%w: download darwin-vz kernel manifest %q: %w", errKernelReleaseUnavailable, manifestAsset.Name, err)
 	}
 	if err := validateDarwinVZKernelManifest(manifest); err != nil {
@@ -422,7 +426,7 @@ func (m *Manager) downloadJSON(ctx context.Context, rawURL string, target any) e
 		return fmt.Errorf("download %s: unexpected status %d: %s", rawURL, res.StatusCode, strings.TrimSpace(string(body)))
 	}
 	if err := json.NewDecoder(io.LimitReader(res.Body, 1<<20)).Decode(target); err != nil {
-		return fmt.Errorf("decode %s: %w", rawURL, err)
+		return fmt.Errorf("%w: decode %s: %w", errDownloadedJSONInvalid, rawURL, err)
 	}
 	return nil
 }

--- a/internal/bootassets/manager.go
+++ b/internal/bootassets/manager.go
@@ -22,6 +22,8 @@ import (
 
 var ErrNoManagedKernelAsset = errors.New("no managed kernel asset")
 
+var errKernelReleaseUnavailable = errors.New("kernel release manifest unavailable")
+
 const (
 	defaultGitHubAPIBase                 = "https://api.github.com"
 	defaultKernelReleaseGitHubRepository = "buildkite/cleanroom-kernels"
@@ -173,7 +175,15 @@ func (m *Manager) kernelPathForSpec(spec KernelSpec) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve assets directory: %w", err)
 	}
-	return filepath.Join(base, "kernels", spec.ID, spec.Filename), nil
+	id, err := cachePathComponent("kernel asset id", spec.ID)
+	if err != nil {
+		return "", err
+	}
+	filename, err := cachePathComponent("kernel asset filename", spec.Filename)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "kernels", id, filename), nil
 }
 
 func (m *Manager) EnsureKernel(ctx context.Context, backendName, goos, goarch string) (EnsureResult, error) {
@@ -277,12 +287,19 @@ func (m *Manager) ResolveKernelPathWithVersion(ctx context.Context, backendName,
 }
 
 func (m *Manager) resolveKernelSpec(ctx context.Context, backendName, goos, goarch, appVersion string) (KernelSpec, error) {
-	if spec, ok, err := m.resolveDarwinVZReleaseKernelSpec(ctx, backendName, goos, goarch, appVersion); ok && err == nil {
-		return spec, nil
+	releaseSpec, releaseOK, releaseErr := m.resolveDarwinVZReleaseKernelSpec(ctx, backendName, goos, goarch, appVersion)
+	if releaseOK && releaseErr == nil {
+		return releaseSpec, nil
+	}
+	if releaseOK && releaseErr != nil && !errors.Is(releaseErr, errKernelReleaseUnavailable) {
+		return KernelSpec{}, releaseErr
 	}
 
 	if spec, ok := m.Lookup(backendName, goos, goarch); ok {
 		return spec, nil
+	}
+	if releaseOK && releaseErr != nil {
+		return KernelSpec{}, releaseErr
 	}
 	return KernelSpec{}, fmt.Errorf("%w for backend=%s host=%s/%s", ErrNoManagedKernelAsset, backendName, goos, goarch)
 }
@@ -351,31 +368,34 @@ func (m *Manager) fetchDarwinVZReleaseKernelSpec(ctx context.Context, releaseSel
 	releaseURL := m.releaseURL(releaseSelector)
 	var release githubRelease
 	if err := m.downloadJSON(metadataCtx, releaseURL, &release); err != nil {
-		return KernelSpec{}, err
+		return KernelSpec{}, fmt.Errorf("%w: %w", errKernelReleaseUnavailable, err)
 	}
 
 	manifestAsset, ok := findDarwinVZKernelManifestAsset(release.Assets)
 	if !ok {
-		return KernelSpec{}, fmt.Errorf("darwin-vz kernel manifest asset not found in kernel release %s", releaseSelector)
+		return KernelSpec{}, fmt.Errorf("%w: darwin-vz kernel manifest asset not found in kernel release %s", errKernelReleaseUnavailable, releaseSelector)
 	}
 
 	var manifest kernelReleaseManifest
 	if err := m.downloadJSON(metadataCtx, manifestAsset.BrowserDownloadURL, &manifest); err != nil {
-		return KernelSpec{}, fmt.Errorf("download darwin-vz kernel manifest %q: %w", manifestAsset.Name, err)
+		return KernelSpec{}, fmt.Errorf("%w: download darwin-vz kernel manifest %q: %w", errKernelReleaseUnavailable, manifestAsset.Name, err)
 	}
 	if err := validateDarwinVZKernelManifest(manifest); err != nil {
 		return KernelSpec{}, fmt.Errorf("invalid darwin-vz kernel manifest %q: %w", manifestAsset.Name, err)
 	}
+	specID, _ := cachePathComponent("id", manifest.ID)
+	imageName, _ := cachePathComponent("assets.image", manifest.Assets.Image)
+	imageSHA256 := strings.TrimSpace(manifest.SHA256)
 
-	imageAsset, ok := findReleaseAsset(release.Assets, manifest.Assets.Image)
+	imageAsset, ok := findReleaseAsset(release.Assets, imageName)
 	if !ok {
-		return KernelSpec{}, fmt.Errorf("darwin-vz kernel image asset %q not found in kernel release %s", manifest.Assets.Image, releaseSelector)
+		return KernelSpec{}, fmt.Errorf("darwin-vz kernel image asset %q not found in kernel release %s", imageName, releaseSelector)
 	}
 	return KernelSpec{
-		ID:       manifest.ID,
-		Filename: manifest.Assets.Image,
+		ID:       specID,
+		Filename: imageName,
 		URL:      imageAsset.BrowserDownloadURL,
-		SHA256:   manifest.SHA256,
+		SHA256:   imageSHA256,
 	}, nil
 }
 
@@ -426,22 +446,62 @@ func findReleaseAsset(assets []githubReleaseAsset, name string) (githubReleaseAs
 }
 
 func validateDarwinVZKernelManifest(manifest kernelReleaseManifest) error {
+	if _, err := cachePathComponent("id", manifest.ID); err != nil {
+		return err
+	}
+	if _, err := cachePathComponent("assets.image", manifest.Assets.Image); err != nil {
+		return err
+	}
+	for _, asset := range []struct {
+		field string
+		value string
+	}{
+		{field: "assets.config", value: manifest.Assets.Config},
+		{field: "assets.sha256", value: manifest.Assets.SHA256},
+		{field: "assets.manifest", value: manifest.Assets.Manifest},
+	} {
+		if strings.TrimSpace(asset.value) == "" {
+			continue
+		}
+		if _, err := cachePathComponent(asset.field, asset.value); err != nil {
+			return err
+		}
+	}
+
 	switch {
-	case strings.TrimSpace(manifest.ID) == "":
-		return errors.New("missing id")
 	case manifest.Backend != "darwin-vz":
 		return fmt.Errorf("unexpected backend %q", manifest.Backend)
 	case manifest.Profile != "rootfs":
 		return fmt.Errorf("unexpected profile %q", manifest.Profile)
 	case manifest.Arch != "arm64":
 		return fmt.Errorf("unexpected arch %q", manifest.Arch)
-	case strings.TrimSpace(manifest.Assets.Image) == "":
-		return errors.New("missing image asset name")
 	case strings.TrimSpace(manifest.SHA256) == "":
 		return errors.New("missing image sha256")
 	default:
 		return nil
 	}
+}
+
+func cachePathComponent(field, value string) (string, error) {
+	component := strings.TrimSpace(value)
+	if component == "" {
+		return "", fmt.Errorf("missing %s", field)
+	}
+	if component == "." || component == ".." {
+		return "", fmt.Errorf("unsafe %s path component %q", field, value)
+	}
+	if strings.ContainsAny(component, `/\`+"\x00") {
+		return "", fmt.Errorf("unsafe %s path component %q", field, value)
+	}
+	for _, r := range component {
+		if r < 0x20 || r == 0x7f {
+			return "", fmt.Errorf("unsafe %s path component %q", field, value)
+		}
+	}
+	if filepath.Clean(component) != component || filepath.Base(component) != component {
+		return "", fmt.Errorf("unsafe %s path component %q", field, value)
+	}
+	return component, nil
 }
 
 func (m *Manager) downloadAndVerify(ctx context.Context, spec KernelSpec, tmpPath string) error {

--- a/internal/bootassets/manager_test.go
+++ b/internal/bootassets/manager_test.go
@@ -323,6 +323,61 @@ func TestResolveKernelPathRejectsUnsafeReleaseManifestPathComponents(t *testing.
 	}
 }
 
+func TestResolveKernelPathRejectsMalformedReleaseManifestWithStaticFallback(t *testing.T) {
+	t.Parallel()
+
+	const fallbackPayload = "static-kernel"
+	const imageName = "cleanroom-darwin-vz-minimal-rootfs-arm64-linux-6.1.155-Image"
+	const manifestName = "cleanroom-darwin-vz-minimal-rootfs-arm64-linux-6.1.155.manifest.json"
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/buildkite/cleanroom-kernels/releases/tags/v0.1.0":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{
+  "tag_name": "v1.2.3",
+  "assets": [
+    {"name": %q, "browser_download_url": %q},
+    {"name": %q, "browser_download_url": %q}
+  ]
+}`, manifestName, srv.URL+"/manifest.json", imageName, srv.URL+"/kernel")
+		case "/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{`))
+		case "/static-kernel":
+			_, _ = w.Write([]byte(fallbackPayload))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	tmpDir := t.TempDir()
+	mgr := New(Options{
+		HTTPClient: srv.Client(),
+		AssetsDir: func() (string, error) {
+			return filepath.Join(tmpDir, "assets"), nil
+		},
+		Specs: map[Selector]KernelSpec{
+			{Backend: "darwin-vz", GOOS: "darwin", GOARCH: "arm64"}: {
+				ID:       "static-darwin-vz-kernel",
+				Filename: "vmlinux-static",
+				URL:      srv.URL + "/static-kernel",
+				SHA256:   sha256Hex([]byte(fallbackPayload)),
+			},
+		},
+		GitHubAPIBase: srv.URL,
+	})
+
+	_, err := mgr.ResolveKernelPathWithVersion(context.Background(), "darwin-vz", "darwin", "arm64", "", "dev")
+	if err == nil {
+		t.Fatal("expected malformed release manifest to be rejected")
+	}
+	if !strings.Contains(err.Error(), "invalid darwin-vz kernel manifest") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestResolveKernelPathRejectsUnsafeStaticSpecPathComponents(t *testing.T) {
 	t.Parallel()
 

--- a/internal/bootassets/manager_test.go
+++ b/internal/bootassets/manager_test.go
@@ -253,6 +253,102 @@ func TestResolveKernelPathUsesPinnedKernelReleaseManifestForTaggedDarwinVZ(t *te
 	}
 }
 
+func TestResolveKernelPathRejectsUnsafeReleaseManifestPathComponents(t *testing.T) {
+	t.Parallel()
+
+	const payload = "release-kernel"
+	const fallbackPayload = "static-kernel"
+	const imageName = "cleanroom-darwin-vz-minimal-rootfs-arm64-linux-6.1.155-Image"
+	const manifestName = "cleanroom-darwin-vz-minimal-rootfs-arm64-linux-6.1.155.manifest.json"
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/buildkite/cleanroom-kernels/releases/tags/v0.1.0":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{
+  "tag_name": "v1.2.3",
+  "assets": [
+    {"name": %q, "browser_download_url": %q},
+    {"name": %q, "browser_download_url": %q}
+  ]
+}`, manifestName, srv.URL+"/manifest.json", imageName, srv.URL+"/kernel")
+		case "/manifest.json":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{
+  "id": "../escape",
+  "backend": "darwin-vz",
+  "profile": "rootfs",
+  "arch": "arm64",
+  "assets": {
+    "image": %q,
+    "config": %q,
+    "sha256": %q,
+    "manifest": %q
+  },
+  "sha256": %q
+}`, imageName, imageName+".config", imageName+".sha256", manifestName, sha256Hex([]byte(payload)))
+		case "/kernel":
+			_, _ = w.Write([]byte(payload))
+		case "/static-kernel":
+			_, _ = w.Write([]byte(fallbackPayload))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	tmpDir := t.TempDir()
+	mgr := New(Options{
+		HTTPClient: srv.Client(),
+		AssetsDir: func() (string, error) {
+			return filepath.Join(tmpDir, "assets"), nil
+		},
+		Specs: map[Selector]KernelSpec{
+			{Backend: "darwin-vz", GOOS: "darwin", GOARCH: "arm64"}: {
+				ID:       "static-darwin-vz-kernel",
+				Filename: "vmlinux-static",
+				URL:      srv.URL + "/static-kernel",
+				SHA256:   sha256Hex([]byte(fallbackPayload)),
+			},
+		},
+		GitHubAPIBase: srv.URL,
+	})
+
+	_, err := mgr.ResolveKernelPathWithVersion(context.Background(), "darwin-vz", "darwin", "arm64", "", "dev")
+	if err == nil {
+		t.Fatal("expected unsafe release manifest path component to be rejected")
+	}
+	if !strings.Contains(err.Error(), "unsafe id path component") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveKernelPathRejectsUnsafeStaticSpecPathComponents(t *testing.T) {
+	t.Parallel()
+
+	mgr := New(Options{
+		AssetsDir: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		Specs: map[Selector]KernelSpec{
+			{Backend: "firecracker", GOOS: "linux", GOARCH: "amd64"}: {
+				ID:       "test-kernel",
+				Filename: "../vmlinux-test",
+				URL:      "https://example.invalid/kernel",
+				SHA256:   sha256Hex([]byte("kernel")),
+			},
+		},
+	})
+
+	_, err := mgr.ResolveKernelPath(context.Background(), "firecracker", "linux", "amd64", "")
+	if err == nil {
+		t.Fatal("expected unsafe static spec path component to be rejected")
+	}
+	if !strings.Contains(err.Error(), "unsafe kernel asset filename path component") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestResolveKernelPathFallsBackToStaticDarwinVZWhenReleaseManifestMissing(t *testing.T) {
 	t.Parallel()
 

--- a/internal/imagemgr/imagemgr.go
+++ b/internal/imagemgr/imagemgr.go
@@ -72,6 +72,8 @@ type Options struct {
 	ResolveAttempts         int
 	ResolveAttemptTimeout   time.Duration
 	RootFSStreamIdleTimeout time.Duration
+	MaxRootFSContentBytes   int64
+	MaxRootFSArchiveEntries int64
 }
 
 type pullImageFunc func(resolveCtx, streamCtx context.Context, ref string) (io.ReadCloser, OCIConfig, error)
@@ -87,6 +89,8 @@ type Manager struct {
 	resolveAttempts         int
 	resolveAttemptTimeout   time.Duration
 	rootFSStreamIdleTimeout time.Duration
+	maxRootFSContentBytes   int64
+	maxRootFSArchiveEntries int64
 
 	mu sync.Mutex
 }
@@ -138,6 +142,8 @@ func New(opts Options) (*Manager, error) {
 		resolveAttempts:         defaultResolveAttempts,
 		resolveAttemptTimeout:   defaultResolveAttemptTimeout,
 		rootFSStreamIdleTimeout: defaultRootFSStreamIdleLimit,
+		maxRootFSContentBytes:   defaultMaxRootFSContentBytes,
+		maxRootFSArchiveEntries: defaultMaxRootFSArchiveEntries,
 	}
 	if opts.ResolveAttempts > 0 {
 		manager.resolveAttempts = opts.ResolveAttempts
@@ -147,6 +153,12 @@ func New(opts Options) (*Manager, error) {
 	}
 	if opts.RootFSStreamIdleTimeout > 0 {
 		manager.rootFSStreamIdleTimeout = opts.RootFSStreamIdleTimeout
+	}
+	if opts.MaxRootFSContentBytes > 0 {
+		manager.maxRootFSContentBytes = opts.MaxRootFSContentBytes
+	}
+	if opts.MaxRootFSArchiveEntries > 0 {
+		manager.maxRootFSArchiveEntries = opts.MaxRootFSArchiveEntries
 	}
 	if opts.PullImage != nil {
 		manager.pullImage = func(_, streamCtx context.Context, ref string) (io.ReadCloser, OCIConfig, error) {
@@ -175,7 +187,11 @@ func New(opts Options) (*Manager, error) {
 		manager.materialize = opts.MaterializeRootFS
 	} else {
 		manager.materialize = func(ctx context.Context, tarStream io.Reader, outputPath string) (int64, error) {
-			return materializeExt4(ctx, manager.mkfsBinary, tarStream, outputPath)
+			limits := rootFSExtractionLimits{
+				MaxContentBytes: manager.maxRootFSContentBytes,
+				MaxEntries:      manager.maxRootFSArchiveEntries,
+			}
+			return materializeExt4WithLimits(ctx, manager.mkfsBinary, tarStream, outputPath, limits)
 		}
 	}
 

--- a/internal/imagemgr/materialize.go
+++ b/internal/imagemgr/materialize.go
@@ -208,6 +208,9 @@ func extractTarWithLimits(root string, stream io.Reader, limits rootFSExtraction
 			if err := ensureNoSymlinkPath(root, linkTarget, false); err != nil {
 				return err
 			}
+			if err := accountRootFSTarHardLink(hdr, linkTarget, limits, &contentBytes); err != nil {
+				return err
+			}
 			if err := ensureNoSymlinkPath(root, filepath.Dir(targetPath), true); err != nil {
 				return err
 			}
@@ -244,13 +247,34 @@ func accountRootFSTarEntry(hdr *tar.Header, limits rootFSExtractionLimits, entri
 	}
 	switch hdr.Typeflag {
 	case tar.TypeReg, tar.TypeRegA:
-		if limits.MaxContentBytes > 0 && hdr.Size > limits.MaxContentBytes-*contentBytes {
-			return fmt.Errorf("refusing rootfs archive: extracted file bytes would exceed limit %d", limits.MaxContentBytes)
+		if err := addRootFSTarContentBytes(limits, contentBytes, hdr.Size); err != nil {
+			return err
 		}
-		*contentBytes += hdr.Size
 	default:
 		return nil
 	}
+	return nil
+}
+
+func accountRootFSTarHardLink(hdr *tar.Header, linkTarget string, limits rootFSExtractionLimits, contentBytes *int64) error {
+	if limits.MaxContentBytes <= 0 {
+		return nil
+	}
+	info, err := os.Stat(linkTarget)
+	if err != nil {
+		return fmt.Errorf("inspect hard link target %q: %w", hdr.Linkname, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("refusing hard link %q -> %q to directory", hdr.Name, hdr.Linkname)
+	}
+	return addRootFSTarContentBytes(limits, contentBytes, info.Size())
+}
+
+func addRootFSTarContentBytes(limits rootFSExtractionLimits, contentBytes *int64, size int64) error {
+	if limits.MaxContentBytes > 0 && size > limits.MaxContentBytes-*contentBytes {
+		return fmt.Errorf("refusing rootfs archive: extracted file bytes would exceed limit %d", limits.MaxContentBytes)
+	}
+	*contentBytes += size
 	return nil
 }
 

--- a/internal/imagemgr/materialize.go
+++ b/internal/imagemgr/materialize.go
@@ -14,12 +14,18 @@ import (
 )
 
 const (
-	minimumRootFSSizeBytes = 512 << 20
-	rootFSHeadroomBytes    = 128 << 20
-	rootFSAlignBytes       = 4 << 20
+	minimumRootFSSizeBytes         = 512 << 20
+	rootFSHeadroomBytes            = 128 << 20
+	rootFSAlignBytes               = 4 << 20
+	defaultMaxRootFSContentBytes   = 32 << 30
+	defaultMaxRootFSArchiveEntries = 1_000_000
 )
 
 func materializeExt4(ctx context.Context, mkfsBinary string, tarStream io.Reader, outputPath string) (int64, error) {
+	return materializeExt4WithLimits(ctx, mkfsBinary, tarStream, outputPath, defaultRootFSExtractionLimits())
+}
+
+func materializeExt4WithLimits(ctx context.Context, mkfsBinary string, tarStream io.Reader, outputPath string, limits rootFSExtractionLimits) (int64, error) {
 	workDir, err := os.MkdirTemp("", "cleanroom-image-materialize-*")
 	if err != nil {
 		return 0, fmt.Errorf("create temporary rootfs materialisation directory: %w", err)
@@ -30,7 +36,7 @@ func materializeExt4(ctx context.Context, mkfsBinary string, tarStream io.Reader
 	if err := os.MkdirAll(rootFSDir, 0o755); err != nil {
 		return 0, fmt.Errorf("create temporary rootfs extraction directory: %w", err)
 	}
-	if err := extractTar(rootFSDir, tarStream); err != nil {
+	if err := extractTarWithLimits(rootFSDir, tarStream, limits); err != nil {
 		return 0, err
 	}
 
@@ -113,7 +119,25 @@ func dirSize(root string) (int64, error) {
 }
 
 func extractTar(root string, stream io.Reader) error {
+	return extractTarWithLimits(root, stream, defaultRootFSExtractionLimits())
+}
+
+type rootFSExtractionLimits struct {
+	MaxContentBytes int64
+	MaxEntries      int64
+}
+
+func defaultRootFSExtractionLimits() rootFSExtractionLimits {
+	return rootFSExtractionLimits{
+		MaxContentBytes: defaultMaxRootFSContentBytes,
+		MaxEntries:      defaultMaxRootFSArchiveEntries,
+	}
+}
+
+func extractTarWithLimits(root string, stream io.Reader, limits rootFSExtractionLimits) error {
 	tr := tar.NewReader(stream)
+	var contentBytes int64
+	var entries int64
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -121,6 +145,9 @@ func extractTar(root string, stream io.Reader) error {
 		}
 		if err != nil {
 			return fmt.Errorf("read rootfs tar stream: %w", err)
+		}
+		if err := accountRootFSTarEntry(hdr, limits, &entries, &contentBytes); err != nil {
+			return err
 		}
 
 		targetPath, err := safeJoin(root, hdr.Name)
@@ -150,7 +177,7 @@ func extractTar(root string, stream io.Reader) error {
 			if err != nil {
 				return fmt.Errorf("create file %q from tar stream: %w", targetPath, err)
 			}
-			if _, err := io.Copy(f, tr); err != nil {
+			if _, err := io.CopyN(f, tr, hdr.Size); err != nil {
 				_ = f.Close()
 				return fmt.Errorf("write file %q from tar stream: %w", targetPath, err)
 			}
@@ -200,6 +227,31 @@ func extractTar(root string, stream io.Reader) error {
 			// Ignore unsupported tar entry kinds (for example device nodes); /dev is mounted at boot.
 		}
 	}
+}
+
+func accountRootFSTarEntry(hdr *tar.Header, limits rootFSExtractionLimits, entries, contentBytes *int64) error {
+	if hdr == nil {
+		return errors.New("refusing nil rootfs tar entry")
+	}
+	if hdr.Size < 0 {
+		return fmt.Errorf("refusing tar entry %q with negative size %d", hdr.Name, hdr.Size)
+	}
+	if limits.MaxEntries > 0 {
+		if *entries >= limits.MaxEntries {
+			return fmt.Errorf("refusing rootfs archive with more than %d entries", limits.MaxEntries)
+		}
+		*entries++
+	}
+	switch hdr.Typeflag {
+	case tar.TypeReg, tar.TypeRegA:
+		if limits.MaxContentBytes > 0 && hdr.Size > limits.MaxContentBytes-*contentBytes {
+			return fmt.Errorf("refusing rootfs archive: extracted file bytes would exceed limit %d", limits.MaxContentBytes)
+		}
+		*contentBytes += hdr.Size
+	default:
+		return nil
+	}
+	return nil
 }
 
 func safeJoin(root, name string) (string, error) {

--- a/internal/imagemgr/materialize_test.go
+++ b/internal/imagemgr/materialize_test.go
@@ -125,6 +125,27 @@ func TestExtractTarRejectsTooManyEntries(t *testing.T) {
 	}
 }
 
+func TestExtractTarCountsHardLinksAgainstContentLimit(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	stream := tarStreamWithEntries(t,
+		tarEntry{Header: &tar.Header{Name: "base", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len("base"))}, Body: []byte("base")},
+		tarEntry{Header: &tar.Header{Name: "base-link", Typeflag: tar.TypeLink, Linkname: "base", Mode: 0o644}},
+	)
+
+	err := extractTarWithLimits(root, bytes.NewReader(stream), rootFSExtractionLimits{
+		MaxContentBytes: 7,
+		MaxEntries:      10,
+	})
+	if err == nil {
+		t.Fatal("expected hard link to count against rootfs content limit")
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "base-link")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected rejected hard link not to be created, stat err=%v", statErr)
+	}
+}
+
 type tarEntry struct {
 	Header *tar.Header
 	Body   []byte

--- a/internal/imagemgr/materialize_test.go
+++ b/internal/imagemgr/materialize_test.go
@@ -87,6 +87,44 @@ func TestExtractTarAllowsAbsoluteInternalSymlinkTarget(t *testing.T) {
 	}
 }
 
+func TestExtractTarRejectsRootFSContentOverLimit(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	stream := tarStreamWithEntries(t,
+		tarEntry{Header: &tar.Header{Name: "large", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len("large"))}, Body: []byte("large")},
+	)
+
+	err := extractTarWithLimits(root, bytes.NewReader(stream), rootFSExtractionLimits{
+		MaxContentBytes: 4,
+		MaxEntries:      10,
+	})
+	if err == nil {
+		t.Fatal("expected oversized rootfs tar to be rejected")
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "large")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected oversized file not to be created, stat err=%v", statErr)
+	}
+}
+
+func TestExtractTarRejectsTooManyEntries(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	stream := tarStreamWithEntries(t,
+		tarEntry{Header: &tar.Header{Name: "one", Typeflag: tar.TypeDir, Mode: 0o755}},
+		tarEntry{Header: &tar.Header{Name: "two", Typeflag: tar.TypeDir, Mode: 0o755}},
+	)
+
+	err := extractTarWithLimits(root, bytes.NewReader(stream), rootFSExtractionLimits{
+		MaxContentBytes: 1024,
+		MaxEntries:      1,
+	})
+	if err == nil {
+		t.Fatal("expected rootfs tar with too many entries to be rejected")
+	}
+}
+
 type tarEntry struct {
 	Header *tar.Header
 	Body   []byte


### PR DESCRIPTION
Image and managed-kernel inputs currently trust upstream-controlled size and path metadata too late in the host setup path. A malicious or broken image rootfs tar can grow the temporary extraction tree until the host runs out of disk, and darwin-vz release manifests can feed cache path components directly into the managed boot asset location.

This change bounds OCI rootfs materialization before extraction: regular file payload is capped at 32 GiB and archive entries are capped at 1,000,000. The image manager keeps those defaults while still allowing tests to exercise lower limits. Managed kernel specs now validate release-manifest and static spec IDs and asset names as single safe path components before joining them under the Cleanroom asset cache. Invalid release manifest content fails closed; genuinely unavailable release metadata can still fall back to the existing static kernel spec.

The storage docs now call out the rootfs materialization bounds, and the DeepSec remediation plan marks Slice 8 ready for review.