### PR TITLE
docs: Use Buildkite OIDC for auth examples

### DIFF
--- a/docs/plans/multi-principal-control-server.md
+++ b/docs/plans/multi-principal-control-server.md
@@ -1,8 +1,8 @@
 # Multi-Principal Control Server Authorization Plan
 
 **Spec reference:** `docs/spec.md` sections 5.4, 6.1, and 6.2; `docs/api.md`; `docs/tls.md`
-**Status:** Runtime exact-principal smoke implemented; controlled sharing follow-ups next
-**Last reviewed:** 2026-05-29
+**Status:** Buildkite OIDC operator path documented; controlled sharing follow-ups next
+**Last reviewed:** 2026-05-30
 
 ## Summary
 
@@ -70,6 +70,10 @@ Slice 2 is split into PR-sized enforcement work:
   real signed OIDC JWTs for two principals, creates one sandbox per principal,
   and proves public CLI operations cannot cross the exact-principal boundary for
   list, get, execute, file, and snapshot workflows.
+- Remote access examples now use Buildkite OIDC as the first operator path:
+  trust `https://agent.buildkite.com`, require immutable Buildkite organization
+  and pipeline IDs, and treat slugs or branches as optional grant constraints
+  rather than ownership identity.
 
 Focused validation run on 2026-05-25:
 
@@ -274,22 +278,22 @@ auth:
   required: true
   oidc:
     issuers:
-      - name: github-actions
-        issuer: https://token.actions.githubusercontent.com
+      - name: buildkite
+        issuer: https://agent.buildkite.com
         audiences:
-          - cleanroom
-        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+          - https://cleanroom.example.com
+        jwks_url: https://agent.buildkite.com/.well-known/jwks
         required_claims:
-          repository_owner_id: "123456"
+          organization_id: "0184990a-477b-4fa8-9968-496074483k77"
   policy:
     bindings:
       - name: cleanroom-repo-bots
         when: >
-          token.issuer == "github-actions" &&
-          claims.repository_id == "987654"
+          token.issuer == "buildkite" &&
+          claims.pipeline_id == "0184990a-4782-42b5-afc1-16715b10b1l0"
         principal:
-          id: 'oidc:${token.issuer}:owner:${claims.repository_owner_id}:repo:${claims.repository_id}'
-          scope: 'owner:${claims.repository_owner_id}'
+          id: 'oidc:${token.issuer}:org:${claims.organization_id}:pipeline:${claims.pipeline_id}'
+          scope: 'org:${claims.organization_id}'
         grants:
           - name: create-cleanroom-sandboxes
             actions:
@@ -308,13 +312,23 @@ auth:
               - sandbox.get
               - sandbox.list
               - sandbox.terminate
+              - sandbox.file.stat
+              - sandbox.file.read
+              - sandbox.file.write
               - execution.create
               - execution.get
               - execution.list
+              - execution.inspect
               - execution.stream
+              - execution.attach
+              - snapshot.create
+              - snapshot.get
+              - snapshot.list
+              - snapshot.restore
             resources:
               - sandbox
               - execution
+              - snapshot
 ```
 
 The exact schema can change during implementation, but the ownership boundary
@@ -894,6 +908,8 @@ Runtime smoke test:
   `auth.policy_file` only as an escape hatch for generated or large policies.
 - Require examples to derive owner principal IDs from immutable provider claim
   IDs where the issuer exposes them.
+- Use Buildkite OIDC for the first documented operator path, with
+  `organization_id` and `pipeline_id` as the ownership inputs.
 
 ## Deferred Work
 
@@ -912,9 +928,6 @@ Runtime smoke test:
 - Should unix-socket callers remain local-trusted when remote auth is required?
   Recommended default: yes for the first implementation, with an explicit
   `auth.require_unix_socket` hardening option later.
-- Which OIDC issuer should the examples use first?
-  Recommended default: GitHub Actions because it is widely available and has
-  useful repository claims, while keeping the implementation generic.
 - Should stage-cache sharing ever be allowed at repo scope?
   Recommended default: no for the first auth-enabled version; exact-principal
   cache partitioning is simpler and avoids leaking private dependency outputs.

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -31,25 +31,31 @@ Non-loopback HTTPS listeners require `auth.required: true`.
 Shared Cleanroom servers can require OIDC JWT bearer tokens for HTTP(S)
 control-plane calls:
 
+Buildkite Pipelines can request tokens from the Buildkite agent OIDC issuer and
+send them to Cleanroom. Configure the server to trust the Buildkite issuer and
+to bind immutable Buildkite IDs to Cleanroom principals:
+
 ```yaml
 auth:
   required: true
   oidc:
     issuers:
-      - name: github-actions
-        issuer: https://token.actions.githubusercontent.com
+      - name: buildkite
+        issuer: https://agent.buildkite.com
         audiences:
-          - cleanroom
-        jwks_url: https://token.actions.githubusercontent.com/.well-known/jwks
+          - https://cleanroom.example.com
+        jwks_url: https://agent.buildkite.com/.well-known/jwks
         required_claims:
