### PR TITLE
feat: Add Firecracker suspend wake

### DIFF
--- a/docs/backend/firecracker.md
+++ b/docs/backend/firecracker.md
@@ -23,6 +23,9 @@ supported layered-cache path.
   active per-command egress rule updates.
 - Effective vCPUs are fixed at VM launch. Cleanroom reports the resolved CPU
   ceiling but does not hotplug CPUs into a running Firecracker microVM.
+- Persistent sandboxes support same-host suspend and wake by stopping and
+  continuing the Firecracker process. This is process freeze/resume, not memory
+  hibernation or daemon-restart recovery.
 - Route git egress through the shared host gateway, with embedded
   `content-cache` for Git and OCI transport caching.
 - Keep secret values out of guest env and policy files.
@@ -70,6 +73,7 @@ Current capability values (visible in `cleanroom doctor --json`):
 - `sandbox.path_remove=true`
 - `sandbox.archive_read=true`
 - `sandbox.archive_write=true`
+- `sandbox.suspend=true`
 - `network.default_deny=true`
 - `network.allowlist_egress=true`
 - `network.stage_scoped_egress=false`

--- a/docs/plans/sandbox-suspend-wake.md
+++ b/docs/plans/sandbox-suspend-wake.md
@@ -1,7 +1,7 @@
 # Transparent Sandbox Suspend And Wake Plan
 
 **Status:** Active
-**Last reviewed:** 2026-05-27
+**Last reviewed:** 2026-05-29
 **Spec references:** `docs/api.md`, `docs/snapshots.md`, `docs/backend/darwin-vz.md`
 **Related plans:** `docs/plans/system-storage-prune.md`, `docs/plans/layered-caching.md`
 
@@ -115,12 +115,19 @@ idle suspend worker when `idle_suspend_after_seconds` is positive, and
 transparent wake is bounded by `wake_timeout_seconds` or the sandbox launch
 timeout when unset.
 
-Slice 4 is implemented in this change: service metrics and logs cover backend
+Slice 4 has landed: service metrics and logs cover backend
 suspend and wake duration and outcome, and the `darwin-vz` E2E path now smokes
 manual suspend, transparent wake through command execution, file read, and local
 port exposure before terminating the sandbox.
 
-Firecracker support remains a follow-up slice.
+Slice 5 is implemented in this change: Firecracker implements same-host
+freeze/resume through its existing process pause and resume helpers, publishes
+the backend-neutral suspend capability, and the Firecracker E2E path smokes
+manual suspend, transparent wake through command execution, file read, local
+port exposure, deny-by-default egress after wake, and termination from a
+suspended state.
+
+Live hibernation and daemon-restart restore remain follow-up work.
 
 ## Target Lifecycle Model
 

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -595,6 +595,34 @@ func (a *Adapter) TerminateSandbox(_ context.Context, sandboxID string) error {
 	return nil
 }
 
