### PR TITLE
ci: Add Test Engine to Linux tests

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${BUILDKITE_TEST_ENGINE_SUITE_SLUG:-}" ]]; then
+  exit 0
+fi
+
+if [[ -n "${BUILDKITE_ANALYTICS_TOKEN:-}" ]]; then
+  exit 0
+fi
+
+case "${BUILDKITE_TEST_ENGINE_OIDC:-true}" in
+  false | FALSE | 0 | off | OFF | no | NO)
+    exit 0
+    ;;
+esac
+
+if ! command -v buildkite-agent >/dev/null 2>&1; then
+  echo "buildkite-agent is required to mint the Test Engine analytics OIDC token" >&2
+  exit 127
+fi
+
+organization_slug="${BUILDKITE_ORGANIZATION_SLUG:-buildkite}"
+suite_url="${BUILDKITE_TEST_ENGINE_SUITE_URL:-https://buildkite.com/organizations/${organization_slug}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}}"
+lifetime_seconds="${BUILDKITE_TEST_ENGINE_OIDC_LIFETIME_SECONDS:-7200}"
+
+export BUILDKITE_ANALYTICS_TOKEN
+BUILDKITE_ANALYTICS_TOKEN="$(buildkite-agent oidc request-token --audience "$suite_url" --lifetime "$lifetime_seconds")"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,10 @@
 steps:
   - label: ":shell: Shellcheck"
     plugins:
-      - github.com/lox/mise-buildkite-plugin#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
           install_args: shellcheck
-    command: shellcheck -x scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-with-host-lock.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/ci-buildkite-release.sh
+    command: shellcheck -x .buildkite/hooks/pre-command scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-with-host-lock.sh scripts/ci-go-test-engine.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/ci-buildkite-release.sh
     cache:
       paths:
         - "~/.local/share/mise"
@@ -16,14 +16,28 @@ steps:
       queue: hosted
 
   - label: ":test_tube: Test (Linux)"
+    parallelism: 4
     plugins:
       - github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91:
-    command: go test ./...
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+          install_args: gotestsum
+      - github.com/buildkite-plugins/test-collector-buildkite-plugin#v1.11.0:
+          files: "tmp/test-engine/*.xml"
+          format: "junit"
+    command: scripts/ci-go-test-engine.sh
+    artifact_paths:
+      - "tmp/test-engine/*.xml"
+    env:
+      BUILDKITE_TEST_ENGINE_SUITE_SLUG: cleanroom-go-linux
+      BUILDKITE_TEST_ENGINE_TEST_RUNNER: gotest
+      BUILDKITE_TEST_ENGINE_RETRY_COUNT: "1"
     cache:
       paths:
         - "~/.local/share/mise"
         - "~/.cache/mise"
         - "~/.local/state/mise"
+        - "~/.cache/cleanroom/test-engine"
       size: "20g"
       name: "mise-cache"
     agents:
@@ -97,7 +111,7 @@ steps:
   - label: ":rocket: Publish release"
     if: build.tag != null
     plugins:
-      - github.com/lox/mise-buildkite-plugin#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
     command: scripts/ci-buildkite-release.sh
     cache:

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 go = "1.26.3"
+gotestsum = "1.13.0"
 shellcheck = "0.11.0"
 hyperfine = "1.20.0"
 svu = "3.4.1"
@@ -14,7 +15,7 @@ run = "go test ./..."
 
 [tasks.lint-shell]
 description = "Lint shell scripts"
-run = "shellcheck -x scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-with-host-lock.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/ci-buildkite-release.sh"
+run = "shellcheck -x .buildkite/hooks/pre-command scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-with-host-lock.sh scripts/ci-go-test-engine.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/ci-buildkite-release.sh"
 
 [tasks.test-full]
 description = "Run full Go test suite"

--- a/scripts/buildkite_pipeline_test.go
+++ b/scripts/buildkite_pipeline_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 )
 
-const miseBuildkitePluginRef = "github.com/lox/mise-buildkite-plugin#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2"
+const miseBuildkitePluginRef = "mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2"
 const miseBuildkitePluginVersion = "2026.5.12"
 const setupGoBuildkitePluginRef = "github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91"
+const testCollectorBuildkitePluginRef = "github.com/buildkite-plugins/test-collector-buildkite-plugin#v1.11.0"
 
 func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
 	t.Parallel()
@@ -32,9 +33,16 @@ func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
           install_args: shellcheck
     command: shellcheck`,
 		`- label: ":test_tube: Test (Linux)"
+    parallelism: 4
     plugins:
       - ` + setupGoBuildkitePluginRef + `:
-    command: go test ./...`,
+      - ` + miseBuildkitePluginRef + `:
+          version: "` + miseBuildkitePluginVersion + `"
+          install_args: gotestsum
+      - ` + testCollectorBuildkitePluginRef + `:
+          files: "tmp/test-engine/*.xml"
+          format: "junit"
+    command: scripts/ci-go-test-engine.sh`,
 		`- label: ":test_tube: Test (macOS)"
     plugins:
       - ` + setupGoBuildkitePluginRef + `:
@@ -87,10 +95,12 @@ func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
 		t.Fatalf("expected .buildkite/pipeline.yml to include the Buildkite release publish step")
 	}
 	for _, needle := range []string{
+		".buildkite/hooks/pre-command",
 		"scripts/base-image-tag.sh",
 		"scripts/install-global.sh",
 		"scripts/e2e-observability.sh",
 		"scripts/ci-with-host-lock.sh",
+		"scripts/ci-go-test-engine.sh",
 		"scripts/ci-example-smoke.sh",
 		"scripts/ci-examples-firecracker.sh",
 		"scripts/ci-examples-darwin-vz.sh",
@@ -125,6 +135,19 @@ func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
 		t.Fatalf("expected .buildkite/pipeline.yml to set the darwin-vz vmnet helper bundle identifier")
 	}
 	for _, needle := range []string{
+		`BUILDKITE_TEST_ENGINE_SUITE_SLUG: cleanroom-go-linux`,
+		`BUILDKITE_TEST_ENGINE_TEST_RUNNER: gotest`,
+		`BUILDKITE_TEST_ENGINE_RETRY_COUNT: "1"`,
+		`artifact_paths:`,
+		`- "tmp/test-engine/*.xml"`,
+		`- "~/.cache/cleanroom/test-engine"`,
+		`install_args: gotestsum`,
+	} {
+		if !strings.Contains(pipeline, needle) {
+			t.Fatalf("expected .buildkite/pipeline.yml to configure Linux Test Engine with %q", needle)
+		}
+	}
+	for _, needle := range []string{
 		"concurrency_group: cleanroom-e2e",
 		"concurrency_group: cleanroom-darwin-vz-e2e",
 	} {
@@ -150,6 +173,71 @@ func TestBuildkiteCommandHookIsRemoved(t *testing.T) {
 	_, err := os.Stat("../.buildkite/hooks/command")
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected .buildkite/hooks/command to be removed, got err=%v", err)
+	}
+}
+
+func TestBuildkitePreCommandHookMintsTestEngineOIDCToken(t *testing.T) {
+	t.Parallel()
+
+	info, err := os.Stat("../.buildkite/hooks/pre-command")
+	if err != nil {
+		t.Fatalf("stat .buildkite/hooks/pre-command: %v", err)
+	}
+	if info.Mode()&0111 == 0 {
+		t.Fatalf("expected .buildkite/hooks/pre-command to be executable")
+	}
+
+	content, err := os.ReadFile("../.buildkite/hooks/pre-command")
+	if err != nil {
+		t.Fatalf("read .buildkite/hooks/pre-command: %v", err)
+	}
+
+	hook := string(content)
+	for _, needle := range []string{
+		`BUILDKITE_TEST_ENGINE_SUITE_SLUG`,
+		`BUILDKITE_ANALYTICS_TOKEN`,
+		`BUILDKITE_TEST_ENGINE_OIDC`,
+		`buildkite-agent oidc request-token --audience "$suite_url" --lifetime "$lifetime_seconds"`,
+		`https://buildkite.com/organizations/${organization_slug}/analytics/suites/${BUILDKITE_TEST_ENGINE_SUITE_SLUG}`,
+	} {
+		if !strings.Contains(hook, needle) {
+			t.Fatalf("expected .buildkite/hooks/pre-command to contain %q", needle)
+		}
+	}
+}
+
+func TestBuildkiteGoTestEngineScriptBootstrapsBktecAndRequiresGotestsum(t *testing.T) {
+	t.Parallel()
+
+	info, err := os.Stat("ci-go-test-engine.sh")
+	if err != nil {
+		t.Fatalf("stat ci-go-test-engine.sh: %v", err)
+	}
+	if info.Mode()&0111 == 0 {
+		t.Fatalf("expected ci-go-test-engine.sh to be executable")
+	}
+
+	content, err := os.ReadFile("ci-go-test-engine.sh")
+	if err != nil {
+		t.Fatalf("read ci-go-test-engine.sh: %v", err)
+	}
+
+	script := string(content)
+	for _, needle := range []string{
+		`BKTEC_VERSION="${BKTEC_VERSION:-2.6.0}"`,
+		`github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/${asset}`,
+		`BUILDKITE_TEST_ENGINE_RESULT_PATH="tmp/test-engine/gotest-${BUILDKITE_PARALLEL_JOB:-0}.xml"`,
+		`BUILDKITE_TEST_ENGINE_SUITE_SLUG is required`,
+		`command -v gotestsum`,
+		`gotestsum is required; install it with mise before running Test Engine`,
+		`bktec run`,
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("expected ci-go-test-engine.sh to contain %q", needle)
+		}
+	}
+	if strings.Contains(script, `go install "gotest.tools/gotestsum`) {
+		t.Fatalf("expected ci-go-test-engine.sh to rely on mise-installed gotestsum")
 	}
 }
 