-          repository_owner_id: "123456"
+          organization_id: "0184990a-477b-4fa8-9968-496074483k77"
   policy:
     bindings:
       - name: repo-bots
-        when: claims.repository_id == "987654"
+        when: >
+          token.issuer == "buildkite" &&
+          claims.pipeline_id == "0184990a-4782-42b5-afc1-16715b10b1l0"
         principal:
-          id: "oidc:${token.issuer}:owner:${claims.repository_owner_id}:repo:${claims.repository_id}"
-          scope: "owner:${claims.repository_owner_id}"
+          id: "oidc:${token.issuer}:org:${claims.organization_id}:pipeline:${claims.pipeline_id}"
+          scope: "org:${claims.organization_id}"
         grants:
           - name: create-cleanroom-sandboxes
             actions:
@@ -63,13 +69,24 @@ auth:
             actions:
               - sandbox.get
               - sandbox.list
+              - sandbox.terminate
+              - sandbox.file.read
+              - sandbox.file.write
+              - sandbox.file.stat
               - execution.create
               - execution.get
               - execution.list
+              - execution.attach
+              - execution.inspect
+              - execution.stream
+              - execution.stdin.write
+              - execution.stdin.close
+              - execution.cancel
               - snapshot.create
               - snapshot.get
               - snapshot.list
               - snapshot.restore
+              - snapshot.delete
             resources:
               - sandbox
               - execution
@@ -77,17 +94,52 @@ auth:
 ```
 
 The inline policy maps trusted token claims to Cleanroom principals and grants.
-Use immutable provider claim IDs, not reusable slugs, for principal IDs. For
-large or generated policies, `auth.policy_file` can point at a separate YAML
-file with the same `bindings` shape; it is mutually exclusive with
+Use immutable Buildkite IDs, not reusable slugs, for principal IDs. Slugs and
+branches are still useful for additional grant conditions, but should not define
+ownership. For large or generated policies, `auth.policy_file` can point at a
+separate YAML file with the same `bindings` shape; it is mutually exclusive with
 `auth.policy`.
+
+In a Buildkite command step, request a short-lived token for the Cleanroom
+server audience and include the immutable claims used by the policy:
+
+```bash
+buildkite-agent oidc request-token \
+  --audience "https://cleanroom.example.com" \
+  --subject-claim pipeline_id \
+  --claim organization_id \
+  > /tmp/cleanroom.jwt
+```
 
 Clients send the token with either `CLEANROOM_AUTH_TOKEN`,
 `--auth-token-env`, or `--auth-token-file`:
 
 ```bash
