### PR TITLE
fix: Derive copy-out paths from sandbox patch

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 11 ready for review
+**Status:** Slice 12 ready for review
 **Last reviewed:** 2026-05-30
 
 ## Summary
@@ -351,6 +351,30 @@ Result: passed.
 
 Repository validation rerun on 2026-05-30 after removing the newer Git
 `cat-file -Z` dependency:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Slice 12 is implemented and ready for review. Workspace copy-out now writes the
+guest patch to a temporary file, applies it to a temporary index rooted at the
+sandbox baseline, and derives the trusted changed-path list from that resulting
+tree before conflict checks, forced obstacle handling, local patch generation,
+or plan output use any target paths. The guest-reported `name-status` payload is
+still parsed as part of the transport format, but it no longer decides which
+local paths are safe to overwrite or report.
+
+Focused validation run on 2026-05-30:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise exec -- go test ./internal/cli
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-30:
 
 ```text
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/deepsec-oci-handler-bounds/cleanroom/mise.toml mise run check

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -221,25 +221,27 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 		return err
 	}
 	if opts.DryRun {
-		var files []repositorychangeset.File
+		_, patch, err := captureGitWorkspaceCopyOutPayload(callCtx, ctx, client, opts, checkout)
+		if err != nil {
+			return err
+		}
+		patchPath, cleanupPatch, err := writeTemporaryWorkspaceCopyOutPatch(patch)
+		if err != nil {
+			return err
+		}
+		defer cleanupPatch()
+		files, err := trustedGitWorkspaceCopyOutFiles(opts.Repository.RootDir, checkout.CommitSHA, patchPath)
+		if err != nil {
+			return err
+		}
+		files, err = addGitWorkspaceCopyOutManifestReverts(opts.Repository.RootDir, checkout.CommitSHA, opts.Binding, files)
+		if err != nil {
+			return err
+		}
 		if opts.ForceCopyOut || useGitWorkspaceCopyOutApplyBase(opts.Binding, opts.Repository, checkout) {
-			var patch []byte
-			files, patch, err = captureGitWorkspaceCopyOutPayload(callCtx, ctx, client, opts, checkout)
-			if err != nil {
-				return err
-			}
-			files, err = addGitWorkspaceCopyOutManifestReverts(opts.Repository.RootDir, checkout.CommitSHA, opts.Binding, files)
-			if err != nil {
-				return err
-			}
 			if len(files) > 0 {
 				var obstaclePaths []string
 				var cleanupApply func()
-				patchPath, cleanup, err := writeTemporaryWorkspaceCopyOutPatch(patch)
-				if err != nil {
-					return err
-				}
-				defer cleanup()
 				if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files, opts.ForceCopyOut, opts.ForceOutHint); err != nil {
 					return err
 				}
@@ -259,19 +261,6 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 					return err
 				}
 			}
-		} else {
-			command := repositorychangeset.WorktreeNameStatusCommand(checkout)
-			if len(command) == 0 {
-				return errors.New("sandbox repository checkout is missing the information needed to plan workspace copy-out")
-			}
-			output, err := runWorkspaceExecutionCapture(callCtx, ctx, client, opts.SandboxID, command, opts.LaunchSeconds)
-			if err != nil {
-				return err
-			}
-			files, err = parseGitNameStatusWorkspaceFiles(output)
-			if err != nil {
-				return err
-			}
 		}
 		entries, err := gitWorkspaceCopyOutPlanFiles(opts.CWD, files)
 		if err != nil {
@@ -280,7 +269,16 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 		return printWorkspacePlan(workspacePlanOutput(ctx, opts), entries)
 	}
 
-	files, patch, err := captureGitWorkspaceCopyOutPayload(callCtx, ctx, client, opts, checkout)
+	_, patch, err := captureGitWorkspaceCopyOutPayload(callCtx, ctx, client, opts, checkout)
+	if err != nil {
+		return err
+	}
+	patchPath, cleanupPatch, err := writeTemporaryWorkspaceCopyOutPatch(patch)
+	if err != nil {
+		return err
+	}
+	defer cleanupPatch()
+	files, err := trustedGitWorkspaceCopyOutFiles(opts.Repository.RootDir, checkout.CommitSHA, patchPath)
 	if err != nil {
 		return err
 	}
@@ -291,11 +289,6 @@ func copyWorkspaceOut(callCtx context.Context, ctx *runtimeContext, client *cont
 	if len(files) == 0 {
 		return nil
 	}
-	patchPath, cleanupPatch, err := writeTemporaryWorkspaceCopyOutPatch(patch)
-	if err != nil {
-		return err
-	}
-	defer cleanupPatch()
 	if err := ensureGitWorkspaceCopyOutSafe(opts.Repository, checkout, opts.Binding, files, opts.ForceCopyOut, opts.ForceOutHint); err != nil {
 		return err
 	}
@@ -836,6 +829,18 @@ func prepareGitWorkspaceCopyOutApplyPatchWithOmittedPaths(local *resolvedReposit
 		return nil, "", nil, fmt.Errorf("write workspace copy-out local apply patch: %w", err)
 	}
 	return applyFiles, patchPath, cleanup, nil
+}
+
+func trustedGitWorkspaceCopyOutFiles(localRoot, baseCommit, sandboxPatchPath string) ([]repositorychangeset.File, error) {
+	sandboxTree, err := gitWorkspaceSandboxTree(localRoot, baseCommit, sandboxPatchPath)
+	if err != nil {
+		return nil, err
+	}
+	nameStatus, err := gitOutputRaw(localRoot, nil, "diff", "--name-status", "--no-renames", "-z", strings.ToLower(strings.TrimSpace(baseCommit)), sandboxTree)
+	if err != nil {
+		return nil, fmt.Errorf("list sandbox workspace copy-out patch paths: %w", err)
+	}
+	return parseGitNameStatusWorkspaceFiles(nameStatus)
 }
 
 func resetGitWorkspaceCopyOutForceIndex(localRoot string, files []repositorychangeset.File, extraPaths []string) error {

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -904,6 +904,31 @@ func TestWorkspaceBindingRecordsCopyInManifest(t *testing.T) {
 
 func TestWorkspaceCopyOutDryRunReportsSandboxGitPlan(t *testing.T) {
 	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	if err := os.WriteFile(filepath.Join(localRoot, "removed.txt"), []byte("remove me\n"), 0o644); err != nil {
+		t.Fatalf("write removed file: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "removed.txt")
+	runGitInDir(t, localRoot, "commit", "-m", "add removed file")
+	baseCommit := headCommit(t, localRoot)
+
+	if err := os.Remove(filepath.Join(localRoot, "removed.txt")); err != nil {
+		t.Fatalf("remove sandbox file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localRoot, "changed.txt"), []byte("changed\n"), 0o644); err != nil {
+		t.Fatalf("write changed file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(localRoot, "nested"), 0o755); err != nil {
+		t.Fatalf("create nested dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localRoot, "nested", "new.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatalf("write nested file: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "-A")
+	nameStatus := gitOutputBytes(t, localRoot, "diff", "--cached", "--name-status", "--no-renames", "-z", baseCommit)
+	patch := gitOutputBytes(t, localRoot, "diff", "--cached", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", baseCommit)
+	runGitInDir(t, localRoot, "reset", "--hard", baseCommit)
+	runGitInDir(t, localRoot, "clean", "-fd")
+
 	resolvedLocalRoot, err := gitOutput(localRoot, "rev-parse", "--show-toplevel")
 	if err != nil {
 		t.Fatalf("resolve local repository root: %v", err)
@@ -914,7 +939,7 @@ func TestWorkspaceCopyOutDryRunReportsSandboxGitPlan(t *testing.T) {
 	}
 	adapter := &integrationAdapter{}
 	host, _ := startIntegrationServer(t, adapter)
-	sandboxID := createWorkspaceCopyTestSandboxWithRepository(t, host, "/sandbox-workspace")
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
 
 	var (
 		mu       sync.Mutex
@@ -925,7 +950,7 @@ func TestWorkspaceCopyOutDryRunReportsSandboxGitPlan(t *testing.T) {
 		commands = append(commands, append([]string(nil), req.Command...))
 		mu.Unlock()
 		if stream.OnStdout != nil {
-			stream.OnStdout([]byte("M\x00changed.txt\x00D\x00removed.txt\x00A\x00nested/new.txt\x00"))
+			stream.OnStdout(workspaceCopyOutTestPayload(nameStatus, patch))
 		}
 		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
 	}
@@ -968,8 +993,8 @@ func TestWorkspaceCopyOutDryRunReportsSandboxGitPlan(t *testing.T) {
 	if !strings.Contains(planCommand, "dest='/sandbox-workspace'") {
 		t.Fatalf("expected copy-out planning to use sandbox workspace root, got %q", planCommand)
 	}
-	if !strings.Contains(planCommand, "diff --cached --name-status --no-renames -z") {
-		t.Fatalf("expected copy-out planning to use git name-status, got %q", planCommand)
+	if !strings.Contains(planCommand, "cleanroom-copy-out-v1") {
+		t.Fatalf("expected copy-out planning to use combined copy-out payload, got %q", planCommand)
 	}
 }
 
@@ -997,12 +1022,20 @@ func TestWorkspaceCopyOutDryRunUsesBoundLocalRoot(t *testing.T) {
 	if err := recordGitWorkspaceBinding(sandboxID, repository, checkout, nil, "copy-in"); err != nil {
 		t.Fatalf("record workspace binding: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(localRoot, "changed.txt"), []byte("changed\n"), 0o644); err != nil {
+		t.Fatalf("write sandbox changed file: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "-A")
+	nameStatus := gitOutputBytes(t, localRoot, "diff", "--cached", "--name-status", "--no-renames", "-z", head)
+	patch := gitOutputBytes(t, localRoot, "diff", "--cached", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", head)
+	runGitInDir(t, localRoot, "reset", "--hard", head)
+	runGitInDir(t, localRoot, "clean", "-fd")
 
 	var executionCalled bool
 	adapter.runStreamFn = func(_ context.Context, _ backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 		executionCalled = true
 		if stream.OnStdout != nil {
-			stream.OnStdout([]byte("M\x00changed.txt\x00"))
+			stream.OnStdout(workspaceCopyOutTestPayload(nameStatus, patch))
 		}
 		return &backend.ExecutionResult{ExitCode: 0, Message: "ok"}, nil
 	}
@@ -1193,6 +1226,74 @@ func TestWorkspaceCopyOutAppliesSandboxGitPatch(t *testing.T) {
 		t.Fatalf("expected one combined copy-out execution, got %d", len(commands))
 	}
 	assertNoWorkspaceCopyOutRecoveryPayload(t)
+}
+
+func TestWorkspaceCopyOutDerivesPathsFromSandboxPatch(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	localRoot := initGitRepository(t, "https://github.com/buildkite/cleanroom.git")
+	if err := os.WriteFile(filepath.Join(localRoot, "secret.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write secret file: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "secret.txt")
+	runGitInDir(t, localRoot, "commit", "-m", "add secret file")
+	baseCommit := headCommit(t, localRoot)
+	resolvedLocalRoot, err := gitOutput(localRoot, "rev-parse", "--show-toplevel")
+	if err != nil {
+		t.Fatalf("resolve local repository root: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(localRoot, "secret.txt"), []byte("sandbox\n"), 0o644); err != nil {
+		t.Fatalf("write sandbox secret file: %v", err)
+	}
+	runGitInDir(t, localRoot, "add", "-A")
+	patch := gitOutputBytes(t, localRoot, "diff", "--cached", "--binary", "--full-index", "--no-ext-diff", "--no-color", "--no-renames", baseCommit)
+	runGitInDir(t, localRoot, "reset", "--hard", baseCommit)
+
+	adapter := &integrationAdapter{}
+	host, _ := startIntegrationServer(t, adapter)
+	sandboxID := createWorkspaceCopyTestSandboxWithRepositoryCommitBranch(t, host, "/sandbox-workspace", baseCommit, "main")
+	adapter.runStreamFn = func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+		command := strings.Join(req.Command, " ")
+		switch {
+		case strings.Contains(command, "cleanroom-copy-out-v1"):
+			if stream.OnStdout != nil {
+				stream.OnStdout(workspaceCopyOutTestPayload([]byte("M\x00README.md\x00"), patch))
+			}
+		default:
+			t.Fatalf("unexpected workspace copy-out command: %q", command)
+		}
+		return &backend.ExecutionResult{ExecutionID: req.ExecutionID, ExitCode: 0, Message: "ok"}, nil
+	}
+
+	stdout, stdoutText := makeStdoutCapture(t)
+	stderr, _ := makeStdoutCapture(t)
+	cmd := WorkspaceCopyOutCommand{
+		clientFlags: clientFlags{Host: host},
+		Chdir:       localRoot,
+		SandboxID:   sandboxID,
+	}
+	if err := cmd.Run(&runtimeContext{
+		CWD:           localRoot,
+		Loader:        repositoryNotFoundLoader{},
+		Config:        runtimeconfig.Config{},
+		Observability: newTestObservability(t),
+		Stdout:        stdout,
+		Stderr:        stderr,
+	}); err != nil {
+		t.Fatalf("WorkspaceCopyOutCommand.Run returned error: %v", err)
+	}
+
+	secret, err := os.ReadFile(filepath.Join(localRoot, "secret.txt"))
+	if err != nil {
+		t.Fatalf("read secret file: %v", err)
+	}
+	if got, want := string(secret), "sandbox\n"; got != want {
+		t.Fatalf("unexpected secret content: got %q want %q", got, want)
+	}
+	expected := "write\t" + filepath.Join(resolvedLocalRoot, "secret.txt") + "\n"
+	if got := stdoutText(); got != expected {
+		t.Fatalf("unexpected copy-out output: got %q want %q", got, expected)
+	}
 }
 
 func TestWorkspaceCopyOutAppliesFromCopyInManifestBase(t *testing.T) {


### PR DESCRIPTION
Workspace copy-out currently trusts the guest-reported `name-status` list before proving the patch actually changes only those paths. A sandbox that reports one path but sends a patch for another can make the client run conflict checks and plan output against stale target data.

This change writes the guest patch to a temporary file, applies it to a temporary index rooted at the sandbox baseline, and derives the trusted changed-path list from the resulting tree before local conflict checks, force obstacle handling, local patch generation, or plan output. The wire format still carries `name-status`, but it no longer decides what local paths are safe to touch.

I added regression coverage for a payload that reports `README.md` while the patch changes `secret.txt`; copy-out now plans and applies `secret.txt` based on the patch. Local validation passed with `mise exec -- go test ./internal/cli` and `mise run check`.