@@ -246,6 +334,7 @@ func TestBuildkiteCIScriptsDoNotInvokeMiseDirectly(t *testing.T) {
 	for _, path := range []string{
 		"ci-cleanroom-e2e.sh",
 		"ci-with-host-lock.sh",
+		"ci-go-test-engine.sh",
 		"ci-example-smoke.sh",
 		"ci-examples-firecracker.sh",
 		"ci-examples-darwin-vz.sh",
@@ -282,6 +371,9 @@ func TestMiseIncludesLinuxBootstrapTasks(t *testing.T) {
 		t.Fatalf("read mise.toml: %v", err)
 	}
 
+	if !strings.Contains(string(content), `gotestsum = "1.13.0"`) {
+		t.Fatalf("expected public mise.toml to pin gotestsum for Test Engine")
+	}
 	if strings.Contains(string(content), "ci-bootstrap-linux-ssm.sh") {
 		t.Fatalf("expected public mise.toml not to expose private bootstrap rerun tasks")
 	}
@@ -301,9 +393,11 @@ func TestMiseLintShellCoversSharedE2EObservabilityHelper(t *testing.T) {
 	mise := string(content)
 	for _, needle := range []string{
 		`[tasks.lint-shell]`,
+		`.buildkite/hooks/pre-command`,
 		`scripts/base-image-tag.sh`,
 		`scripts/e2e-observability.sh`,
 		`scripts/ci-with-host-lock.sh`,
+		`scripts/ci-go-test-engine.sh`,
 		`scripts/ci-example-smoke.sh`,
 		`scripts/ci-examples-firecracker.sh`,
 		`scripts/ci-examples-darwin-vz.sh`,

--- a/scripts/ci-go-test-engine.sh
+++ b/scripts/ci-go-test-engine.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BKTEC_VERSION="${BKTEC_VERSION:-2.6.0}"
+
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/cleanroom/test-engine"
+bin_dir="${cache_dir}/bin"
+mkdir -p "$bin_dir" tmp/test-engine
+
+install_bktec() {
+  local goos goarch asset url target
+
+  target="${bin_dir}/bktec-${BKTEC_VERSION}"
+  if [[ -x "$target" ]]; then
+    ln -sf "$target" "${bin_dir}/bktec"
+    return
+  fi
+
+  goos="$(go env GOOS)"
+  goarch="$(go env GOARCH)"
+  asset="bktec_${BKTEC_VERSION}_${goos}_${goarch}"
+  url="https://github.com/buildkite/test-engine-client/releases/download/v${BKTEC_VERSION}/${asset}"
+
+  curl -fsSL -o "${target}.tmp" "$url"
+  chmod +x "${target}.tmp"
+  mv "${target}.tmp" "$target"
+  ln -sf "$target" "${bin_dir}/bktec"
+}
+
+install_bktec
+
+export PATH="${bin_dir}:$PATH"
+export BUILDKITE_TEST_ENGINE_TEST_RUNNER="${BUILDKITE_TEST_ENGINE_TEST_RUNNER:-gotest}"
+export BUILDKITE_TEST_ENGINE_RETRY_COUNT="${BUILDKITE_TEST_ENGINE_RETRY_COUNT:-1}"
+export BUILDKITE_TEST_ENGINE_RESULT_PATH="tmp/test-engine/gotest-${BUILDKITE_PARALLEL_JOB:-0}.xml"
+
+if [[ -z "${BUILDKITE_TEST_ENGINE_SUITE_SLUG:-}" ]]; then
+  echo "BUILDKITE_TEST_ENGINE_SUITE_SLUG is required" >&2
+  exit 64
+fi
+
+if ! command -v gotestsum >/dev/null 2>&1; then
+  echo "gotestsum is required; install it with mise before running Test Engine" >&2
+  exit 127
+fi
+
+bktec run


### PR DESCRIPTION
Linux unit tests currently run as one plain `go test ./...` step, so the job cannot use Buildkite Test Engine history, package-level balancing, or result reporting. That makes the hosted Linux test job harder to scale as the package set grows.

This wires the Linux test step into the new `cleanroom-go-linux` Test Engine suite while leaving macOS and the host-locked VM/E2E jobs unchanged. The Linux step now runs four parallel bktec partitions, uses the existing mise Buildkite plugin to provide pinned `gotestsum`, uploads JUnit XML through the Test Collector plugin, and keeps the XML as build artifacts for inspection.

Because the collector plugin needs `BUILDKITE_ANALYTICS_TOKEN` in the job environment, a narrow `.buildkite/hooks/pre-command` hook mints a suite-scoped OIDC token only when a step sets `BUILDKITE_TEST_ENGINE_SUITE_SLUG`. The bktec wrapper itself still bootstraps pinned `bktec` and fails clearly if `gotestsum` is not available from mise.