-CLEANROOM_AUTH_TOKEN="$TOKEN" \
-  cleanroom sandbox create --host https://server.example.com:7777
+cleanroom sandbox create \
+  --host https://cleanroom.example.com \
+  --auth-token-file /tmp/cleanroom.jwt
+```
+
+Use `cleanroom auth check` before pointing a pipeline at a shared server. A
+create check needs a request fixture; existing-resource checks need the expected
+owner fields:
+
+```bash
+cleanroom auth check \
+  --config /etc/cleanroom/config.yaml \
+  --token-file /tmp/cleanroom.jwt \
+  --action sandbox.create \
+  --request create-request.json \
+  --json
+
+cleanroom auth check \
+  --config /etc/cleanroom/config.yaml \
+  --token-file /tmp/cleanroom.jwt \
+  --action sandbox.get \
+  --resource-id sbx_123 \
+  --owner-principal-id oidc:buildkite:org:0184990a-477b-4fa8-9968-496074483k77:pipeline:0184990a-4782-42b5-afc1-16715b10b1l0 \
+  --owner-scope org:0184990a-477b-4fa8-9968-496074483k77 \
+  --json
 ```
 
 With auth enabled, sandboxes, executions, snapshots, file operations, streams,

--- a/internal/cli/auth_check_test.go
+++ b/internal/cli/auth_check_test.go
@@ -41,7 +41,7 @@ func TestAuthCheckCommandReportsAllowedDecision(t *testing.T) {
 	if !decision.Allowed {
 		t.Fatalf("expected allowed decision, got %#v", decision)
 	}
-	if got, want := decision.Principal.ID, "oidc:github-actions:owner:123456:repo:987654"; got != want {
+	if got, want := decision.Principal.ID, "oidc:buildkite:org:org-uuid:pipeline:pipeline-uuid"; got != want {
 		t.Fatalf("unexpected principal ID: got %q want %q", got, want)
 	}
 	if got, want := decision.Binding, "cleanroom-repo-bots"; got != want {
@@ -56,23 +56,23 @@ auth:
   required: true
   oidc:
     issuers:
-      - name: github-actions
-        issuer: https://token.actions.githubusercontent.com
-        audiences: [cleanroom]
+      - name: buildkite
+        issuer: https://agent.buildkite.com
+        audiences: [https://cleanroom.example.com]
         jwks_url: ` + fixture.jwksURL + `
         required_claims:
-          repository_owner_id: "123456"
+          organization_id: "org-uuid"
         clock_skew_seconds: 60
         max_token_lifetime_seconds: 3600
   policy:
     bindings:
       - name: cleanroom-repo-bots
         when: >
-          token.issuer == "github-actions" &&
-          claims.repository_id == "987654"
+          token.issuer == "buildkite" &&
+          claims.pipeline_id == "pipeline-uuid"
         principal:
-          id: 'oidc:${token.issuer}:owner:${claims.repository_owner_id}:repo:${claims.repository_id}'
-          scope: 'owner:${claims.repository_owner_id}'
+          id: 'oidc:${token.issuer}:org:${claims.organization_id}:pipeline:${claims.pipeline_id}'
+          scope: 'org:${claims.organization_id}'
         grants:
           - name: create-cleanroom-sandbox
             actions: [sandbox.create]
@@ -108,7 +108,7 @@ auth:
 	if !decision.Allowed {
 		t.Fatalf("expected allowed decision, got %#v", decision)
 	}
-	if got, want := decision.Principal.ID, "oidc:github-actions:owner:123456:repo:987654"; got != want {
+	if got, want := decision.Principal.ID, "oidc:buildkite:org:org-uuid:pipeline:pipeline-uuid"; got != want {
 		t.Fatalf("unexpected principal ID: got %q want %q", got, want)
 	}
 }
@@ -164,7 +164,7 @@ func TestAuthCheckCommandReportsBindingConditionError(t *testing.T) {
       - actions: [sandbox.create]
         resources: [sandbox]
   - name: fallback
-    when: 'token.issuer == "github-actions"'
+    when: 'token.issuer == "buildkite"'
     principal:
       id: 'oidc:${token.issuer}:${claims.sub}'
     grants:
@@ -248,12 +248,12 @@ auth:
   required: true
   oidc:
     issuers:
-      - name: github-actions
-        issuer: https://token.actions.githubusercontent.com
-        audiences: [cleanroom]
+      - name: buildkite
+        issuer: https://agent.buildkite.com
+        audiences: [https://cleanroom.example.com]
         jwks_url: ` + jwks.URL + `
         required_claims:
-          repository_owner_id: "123456"
+          organization_id: "org-uuid"
         clock_skew_seconds: 60
         max_token_lifetime_seconds: 3600
   policy_file: auth-policy.yaml
@@ -263,15 +263,16 @@ auth:
 	}
 	tokenPath := filepath.Join(dir, "token.jwt")
 	token := cliAuthSignToken(t, key, "kid-1", jwt.MapClaims{
-		"iss":                 "https://token.actions.githubusercontent.com",
-		"sub":                 "repo:buildkite/cleanroom:ref:refs/heads/main",
-		"aud":                 []string{"cleanroom"},
-		"iat":                 jwt.NewNumericDate(now.Add(-time.Minute)),
-		"nbf":                 jwt.NewNumericDate(now.Add(-time.Minute)),
-		"exp":                 jwt.NewNumericDate(now.Add(time.Minute)),
-		"repository":          "buildkite/cleanroom",
-		"repository_owner_id": "123456",
-		"repository_id":       "987654",
+		"iss":               "https://agent.buildkite.com",
+		"sub":               "pipeline-uuid",
+		"aud":               []string{"https://cleanroom.example.com"},
+		"iat":               jwt.NewNumericDate(now.Add(-time.Minute)),
+		"nbf":               jwt.NewNumericDate(now.Add(-time.Minute)),
+		"exp":               jwt.NewNumericDate(now.Add(time.Minute)),
+		"organization_id":   "org-uuid",
+		"organization_slug": "buildkite",
+		"pipeline_id":       "pipeline-uuid",
+		"pipeline_slug":     "cleanroom",
 	})
 	if err := os.WriteFile(tokenPath, []byte(token+"\n"), 0o600); err != nil {
 		t.Fatalf("write token: %v", err)
@@ -346,11 +347,11 @@ func cliAuthPolicyYAML() string {
 	return `bindings:
   - name: cleanroom-repo-bots
     when: >
-      token.issuer == "github-actions" &&
-      claims.repository_id == "987654"
+      token.issuer == "buildkite" &&
+      claims.pipeline_id == "pipeline-uuid"
     principal:
-      id: 'oidc:${token.issuer}:owner:${claims.repository_owner_id}:repo:${claims.repository_id}'
-      scope: 'owner:${claims.repository_owner_id}'
+      id: 'oidc:${token.issuer}:org:${claims.organization_id}:pipeline:${claims.pipeline_id}'
+      scope: 'org:${claims.organization_id}'
     grants:
       - name: create-cleanroom-sandbox
         actions: [sandbox.create]


### PR DESCRIPTION
The remote auth docs still led with GitHub Actions OIDC even though the first operator path for this repo should be Buildkite Pipelines. That made the recommended shared-server setup feel adjacent to the real deployment model and kept the auth-check fixture anchored to another provider's claim shape.

This updates the remote-access docs and multi-principal plan to use Buildkite OIDC from `https://agent.buildkite.com`, with ownership derived from immutable `organization_id` and `pipeline_id` claims. It also updates the CLI auth-check fixture so the documented inline-policy shape is exercised with Buildkite-style issuer, audience, and claims.

The examples intentionally keep slugs and branches out of ownership identity; they remain suitable as optional grant conditions only.