### PR TITLE
fix: Clean up darwin-vz snapshot on resume failure

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 9 ready for review
+**Status:** Slice 10 ready for review
 **Last reviewed:** 2026-05-29
 
 ## Summary
@@ -283,6 +283,28 @@ rg -n "uses:\s*[^@\s]+@v[0-9]+\b|uses:\s*[^@\s]+@main\b|uses:\s*[^@\s]+@master\b
 ```
 
 Result: passed with no matches.
+
+Repository validation run on 2026-05-29:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Slice 10 is implemented and ready for review. darwin-vz snapshot creation now
+tracks the stored snapshot rootfs once persistence succeeds and removes it if a
+later error makes the API return failure. This specifically covers failed VM
+resume after snapshot persistence, where the caller would otherwise not record
+the snapshot while the stored rootfs remained on disk.
+
+Focused validation run on 2026-05-29:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise exec -- go test ./internal/backend/darwinvz
+```
+
+Result: passed.
 
 Repository validation run on 2026-05-29:
 

--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -874,6 +874,19 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 	if err != nil {
 		return nil, err
 	}
+	snapshotCleanupRef := ""
+	defer func() {
+		if retErr == nil || strings.TrimSpace(snapshotCleanupRef) == "" {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cleanupErr := driver.DestroySnapshot(cleanupCtx, volumestore.DestroySnapshotRequest{SnapshotRef: snapshotCleanupRef})
+		cancel()
+		if cleanupErr != nil {
+			retErr = fmt.Errorf("%w (cleanup snapshot %q failed: %v)", retErr, snapshotCleanupRef, cleanupErr)
+		}
+	}()
+
 	helperRequest := a.helperRequestFn
 	if helperRequest == nil {
 		helperRequest = func(ctx context.Context, helper *helperSession, req helperControlRequest) (helperControlResponse, error) {
@@ -909,8 +922,16 @@ func (a *Adapter) CreateSnapshot(ctx context.Context, req backend.SnapshotReques
 	if err != nil {
 		return nil, fmt.Errorf("persist snapshot rootfs: %w", err)
 	}
+	snapshotStorageRef := strings.TrimSpace(snapshot.StorageRef)
+	snapshotCleanupRef = snapshotStorageRef
+	if snapshotCleanupRef == "" {
+		snapshotCleanupRef = strings.TrimSpace(snapshot.Ref)
+	}
+	if snapshotStorageRef == "" {
+		return nil, errors.New("snapshot storage returned empty storage_ref")
+	}
 
-	return &backend.SnapshotResult{StorageRef: snapshot.StorageRef}, nil
+	return &backend.SnapshotResult{StorageRef: snapshotStorageRef}, nil
 }
 
 func (a *Adapter) ProvisionSandboxFromSnapshot(ctx context.Context, req backend.ProvisionFromSnapshotRequest) error {

--- a/internal/backend/darwinvz/snapshot_test.go
+++ b/internal/backend/darwinvz/snapshot_test.go
@@ -81,6 +81,65 @@ func TestCreateSnapshotSyncsPausesAndClonesRootFS(t *testing.T) {
 	}
 }
 
+func TestCreateSnapshotCleansStoredRootFSWhenResumeFails(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	rootfsPath := filepath.Join(t.TempDir(), "rootfs.ext4")
+	if err := os.WriteFile(rootfsPath, []byte("snapshot-bytes"), 0o644); err != nil {
+		t.Fatalf("write rootfs: %v", err)
+	}
+
+	adapter := &Adapter{
+		executeInSandboxFn: func(_ context.Context, _ context.Context, _ *sandboxInstance, _ backend.ExecutionRequest, _ backend.OutputStream) (*backend.ExecutionResult, error) {
+			return &backend.ExecutionResult{ExitCode: 0}, nil
+		},
+		helperRequestFn: func(_ context.Context, _ *helperSession, req helperControlRequest) (helperControlResponse, error) {
+			switch req.Op {
+			case "PauseVM":
+				return helperControlResponse{OK: true}, nil
+			case "ResumeVM":
+				return helperControlResponse{}, fmt.Errorf("resume failed")
+			default:
+				t.Fatalf("unexpected helper op %q", req.Op)
+				return helperControlResponse{}, nil
+			}
+		},
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID:    "cr-test",
+				Helper:       &helperSession{},
+				VMID:         "vm-test",
+				Policy:       &policy.CompiledPolicy{NetworkDefault: "deny"},
+				vmRootFSPath: rootfsPath,
+				exitedCh:     make(chan struct{}),
+			},
+		},
+	}
+
+	result, err := adapter.CreateSnapshot(context.Background(), backend.SnapshotRequest{
+		SandboxID:  "cr-test",
+		SnapshotID: "snap-test",
+		FirecrackerConfig: backend.FirecrackerConfig{
+			Snapshots: backend.SnapshotConfig{Enabled: true},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected CreateSnapshot to fail when resume fails")
+	}
+	if result != nil {
+		t.Fatalf("expected no snapshot result, got %#v", result)
+	}
+	if got := err.Error(); !strings.Contains(got, "resume darwin-vz sandbox after snapshot") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	snapshotPath := filepath.Join(stateHome, "cleanroom", "snapshots", "darwin-vz", "snap-test", "rootfs.ext4")
+	if _, err := os.Stat(snapshotPath); !os.IsNotExist(err) {
+		t.Fatalf("expected stored snapshot rootfs to be removed, got err=%v", err)
+	}
+}
+
 func TestProvisionSandboxFromSnapshotUsesSnapshotRootFS(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
darwin-vz snapshot creation can persist the rootfs snapshot and then fail while resuming the paused VM. When that happens, the caller sees a failed snapshot operation and never records the snapshot, but the stored rootfs is left behind.

This change tracks the stored snapshot ref after persistence and destroys it on any later error in `CreateSnapshot`. A failed resume now returns the resume error after cleanup, while successful snapshots keep the existing behavior. It also fails closed if snapshot persistence returns an empty `storage_ref`.

Covered by a darwin-vz regression test for resume failure cleanup. I also ran `mise exec -- go test ./internal/backend/darwinvz` and `mise run check`.