+func (a *Adapter) SuspendSandbox(ctx context.Context, sandboxID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	instance, err := a.lookupRunningSandbox(sandboxID)
+	if err != nil {
+		return err
+	}
+	if err := pauseSandboxProcess(instance); err != nil {
+		return fmt.Errorf("freeze firecracker sandbox: %w", err)
+	}
+	return nil
+}
+
+func (a *Adapter) ResumeSandbox(ctx context.Context, sandboxID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	instance, err := a.lookupRunningSandbox(sandboxID)
+	if err != nil {
+		return err
+	}
+	if err := resumeSandboxProcess(instance); err != nil {
+		return fmt.Errorf("resume firecracker sandbox: %w", err)
+	}
+	return nil
+}
+
 func (a *Adapter) DialSandboxPort(ctx context.Context, sandboxID string, port int) (net.Conn, error) {
 	sandboxID = strings.TrimSpace(sandboxID)
 	if sandboxID == "" {

--- a/internal/backend/firecracker/capabilities_test.go
+++ b/internal/backend/firecracker/capabilities_test.go
@@ -28,3 +28,11 @@ func TestCapabilitiesDeclareNetworkSupport(t *testing.T) {
 		t.Fatalf("expected %s=true", backend.CapabilitySandboxPortDial)
 	}
 }
+
+func TestCapabilitiesForAdapterExposeSandboxSuspend(t *testing.T) {
+	caps := backend.CapabilitiesForAdapter(New())
+
+	if !caps[backend.CapabilitySandboxSuspend] {
+		t.Fatalf("expected %s=true", backend.CapabilitySandboxSuspend)
+	}
+}

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -7,10 +7,12 @@ import (
 	"errors"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -110,6 +112,49 @@ func TestProvisionSandboxForwardsCacheOutputVolumes(t *testing.T) {
 	}
 	if !reflect.DeepEqual(gotSpecs, specs) {
 		t.Fatalf("unexpected cache output volume specs: got %#v want %#v", gotSpecs, specs)
+	}
+}
+
+func TestSuspendAndResumeSandboxSignalFirecrackerProcess(t *testing.T) {
+	var signals []syscall.Signal
+	prevSignal := sendProcessSignal
+	sendProcessSignal = func(_ *os.Process, sig syscall.Signal) error {
+		signals = append(signals, sig)
+		return nil
+	}
+	t.Cleanup(func() { sendProcessSignal = prevSignal })
+
+	adapter := &Adapter{
+		sandboxes: map[string]*sandboxInstance{
+			"cr-test": {
+				SandboxID: "cr-test",
+				fcCmd:     &exec.Cmd{Process: &os.Process{Pid: 42}},
+				exitedCh:  make(chan struct{}),
+			},
+		},
+	}
+
+	if err := adapter.SuspendSandbox(context.Background(), "cr-test"); err != nil {
+		t.Fatalf("SuspendSandbox returned error: %v", err)
+	}
+	if err := adapter.ResumeSandbox(context.Background(), "cr-test"); err != nil {
+		t.Fatalf("ResumeSandbox returned error: %v", err)
+	}
+	if got, want := signals, []syscall.Signal{syscall.SIGSTOP, syscall.SIGCONT}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected signals: got %v want %v", got, want)
+	}
+}
+
+func TestSuspendSandboxRejectsUnknownSandbox(t *testing.T) {
+	t.Parallel()
+
+	adapter := &Adapter{}
+	err := adapter.SuspendSandbox(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected SuspendSandbox to reject unknown sandbox")
+	}
+	if !strings.Contains(err.Error(), `unknown sandbox "missing"`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/scripts/ci-cleanroom-e2e.sh
+++ b/scripts/ci-cleanroom-e2e.sh
@@ -72,6 +72,19 @@ verify_helper_capabilities() {
   fi
 }
 
+choose_local_tcp_port() {
+  local port
+  for _ in $(seq 1 50); do
+    port=$((20000 + RANDOM % 20000))
+    if ! nc -z 127.0.0.1 "$port" >/dev/null 2>&1; then
+      printf '%s\n' "$port"
+      return 0
+    fi
+  done
+  echo "could not find an available local tcp port" >&2
+  return 1
+}
+
 # purge_stale_cleanroom_resources removes TAP devices, iptables rules,
 # and firecracker processes left over from a previous run that crashed
 # before cleanup.
@@ -127,6 +140,10 @@ cleanup() {
     "./dist/cleanroom" \
     "${listen_endpoint:-}" \
     "${tmpdir:-}" || true
+  if [[ -n "${exposure_pid:-}" ]]; then
+    kill "$exposure_pid" >/dev/null 2>&1 || true
+    wait "$exposure_pid" >/dev/null 2>&1 || true
+  fi
   if [[ -n "${srv_pid:-}" ]]; then
     kill "$srv_pid" >/dev/null 2>&1 || true
     wait "$srv_pid" >/dev/null 2>&1 || true
@@ -288,6 +305,121 @@ if ! grep -q '^persisted-data$' "$tmpdir/persist-download.out"; then
   exit 1
 fi
 
+echo "--- :pause_button: Suspend/wake lifecycle smoke"
+./dist/cleanroom sandbox suspend --host "$listen_endpoint" "$sandbox_id"
+./dist/cleanroom sandbox inspect --host "$listen_endpoint" "$sandbox_id" >"$tmpdir/suspend-inspect.out"
+if ! grep -q '^status: suspended$' "$tmpdir/suspend-inspect.out"; then
+  echo "expected sandbox to inspect as suspended" >&2
+  cat "$tmpdir/suspend-inspect.out" >&2 || true
+  exit 1
+fi
+
+./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc 'printf after-wake >/tmp/firecracker-suspend-wake.txt; echo command-after-wake' | tee "$tmpdir/wake-exec.out"
+if ! grep -q '^command-after-wake$' "$tmpdir/wake-exec.out"; then
+  echo "expected command-after-wake output missing" >&2
+  exit 1
+fi
+
+./dist/cleanroom sandbox suspend --host "$listen_endpoint" "$sandbox_id"
+./dist/download-sandbox-file \
+  --host "$listen_endpoint" \
+  --sandbox-id "$sandbox_id" \
+  --path /tmp/firecracker-suspend-wake.txt \
+  --timeout 45s \
+  --max-bytes 4096 >"$tmpdir/wake-file-download.out"
+if ! grep -q '^after-wake$' "$tmpdir/wake-file-download.out"; then
+  echo "expected downloaded wake file content missing" >&2
+  cat "$tmpdir/wake-file-download.out" >&2 || true
+  exit 1
+fi
+
+./dist/cleanroom sandbox suspend --host "$listen_endpoint" "$sandbox_id"
+# shellcheck disable=SC2016 # Guest-side script must keep $status for the guest shell.
+./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc '
+if ! command -v wget >/dev/null 2>&1; then
+  echo "guest image missing wget; cannot verify post-wake gateway deny" >&2
+  exit 2
+fi
+set +e
+http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= ALL_PROXY= all_proxy= NO_PROXY= no_proxy= wget -T 10 -q -O /dev/null https://buildkite.com
+status=$?
+set -e
+if [ "$status" -eq 0 ]; then
+  echo "non-allowlisted egress succeeded after wake" >&2
+  exit 1
+fi
+echo gateway-deny-after-wake
+' | tee "$tmpdir/wake-gateway-deny.out"
+if ! grep -q '^gateway-deny-after-wake$' "$tmpdir/wake-gateway-deny.out"; then
+  echo "expected gateway deny confirmation after wake" >&2
+  cat "$tmpdir/wake-gateway-deny.out" >&2 || true
+  exit 1
+fi
+
+./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc "cat > /tmp/cleanroom-http-responder <<'EOF'
+#!/bin/sh
+printf 'HTTP/1.1 200 OK\r\nContent-Length: 14\r\nConnection: close\r\n\r\nwake-exposure\n' | nc -l -p 18080
+EOF
+chmod +x /tmp/cleanroom-http-responder
+/tmp/cleanroom-http-responder >/tmp/cleanroom-nc-check.log 2>&1 &
+sleep 0.2
+wget -q -O - http://127.0.0.1:18080/
+/tmp/cleanroom-http-responder >/tmp/cleanroom-nc.log 2>&1 &" | tee "$tmpdir/exposure-guest.out"
+if ! grep -q '^wake-exposure$' "$tmpdir/exposure-guest.out"; then
+  echo "expected in-guest exposure response missing before suspend" >&2
+  cat "$tmpdir/exposure-guest.out" >&2 || true
+  exit 1
+fi
+
+./dist/cleanroom sandbox suspend --host "$listen_endpoint" "$sandbox_id"
+exposure_port="$(choose_local_tcp_port)"
+./dist/cleanroom port-forward --host "$listen_endpoint" --in "$sandbox_id" "$exposure_port:18080" >"$tmpdir/exposure.out" 2>"$tmpdir/exposure.err" &
+exposure_pid=$!
+for _ in $(seq 1 40); do
+  if grep -q "tcp://127.0.0.1:$exposure_port" "$tmpdir/exposure.out"; then
+    break
+  fi
+  if ! kill -0 "$exposure_pid" >/dev/null 2>&1; then
+    echo "port-forward exited before registering exposure" >&2
+    cat "$tmpdir/exposure.out" >&2 || true
+    cat "$tmpdir/exposure.err" >&2 || true
+    dump_runtime_diagnostics 80
+    exit 1
+  fi
+  sleep 0.25
+done
+if ! grep -q "tcp://127.0.0.1:$exposure_port" "$tmpdir/exposure.out"; then
+  echo "timed out waiting for port-forward registration" >&2
+  cat "$tmpdir/exposure.out" >&2 || true
+  cat "$tmpdir/exposure.err" >&2 || true
+  dump_runtime_diagnostics 80
+  exit 1
+fi
+
+set +e
+curl --fail --max-time 20 --silent --show-error "http://127.0.0.1:$exposure_port/" | tee "$tmpdir/exposure-http.out"
+curl_status=${PIPESTATUS[0]}
+set -e
+if [[ "$curl_status" -ne 0 ]]; then
+  echo "local exposure request failed with status $curl_status" >&2
+  echo "port-forward stdout:" >&2
+  cat "$tmpdir/exposure.out" >&2 || true
+  echo "port-forward stderr:" >&2
+  cat "$tmpdir/exposure.err" >&2 || true
+  ./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc 'ps; wget -S -O - http://127.0.0.1:18080/ || true' >&2 || true
+  dump_runtime_diagnostics 80
+  exit 1
+fi
+if ! grep -q '^wake-exposure$' "$tmpdir/exposure-http.out"; then
+  echo "expected local exposure response missing" >&2
+  cat "$tmpdir/exposure-http.out" >&2 || true
+  exit 1
+fi
+kill "$exposure_pid" >/dev/null 2>&1 || true
+wait "$exposure_pid" >/dev/null 2>&1 || true
+unset exposure_pid
+
+./dist/cleanroom sandbox suspend --host "$listen_endpoint" "$sandbox_id"
 ./dist/cleanroom sandbox rm --host "$listen_endpoint" "$sandbox_id" | tee "$tmpdir/sandbox-rm.out"
 if ! grep -q 'sandbox terminated' "$tmpdir/sandbox-rm.out"; then
   echo "expected sandbox terminate acknowledgement" >&2

--- a/scripts/ci_cleanroom_e2e_test.go
+++ b/scripts/ci_cleanroom_e2e_test.go
@@ -127,6 +127,35 @@ func TestCiCleanroomE2EReusedSandboxExecOmitsChdir(t *testing.T) {
 	}
 }
 
+func TestCiCleanroomE2ESmokesSuspendWakeLifecycle(t *testing.T) {
+	t.Helper()
+
+	content, err := os.ReadFile("ci-cleanroom-e2e.sh")
+	if err != nil {
+		t.Fatalf("read ci-cleanroom-e2e.sh: %v", err)
+	}
+
+	script := string(content)
+	for _, needle := range []string{
+		`choose_local_tcp_port()`,
+		`./dist/cleanroom sandbox suspend --host "$listen_endpoint" "$sandbox_id"`,
+		`./dist/cleanroom exec --host "$listen_endpoint" --in "$sandbox_id" -- sh -lc 'printf after-wake >/tmp/firecracker-suspend-wake.txt; echo command-after-wake'`,
+		`--path /tmp/firecracker-suspend-wake.txt`,
+		`guest image missing wget; cannot verify post-wake gateway deny`,
+		`http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= ALL_PROXY= all_proxy= NO_PROXY= no_proxy= wget -T 10 -q -O /dev/null https://buildkite.com`,
+		`gateway-deny-after-wake`,
+		`printf 'HTTP/1.1 200 OK\r\nContent-Length: 14\r\nConnection: close\r\n\r\nwake-exposure\n' | nc -l -p 18080`,
+		`./dist/cleanroom port-forward --host "$listen_endpoint" --in "$sandbox_id" "$exposure_port:18080"`,
+		`curl_status=${PIPESTATUS[0]}`,
+		`curl --fail --max-time 20 --silent --show-error "http://127.0.0.1:$exposure_port/"`,
+		`kill "$exposure_pid" >/dev/null 2>&1 || true`,
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("expected ci-cleanroom-e2e.sh to contain %q", needle)
+		}
+	}
+}
+
 func TestCiCleanroomE2EIsolatesCacheInTempDir(t *testing.T) {
 	t.Helper()
 


### PR DESCRIPTION
Persistent Firecracker sandboxes now have the same manual and transparent suspend/wake surface as darwin-vz, but the backend still could not advertise or perform the lifecycle operation. That left the backend-neutral suspend controls only partially useful on Linux hosts.

This adds Firecracker `SuspendSandbox` and `ResumeSandbox` by freezing and continuing the existing Firecracker process with `SIGSTOP` and `SIGCONT`. The control service still owns lifecycle state, wake coalescing, and idle policy; Firecracker only implements the backend operation.

The Firecracker E2E script now creates a persistent sandbox and proves manual suspend, exec wake, file-read wake, deny-by-default egress after wake, port-forward wake to a guest `nc` responder, and removal from a suspended state.

Docs call this process freeze/resume, not hibernation or daemon-restart restore.