### PR TITLE
ci: Pin base image workflow actions

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -50,17 +50,17 @@ jobs:
             platform_key: linux-arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         id: build
         with:
           context: .
@@ -79,7 +79,7 @@ jobs:
           fi
           touch "$RUNNER_TEMP/digests/${digest#sha256:}"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: digests__${{ matrix.image.name }}__${{ matrix.platform.platform_key }}
           path: ${{ runner.temp }}/digests/*
@@ -117,23 +117,23 @@ jobs:
             dockerfile: images/Dockerfile.base-image-agents
             repository: ghcr.io/buildkite/cleanroom-base/alpine-agents
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Compute base image tag
         id: meta
         run: |
           echo "base_tag=$(scripts/base-image-tag.sh '${{ matrix.image.name }}' '${{ matrix.image.dockerfile }}')" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: digests__${{ matrix.image.name }}__*
           path: ${{ runner.temp }}/digests
           merge-multiple: true
           if-no-files-found: ignore
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,8 +1,8 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 8 ready for review
-**Last reviewed:** 2026-05-28
+**Status:** Slice 9 ready for review
+**Last reviewed:** 2026-05-29
 
 ## Summary
 
@@ -263,6 +263,28 @@ MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bo
 Result: passed.
 
 Repository validation run on 2026-05-28:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Slice 9 is implemented and ready for review. The package-publishing
+`.github/workflows/base-image.yml` workflow no longer runs third-party GitHub
+Actions from mutable major tags while holding `packages: write`; each action ref
+is pinned to the commit currently behind the referenced major tag, with the tag
+kept as an inline note for reviewability.
+
+Focused validation run on 2026-05-29:
+
+```text
+rg -n "uses:\s*[^@\s]+@v[0-9]+\b|uses:\s*[^@\s]+@main\b|uses:\s*[^@\s]+@master\b" .github/workflows -g'*.yml' -g'*.yaml'
+```
+
+Result: passed with no matches.
+
+Repository validation run on 2026-05-29:
 
 ```text
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise run check


### PR DESCRIPTION
The base-image workflow publishes to GHCR with `packages: write`, but its third-party actions were running from mutable major tags. That leaves the package-publishing path dependent on tag movement in upstream action repositories.

This pins every action in `.github/workflows/base-image.yml` to the commit currently behind the referenced major tag, while leaving the tag as an inline note for reviewers. The workflow still builds the same image matrix and publishes the same manifest tags; only the action resolution point changes.

This covers DeepSec remediation Slice 9.