### PR TITLE
fix: Scope Git pack cache authorization

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 13 ready for review
+**Status:** Slice 14 ready for review
 **Last reviewed:** 2026-05-30
 
 ## Summary
@@ -10,8 +10,10 @@ DeepSec revalidated 26 findings against the Cleanroom checkout on 2026-05-27.
 All 26 were treated as true positives that needed code, configuration, or CI
 fixes. A post-merge re-check on 2026-05-30 scanned current `main`, processed one
 new candidate, and force-revalidated all 27 findings. That pass marked 22
-findings fixed and left 5 true positives; Slice 13 closes the 3 remaining
-remote control-plane auth findings from that set.
+findings fixed and left 5 true positives. Slice 13 closed the 3 remaining
+remote control-plane auth findings from that set, and Slice 14 closes the
+cached Git pack authorization finding. One true positive remains: unbounded
+dynamic Git content-cache handler creation.
 
 This plan tracks each finding separately while keeping implementation in
 reviewable slices. A slice may close several findings when they share the same
@@ -449,6 +451,43 @@ surface finding revalidated as fixed. The report now has 2 true positives
 remaining: cached Git pack authorization and unbounded dynamic Git handler
 creation.
 
+Slice 14 is implemented and ready for review. Git pack cache metadata is now
+partitioned by host, effective policy key, owner authorization envelope, and
+resolved upstream credential material. Empty credentials therefore cannot read
+pack metadata written under host-side Basic credentials, and a changed owner
+envelope or credential produces a separate pack index. `git-upload-pack`
+requests with non-Basic upstream credentials bypass the embedded pack cache and
+use the existing mirror-backed/direct Git fallback because the embedded
+content-cache auth hook only re-checks Basic credentials on cache hits.
+
+Focused validation run on 2026-05-30:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/Develop/cleanroom/mise.toml mise exec -- go test ./internal/gateway -run 'TestCachedGitHandler|TestGitHandlerForHost|TestContentCacheGitBasicAuthProvider|TestGitContentCacheUpstream'
+```
+
+Result: passed.
+
+Focused validation run on 2026-05-30:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/Develop/cleanroom/mise.toml mise exec -- go test ./internal/gateway
+```
+
+Result: passed.
+
+Targeted DeepSec revalidation on 2026-05-30:
+
+```text
+cd /Users/lachlan/Develop/cleanroom/.deepsec
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec revalidate --project-id cleanroom --force --filter internal/gateway/git_cached.go --min-severity HIGH --concurrency 1 --root /Users/lachlan/Develop/cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec report --project-id cleanroom
+```
+
+Result: the cached Git pack authorization finding revalidated as fixed. The
+report now has 1 true positive remaining: unbounded dynamic Git handler
+creation.
+
 ## Triage
 
 | Finding | Severity | Decision | Remediation slice |
@@ -465,7 +504,7 @@ creation.
 | Privileged DNS install writes and chowns certificate paths in a user-controlled directory without symlink checks | High | Needs fix | Slice 4b: DNS and exposure certificate path hardening |
 | Privileged certificate writes follow user-controlled symlinks | High | Needs fix | Slice 4b: DNS and exposure certificate path hardening |
 | Remote URL path can inject fields into git credential fill lookup | High | Needs fix | Slice 6: gateway credential and cache authorization hardening |
-| Cached Git pack responses are not scoped to current repo authorization | High | Still true positive after re-check | Slice 14: Git pack cache authorization binding |
+| Cached Git pack responses are not scoped to current repo authorization | High | Fixed by Slice 14 | Slice 14: Git pack cache authorization binding |
 | Policy protobufs can request allow-all sandbox egress | High | Needs fix | Slice 7: policy compile and protobuf validation hardening |
 | Repository-controlled submodule URLs are mirrored by the host without policy validation | High | Needs fix | Slice 2: host-side repository mirror policy enforcement |
 | Unbounded OCI handler creation from request-controlled registry prefixes | High bug | Needs fix | Slice 6: gateway credential and cache authorization hardening |

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 14 ready for review
+**Status:** Slice 15 ready for review
 **Last reviewed:** 2026-05-30
 
 ## Summary
@@ -12,8 +12,9 @@ fixes. A post-merge re-check on 2026-05-30 scanned current `main`, processed one
 new candidate, and force-revalidated all 27 findings. That pass marked 22
 findings fixed and left 5 true positives. Slice 13 closed the 3 remaining
 remote control-plane auth findings from that set, and Slice 14 closes the
-cached Git pack authorization finding. One true positive remains: unbounded
-dynamic Git content-cache handler creation.
+cached Git pack authorization finding. Slice 15 closes the remaining dynamic
+Git content-cache handler growth finding. The 2026-05-30 DeepSec status now
+shows all 27 findings revalidated as fixed.
 
 This plan tracks each finding separately while keeping implementation in
 reviewable slices. A slice may close several findings when they share the same
@@ -488,6 +489,44 @@ Result: the cached Git pack authorization finding revalidated as fixed. The
 report now has 1 true positive remaining: unbounded dynamic Git handler
 creation.
 
+Slice 15 is implemented and ready for review. Scoped Git content-cache handlers
+now use the same lease-and-LRU pattern as OCI, fetch, and Go proxy handlers.
+The cache keeps a bounded set of scoped handlers, refreshes recency on reuse,
+evicts least-recently-used scopes when the bound is exceeded, and closes evicted
+handlers after in-flight requests release their leases. The non-Basic
+`git-upload-pack` fallback path now uses a direct Git proxy instead of the
+mirror-backed fallback, so bearer-token requests do not reuse mirror contents
+keyed only by repository URL.
+
+Focused validation run on 2026-05-30:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/Develop/cleanroom/mise.toml mise exec -- go test ./internal/gateway -run 'TestCachedGitHandler|TestGitHandlerForHost|TestContentCacheGitBasicAuthProvider|TestGitContentCacheUpstream'
+```
+
+Result: passed.
+
+Focused validation run on 2026-05-30:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/Develop/cleanroom/mise.toml mise exec -- go test ./internal/gateway
+```
+
+Result: passed.
+
+Targeted DeepSec revalidation on 2026-05-30:
+
+```text
+cd /Users/lachlan/Develop/cleanroom/.deepsec
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec revalidate --project-id cleanroom --force --filter internal/gateway/contentcache.go --min-severity MEDIUM --concurrency 1 --root /Users/lachlan/Develop/cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec report --project-id cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec status --project-id cleanroom
+```
+
+Result: the dynamic Git handler creation finding revalidated as fixed. DeepSec
+status now reports 27/27 findings revalidated, with 0 true positives and 27
+fixed findings.
+
 ## Triage
 
 | Finding | Severity | Decision | Remediation slice |
@@ -514,7 +553,7 @@ creation.
 | Release manifest fields are used as host cache path components | Medium | Needs fix | Slice 8: image and boot asset resource bounds |
 | Fetch cache hits can bypass per-sandbox redirect policy | Medium | Needs fix | Slice 6: gateway credential and cache authorization hardening |
 | Go proxy cache hits can bypass effective policy validation | Medium | Needs fix | Slice 6: gateway credential and cache authorization hardening |
-| Unbounded dynamic Git cache handlers can exhaust gateway memory | Medium | New true positive from re-check | Slice 15: bound dynamic Git handler creation |
+| Unbounded dynamic Git cache handlers can exhaust gateway memory | Medium | Fixed by Slice 15 | Slice 15: bound dynamic Git handler creation |
 | Snapshot storage can be orphaned when VM resume fails | Bug | Needs fix | Slice 10: darwin-vz lifecycle cleanup |
 | Portable dependency validation treats glob key files as literals | Bug | Needs fix | Slice 11: dependency validation correctness |
 | Newline-containing Git paths break batched digest calculation | Bug | Needs fix | Slice 11: dependency validation correctness |

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -109,11 +109,6 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	ociHTTPClient := newOCIContentCacheHTTPClient(cfg.Credentials)
 	rubyGemsHTTPClient := newRubyGemsContentCacheHTTPClient(cfg.Credentials)
 
-	packIdx, err := metadb.NewEnvelopeIndex(db, "git", "pack", 24*time.Hour)
-	if err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("create git pack index: %w", err)
-	}
 	manifestIdx, err := metadb.NewEnvelopeIndex(db, "oci", "manifest", 24*time.Hour)
 	if err != nil {
 		_ = db.Close()
@@ -164,7 +159,6 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		return nil, fmt.Errorf("create rubygems gemspec index: %w", err)
 	}
 
-	gitIndex := ccgit.NewIndex(packIdx)
 	sumDBIndex := ccgoproxy.NewSumdbIndex(sumDBIdx)
 	ociIndex := ccoci.NewIndex(imageIdx, manifestIdx, blobIdx)
 	rubyGemsIndex := ccrubygems.NewIndex(
@@ -268,7 +262,7 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	cache.resolveOCIRoute = func(prefix string) (ociRoute, error) {
 		return resolveOCIRegistryRoute(prefix, registryMappings)
 	}
-	cache.buildGitHandler = func(host string) (http.Handler, error) {
+	cache.buildGitHandler = func(host, cacheScope string) (http.Handler, error) {
 		host = strings.ToLower(strings.TrimSpace(host))
 		if host == "" {
 			return nil, fmt.Errorf("empty git host")
@@ -277,6 +271,10 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 			if _, ok := allowedGitHosts[host]; !ok {
 				return nil, fmt.Errorf("%w: %s", errGitHostNotConfiguredForCaching, host)
 			}
+		}
+		gitIndex, err := newScopedGitIndex(db, scopedMetadataPrefix("git:"+cacheScope))
+		if err != nil {
+			return nil, err
 		}
 		return ccgit.NewHandler(
 			gitIndex,
@@ -412,6 +410,14 @@ func newScopedFetchIndex(db metadb.EnvelopeStore, policyPrefix string) (*ccfetch
 		return nil, fmt.Errorf("create scoped fetch resource index: %w", err)
 	}
 	return ccfetch.NewIndex(resourceIdx), nil
+}
+
+func newScopedGitIndex(db metadb.EnvelopeStore, scopePrefix string) (*ccgit.Index, error) {
+	packIdx, err := newScopedEnvelopeIndex(db, "git", "pack", scopePrefix, 24*time.Hour)
+	if err != nil {
+		return nil, fmt.Errorf("create scoped git pack index: %w", err)
+	}
+	return ccgit.NewIndex(packIdx), nil
 }
 
 func newScopedEnvelopeIndex(db metadb.EnvelopeStore, protocol, kind, policyPrefix string, ttl time.Duration) (*metadb.EnvelopeIndex, error) {

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -185,7 +185,8 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 
 	cache := &ContentCache{
 		closer:         db,
-		gitHandlers:    make(map[string]http.Handler),
+		gitHandlers:    make(map[string]*gitHandlerEntry),
+		maxGitHandlers: defaultMaxGitHandlers,
 		ociHandlers:    make(map[string]*ociHandlerEntry),
 		maxOCIHandlers: defaultMaxOCIHandlers,
 		ociMirrorHosts: ociMirrorHosts(cfg.OCIRegistries),
@@ -262,28 +263,33 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	cache.resolveOCIRoute = func(prefix string) (ociRoute, error) {
 		return resolveOCIRegistryRoute(prefix, registryMappings)
 	}
-	cache.buildGitHandler = func(host, cacheScope string) (http.Handler, error) {
+	cache.buildGitHandler = func(host, cacheScope string) (gitHandlerEntry, error) {
 		host = strings.ToLower(strings.TrimSpace(host))
 		if host == "" {
-			return nil, fmt.Errorf("empty git host")
+			return gitHandlerEntry{}, fmt.Errorf("empty git host")
 		}
 		if len(allowedGitHosts) > 0 {
 			if _, ok := allowedGitHosts[host]; !ok {
-				return nil, fmt.Errorf("%w: %s", errGitHostNotConfiguredForCaching, host)
+				return gitHandlerEntry{}, fmt.Errorf("%w: %s", errGitHostNotConfiguredForCaching, host)
 			}
 		}
 		gitIndex, err := newScopedGitIndex(db, scopedMetadataPrefix("git:"+cacheScope))
 		if err != nil {
-			return nil, err
+			return gitHandlerEntry{}, err
 		}
-		return ccgit.NewHandler(
+		handler := ccgit.NewHandler(
 			gitIndex,
 			cafs,
 			ccgit.WithUpstream(newGitContentCacheUpstream(gitHTTPClient, logger, cfg.Credentials)),
 			ccgit.WithAllowedHosts([]string{host}),
 			ccgit.WithDownloader(dl),
 			ccgit.WithLogger(logger),
-		), nil
+		)
+		entry := gitHandlerEntry{handler: handler}
+		if closer, ok := any(handler).(interface{ Close() }); ok {
+			entry.closer = closeFunc(closer.Close)
+		}
+		return entry, nil
 	}
 	cache.buildOCIHandler = func(prefix string) (ociHandlerEntry, error) {
 		route, err := cache.resolveOCIRoute(prefix)

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -17,12 +17,13 @@ import (
 )
 
 const (
+	defaultMaxGitHandlers           = 32
 	defaultMaxGoProxyScopedHandlers = 32
 	defaultMaxFetchScopedHandlers   = 32
 	defaultMaxOCIHandlers           = 32
 )
 
-type gitHandlerFactory func(host, cacheScope string) (http.Handler, error)
+type gitHandlerFactory func(host, cacheScope string) (gitHandlerEntry, error)
 
 type ociHandlerFactory func(prefix string) (ociHandlerEntry, error)
 
@@ -37,6 +38,13 @@ type ociHandlerEntry struct {
 	closer       io.Closer
 	active       int
 	evicted      bool
+}
+
+type gitHandlerEntry struct {
+	handler http.Handler
+	closer  io.Closer
+	active  int
+	evicted bool
 }
 
 type goProxyScopedHandler struct {
@@ -100,7 +108,9 @@ type ContentCache struct {
 	closer io.Closer
 
 	gitMu           sync.Mutex
-	gitHandlers     map[string]http.Handler
+	gitHandlers     map[string]*gitHandlerEntry
+	gitOrder        []string
+	maxGitHandlers  int
 	buildGitHandler gitHandlerFactory
 
 	ociMu           sync.Mutex
@@ -123,8 +133,15 @@ func (c *ContentCache) Close() error {
 		return nil
 	}
 
+	closers := make([]io.Closer, 0, 4)
+	c.gitMu.Lock()
+	for _, entry := range c.gitHandlers {
+		if entry.closer != nil {
+			closers = append(closers, entry.closer)
+		}
+	}
+	c.gitMu.Unlock()
 	c.ociMu.Lock()
-	closers := make([]io.Closer, 0, len(c.ociHandlers)+4)
 	for _, entry := range c.ociHandlers {
 		if entry.closer != nil {
 			closers = append(closers, entry.closer)
@@ -170,36 +187,119 @@ func (c *ContentCache) HasGitHandler() bool {
 	return c != nil && c.buildGitHandler != nil
 }
 
-// GitHandlerForHost returns a git cache handler scoped to the requested host
-// and authorization scope.
-func (c *ContentCache) GitHandlerForHost(host, cacheScope string) (http.Handler, error) {
+// GitHandlerForHost returns a leased git cache handler scoped to the requested
+// host and authorization scope.
+func (c *ContentCache) GitHandlerForHost(host, cacheScope string) (http.Handler, func(), error) {
 	if c == nil || c.buildGitHandler == nil {
-		return nil, errors.New("git cache not configured")
+		return nil, nil, errors.New("git cache not configured")
 	}
 
 	host = strings.ToLower(strings.TrimSpace(host))
 	if host == "" {
-		return nil, errors.New("empty git host")
+		return nil, nil, errors.New("empty git host")
 	}
 	cacheScope = strings.TrimSpace(cacheScope)
 	if cacheScope == "" {
-		return nil, errors.New("empty git cache scope")
+		return nil, nil, errors.New("empty git cache scope")
 	}
 	cacheKey := host + "\x00" + cacheScope
 
 	c.gitMu.Lock()
-	defer c.gitMu.Unlock()
 
-	if handler, ok := c.gitHandlers[cacheKey]; ok {
-		return handler, nil
+	if entry, ok := c.gitHandlers[cacheKey]; ok {
+		entry.active++
+		c.touchGitHandlerLocked(cacheKey)
+		release := c.releaseGitHandler(entry)
+		c.gitMu.Unlock()
+		return entry.handler, release, nil
 	}
 
-	handler, err := c.buildGitHandler(host, cacheScope)
+	entryValue, err := c.buildGitHandler(host, cacheScope)
 	if err != nil {
-		return nil, err
+		c.gitMu.Unlock()
+		return nil, nil, err
 	}
-	c.gitHandlers[cacheKey] = handler
-	return handler, nil
+	if c.gitHandlers == nil {
+		c.gitHandlers = make(map[string]*gitHandlerEntry)
+	}
+	entry := &entryValue
+	entry.active = 1
+	c.gitHandlers[cacheKey] = entry
+	c.touchGitHandlerLocked(cacheKey)
+	evicted := c.evictGitHandlerLocked()
+	release := c.releaseGitHandler(entry)
+	c.gitMu.Unlock()
+	if evicted != nil {
+		_ = evicted.Close()
+	}
+	return entry.handler, release, nil
+}
+
+func (c *ContentCache) touchGitHandlerLocked(cacheKey string) {
+	for i, existing := range c.gitOrder {
+		if existing != cacheKey {
+			continue
+		}
+		copy(c.gitOrder[i:], c.gitOrder[i+1:])
+		c.gitOrder = c.gitOrder[:len(c.gitOrder)-1]
+		break
+	}
+	c.gitOrder = append(c.gitOrder, cacheKey)
+}
+
+func (c *ContentCache) evictGitHandlerLocked() io.Closer {
+	maxHandlers := c.maxGitHandlers
+	if maxHandlers <= 0 {
+		maxHandlers = defaultMaxGitHandlers
+	}
+	if len(c.gitOrder) <= maxHandlers {
+		return nil
+	}
+
+	evictedKey := c.gitOrder[0]
+	c.gitOrder = c.gitOrder[1:]
+	entry, ok := c.gitHandlers[evictedKey]
+	if !ok {
+		return nil
+	}
+	delete(c.gitHandlers, evictedKey)
+	if entry.active > 0 {
+		entry.evicted = true
+		return nil
+	}
+	return c.closeEvictedGitHandler(entry)
+}
+
+func (c *ContentCache) releaseGitHandler(entry *gitHandlerEntry) func() {
+	var once sync.Once
+	return func() {
+		var closer io.Closer
+		once.Do(func() {
+			c.gitMu.Lock()
+			if entry.active > 0 {
+				entry.active--
+			}
+			if entry.active == 0 && entry.evicted {
+				closer = c.closeEvictedGitHandler(entry)
+			}
+			c.gitMu.Unlock()
+		})
+		if closer != nil {
+			_ = closer.Close()
+		}
+	}
+}
+
+func (c *ContentCache) closeEvictedGitHandler(entry *gitHandlerEntry) io.Closer {
+	return closeFunc(func() {
+		c.gitMu.Lock()
+		handlerCloser := entry.closer
+		entry.closer = nil
+		c.gitMu.Unlock()
+		if handlerCloser != nil {
+			_ = handlerCloser.Close()
+		}
+	})
 }
 
 // HasOCIHandler reports whether OCI caching is configured.

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -22,7 +22,7 @@ const (
 	defaultMaxOCIHandlers           = 32
 )
 
-type gitHandlerFactory func(host string) (http.Handler, error)
+type gitHandlerFactory func(host, cacheScope string) (http.Handler, error)
 
 type ociHandlerFactory func(prefix string) (ociHandlerEntry, error)
 
@@ -170,8 +170,9 @@ func (c *ContentCache) HasGitHandler() bool {
 	return c != nil && c.buildGitHandler != nil
 }
 
-// GitHandlerForHost returns a git cache handler scoped to the requested host.
-func (c *ContentCache) GitHandlerForHost(host string) (http.Handler, error) {
+// GitHandlerForHost returns a git cache handler scoped to the requested host
+// and authorization scope.
+func (c *ContentCache) GitHandlerForHost(host, cacheScope string) (http.Handler, error) {
 	if c == nil || c.buildGitHandler == nil {
 		return nil, errors.New("git cache not configured")
 	}
@@ -180,19 +181,24 @@ func (c *ContentCache) GitHandlerForHost(host string) (http.Handler, error) {
 	if host == "" {
 		return nil, errors.New("empty git host")
 	}
+	cacheScope = strings.TrimSpace(cacheScope)
+	if cacheScope == "" {
+		return nil, errors.New("empty git cache scope")
+	}
+	cacheKey := host + "\x00" + cacheScope
 
 	c.gitMu.Lock()
 	defer c.gitMu.Unlock()
 
-	if handler, ok := c.gitHandlers[host]; ok {
+	if handler, ok := c.gitHandlers[cacheKey]; ok {
 		return handler, nil
 	}
 
-	handler, err := c.buildGitHandler(host)
+	handler, err := c.buildGitHandler(host, cacheScope)
 	if err != nil {
 		return nil, err
 	}
-	c.gitHandlers[host] = handler
+	c.gitHandlers[cacheKey] = handler
 	return handler, nil
 }
 

--- a/internal/gateway/contentcache_types_test.go
+++ b/internal/gateway/contentcache_types_test.go
@@ -24,7 +24,9 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
 
-type comparableHandler struct{}
+type comparableHandler struct {
+	id int
+}
 
 func (comparableHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}
 
@@ -129,6 +131,37 @@ func TestContentCacheGitBasicAuthProviderIgnoresNonBasicCredential(t *testing.T)
 	}
 	if username != "" || password != "" {
 		t.Fatalf("expected non-Basic credential to be ignored, got (%q, %q)", username, password)
+	}
+}
+
+func TestGitHandlerForHostPartitionsByCacheScope(t *testing.T) {
+	t.Parallel()
+
+	cache := &ContentCache{
+		gitHandlers: make(map[string]http.Handler),
+		buildGitHandler: func(host, cacheScope string) (http.Handler, error) {
+			return &comparableHandler{}, nil
+		},
+	}
+
+	handlerA, err := cache.GitHandlerForHost("GitHub.COM", "scope-a")
+	if err != nil {
+		t.Fatalf("handler A: %v", err)
+	}
+	reusedA, err := cache.GitHandlerForHost("github.com", "scope-a")
+	if err != nil {
+		t.Fatalf("reused handler A: %v", err)
+	}
+	handlerB, err := cache.GitHandlerForHost("github.com", "scope-b")
+	if err != nil {
+		t.Fatalf("handler B: %v", err)
+	}
+
+	if reusedA != handlerA {
+		t.Fatal("expected same host and cache scope to reuse git handler")
+	}
+	if handlerB == handlerA {
+		t.Fatal("expected different cache scopes to use different git handlers")
 	}
 }
 

--- a/internal/gateway/contentcache_types_test.go
+++ b/internal/gateway/contentcache_types_test.go
@@ -138,24 +138,27 @@ func TestGitHandlerForHostPartitionsByCacheScope(t *testing.T) {
 	t.Parallel()
 
 	cache := &ContentCache{
-		gitHandlers: make(map[string]http.Handler),
-		buildGitHandler: func(host, cacheScope string) (http.Handler, error) {
-			return &comparableHandler{}, nil
+		gitHandlers: make(map[string]*gitHandlerEntry),
+		buildGitHandler: func(host, cacheScope string) (gitHandlerEntry, error) {
+			return gitHandlerEntry{handler: &comparableHandler{}}, nil
 		},
 	}
 
-	handlerA, err := cache.GitHandlerForHost("GitHub.COM", "scope-a")
+	handlerA, releaseA, err := cache.GitHandlerForHost("GitHub.COM", "scope-a")
 	if err != nil {
 		t.Fatalf("handler A: %v", err)
 	}
-	reusedA, err := cache.GitHandlerForHost("github.com", "scope-a")
+	defer releaseA()
+	reusedA, releaseReusedA, err := cache.GitHandlerForHost("github.com", "scope-a")
 	if err != nil {
 		t.Fatalf("reused handler A: %v", err)
 	}
-	handlerB, err := cache.GitHandlerForHost("github.com", "scope-b")
+	defer releaseReusedA()
+	handlerB, releaseB, err := cache.GitHandlerForHost("github.com", "scope-b")
 	if err != nil {
 		t.Fatalf("handler B: %v", err)
 	}
+	defer releaseB()
 
 	if reusedA != handlerA {
 		t.Fatal("expected same host and cache scope to reuse git handler")
@@ -163,6 +166,67 @@ func TestGitHandlerForHostPartitionsByCacheScope(t *testing.T) {
 	if handlerB == handlerA {
 		t.Fatal("expected different cache scopes to use different git handlers")
 	}
+}
+
+func TestGitHandlerForHostEvictsLeastRecentlyUsedHandler(t *testing.T) {
+	t.Parallel()
+
+	var closed []string
+	cache := &ContentCache{
+		gitHandlers:    make(map[string]*gitHandlerEntry),
+		maxGitHandlers: 2,
+		buildGitHandler: func(host, cacheScope string) (gitHandlerEntry, error) {
+			scope := cacheScope
+			return gitHandlerEntry{
+				handler: &comparableHandler{},
+				closer: closeFunc(func() {
+					closed = append(closed, scope)
+				}),
+			}, nil
+		},
+	}
+
+	handlerA, releaseA, err := cache.GitHandlerForHost("github.com", "scope-a")
+	if err != nil {
+		t.Fatalf("handler A: %v", err)
+	}
+	_, releaseB, err := cache.GitHandlerForHost("github.com", "scope-b")
+	if err != nil {
+		t.Fatalf("handler B: %v", err)
+	}
+	reusedA, releaseReusedA, err := cache.GitHandlerForHost("github.com", "scope-a")
+	if err != nil {
+		t.Fatalf("reused handler A: %v", err)
+	}
+	if reusedA != handlerA {
+		t.Fatal("expected scope-a handler to be reused before eviction")
+	}
+	_, releaseC, err := cache.GitHandlerForHost("github.com", "scope-c")
+	if err != nil {
+		t.Fatalf("handler C: %v", err)
+	}
+
+	if got, want := len(cache.gitHandlers), 2; got != want {
+		t.Fatalf("expected %d cached handlers, got %d", want, got)
+	}
+	if _, ok := cache.gitHandlers["github.com\x00scope-a"]; !ok {
+		t.Fatal("expected scope-a to remain cached after recent reuse")
+	}
+	if _, ok := cache.gitHandlers["github.com\x00scope-c"]; !ok {
+		t.Fatal("expected scope-c to be cached")
+	}
+	if len(closed) != 0 {
+		t.Fatalf("expected active evicted handler not to close yet, got %v", closed)
+	}
+
+	releaseB()
+	if len(closed) != 1 || closed[0] != "scope-b" {
+		t.Fatalf("expected scope-b to close after release, got %v", closed)
+	}
+
+	releaseA()
+	releaseReusedA()
+	releaseC()
 }
 
 func TestGitContentCacheUpstreamFailsBeforeHTTPWhenCredentialsFail(t *testing.T) {

--- a/internal/gateway/git_cached.go
+++ b/internal/gateway/git_cached.go
@@ -2,9 +2,12 @@ package gateway
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"charm.land/log/v2"
@@ -12,7 +15,7 @@ import (
 )
 
 type gitHostHandlerProvider interface {
-	GitHandlerForHost(host string) (http.Handler, error)
+	GitHandlerForHost(host, cacheScope string) (http.Handler, error)
 }
 
 // cachedGitHandler wraps a content-cache git handler with cleanroom's
@@ -24,10 +27,11 @@ type cachedGitHandler struct {
 	fallback     http.Handler
 	logger       *log.Logger
 	requireOwner bool
+	credentials  CredentialProvider
 }
 
-func newCachedGitHandler(cache gitHostHandlerProvider, fallback http.Handler, logger *log.Logger, requireOwner bool) *cachedGitHandler {
-	return &cachedGitHandler{cache: cache, fallback: fallback, logger: logger, requireOwner: requireOwner}
+func newCachedGitHandler(cache gitHostHandlerProvider, fallback http.Handler, logger *log.Logger, requireOwner bool, credentials CredentialProvider) *cachedGitHandler {
+	return &cachedGitHandler{cache: cache, fallback: fallback, logger: logger, requireOwner: requireOwner, credentials: credentials}
 }
 
 func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -51,13 +55,7 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !gitRequestUsesDotGit(repoPath) {
-		if h.fallback == nil {
-			setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
-			writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, "git cache fallback is not configured for non-.git remotes")
-			return
-		}
-		setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonFallback)
-		h.fallback.ServeHTTP(w, r)
+		h.serveFallback(w, r, scope, upstreamHost, repoPath, "git cache fallback is not configured for non-.git remotes")
 		return
 	}
 
@@ -69,25 +67,30 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Classify the request to reject pushes before hitting the cache layer.
-	if _, err := classifyGitRequest(r.Method, repoPath, r.URL.RawQuery); err != nil {
+	requestType, err := classifyGitRequest(r.Method, repoPath, r.URL.RawQuery)
+	if err != nil {
 		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonMethodNotAllowed)
 		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonMethodNotAllowed)
 		writeReasonError(w, http.StatusForbidden, reasonMethodNotAllowed, err.Error())
 		return
 	}
 
-	cacheHandler, err := h.cache.GitHandlerForHost(upstreamHost)
+	cacheScope, cacheable, err := h.cacheScopeKey(r.Context(), scope, upstreamHost, repoPath, requestType)
+	if err != nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
+		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
+		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, fmt.Sprintf("git cache authorization unavailable for %s%s: %v", upstreamHost, repoPath, err))
+		return
+	}
+	if !cacheable {
+		h.serveFallback(w, r, scope, upstreamHost, repoPath, "git cache fallback is not configured for upload-pack requests without Basic upstream credentials")
+		return
+	}
+
+	cacheHandler, err := h.cache.GitHandlerForHost(upstreamHost, cacheScope)
 	if err != nil {
 		if errors.Is(err, errGitHostNotConfiguredForCaching) {
-			if h.fallback == nil {
-				setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
-				h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
-				writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, fmt.Sprintf("git cache fallback is not configured for %s", upstreamHost))
-				return
-			}
-			setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonFallback)
-			h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonFallback)
-			h.fallback.ServeHTTP(w, r)
+			h.serveFallback(w, r, scope, upstreamHost, repoPath, fmt.Sprintf("git cache fallback is not configured for %s", upstreamHost))
 			return
 		}
 		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
@@ -104,6 +107,73 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/git")
 	r.URL.RawPath = ""
 	cacheHandler.ServeHTTP(w, r)
+}
+
+func (h *cachedGitHandler) serveFallback(w http.ResponseWriter, r *http.Request, scope *SandboxScope, upstreamHost, repoPath, unavailableMessage string) {
+	if h.fallback == nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
+		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
+		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, unavailableMessage)
+		return
+	}
+	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonFallback)
+	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonFallback)
+	h.fallback.ServeHTTP(w, r)
+}
+
+func (h *cachedGitHandler) cacheScopeKey(ctx context.Context, scope *SandboxScope, upstreamHost, repoPath, requestType string) (string, bool, error) {
+	credentialScope := "credential:anonymous"
+	if h.credentials != nil {
+		remoteURL, err := canonicalUpstreamRemoteURL(upstreamHost, repoPath)
+		if err != nil {
+			return "", false, err
+		}
+		header, err := h.credentials.Resolve(ctx, remoteURL)
+		if err != nil {
+			return "", false, fmt.Errorf("resolve upstream credentials: %w", err)
+		}
+		header = strings.TrimSpace(header)
+		if header != "" {
+			_, _, basic, err := parseBasicAuthHeader(header)
+			if err != nil {
+				return "", false, err
+			}
+			if requestType == "upload-pack" && !basic {
+				return "", false, nil
+			}
+			credentialScope = "credential:" + digestString(header)
+		}
+	}
+
+	policyScope := "policy:nil"
+	if scope != nil && scope.Policy != nil {
+		policyScope = "policy:" + compiledPolicyCacheKey(scope.Policy)
+	}
+
+	ownerScope := "ownerless"
+	if scope != nil && scope.GatewayScope.HasOwner() {
+		prefixes := append([]string(nil), scope.GatewayScope.Authorization.GitRepoPrefixes...)
+		sort.Strings(prefixes)
+		ownerScope = strings.Join([]string{
+			"owner",
+			scope.GatewayScope.Owner.PrincipalID,
+			scope.GatewayScope.Owner.Scope,
+			strings.Join(prefixes, "\x00"),
+		}, "\x00")
+	}
+
+	return digestString(strings.Join([]string{
+		"git-cache-v2",
+		strings.ToLower(strings.TrimSpace(upstreamHost)),
+		policyScope,
+		ownerScope,
+		credentialScope,
+	}, "\x00")), true, nil
+}
+
+func digestString(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
 }
 
 func (h *cachedGitHandler) auditLog(ctx context.Context, sandboxID, upstreamHost, repoPath, action, reason string) {

--- a/internal/gateway/git_cached.go
+++ b/internal/gateway/git_cached.go
@@ -15,7 +15,7 @@ import (
 )
 
 type gitHostHandlerProvider interface {
-	GitHandlerForHost(host, cacheScope string) (http.Handler, error)
+	GitHandlerForHost(host, cacheScope string) (http.Handler, func(), error)
 }
 
 // cachedGitHandler wraps a content-cache git handler with cleanroom's
@@ -25,13 +25,18 @@ type gitHostHandlerProvider interface {
 type cachedGitHandler struct {
 	cache        gitHostHandlerProvider
 	fallback     http.Handler
+	direct       http.Handler
 	logger       *log.Logger
 	requireOwner bool
 	credentials  CredentialProvider
 }
 
 func newCachedGitHandler(cache gitHostHandlerProvider, fallback http.Handler, logger *log.Logger, requireOwner bool, credentials CredentialProvider) *cachedGitHandler {
-	return &cachedGitHandler{cache: cache, fallback: fallback, logger: logger, requireOwner: requireOwner, credentials: credentials}
+	return newCachedGitHandlerWithDirectFallback(cache, fallback, fallback, logger, requireOwner, credentials)
+}
+
+func newCachedGitHandlerWithDirectFallback(cache gitHostHandlerProvider, fallback, direct http.Handler, logger *log.Logger, requireOwner bool, credentials CredentialProvider) *cachedGitHandler {
+	return &cachedGitHandler{cache: cache, fallback: fallback, direct: direct, logger: logger, requireOwner: requireOwner, credentials: credentials}
 }
 
 func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -83,11 +88,11 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !cacheable {
-		h.serveFallback(w, r, scope, upstreamHost, repoPath, "git cache fallback is not configured for upload-pack requests without Basic upstream credentials")
+		h.serveDirect(w, r, scope, upstreamHost, repoPath, "direct git fallback is not configured for upload-pack requests without Basic upstream credentials")
 		return
 	}
 
-	cacheHandler, err := h.cache.GitHandlerForHost(upstreamHost, cacheScope)
+	cacheHandler, release, err := h.cache.GitHandlerForHost(upstreamHost, cacheScope)
 	if err != nil {
 		if errors.Is(err, errGitHostNotConfiguredForCaching) {
 			h.serveFallback(w, r, scope, upstreamHost, repoPath, fmt.Sprintf("git cache fallback is not configured for %s", upstreamHost))
@@ -97,6 +102,9 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
 		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, fmt.Sprintf("git cache handler unavailable for %s: %v", upstreamHost, err))
 		return
+	}
+	if release != nil {
+		defer release()
 	}
 	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonCached)
 	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonCached)
@@ -119,6 +127,18 @@ func (h *cachedGitHandler) serveFallback(w http.ResponseWriter, r *http.Request,
 	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonFallback)
 	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonFallback)
 	h.fallback.ServeHTTP(w, r)
+}
+
+func (h *cachedGitHandler) serveDirect(w http.ResponseWriter, r *http.Request, scope *SandboxScope, upstreamHost, repoPath, unavailableMessage string) {
+	if h.direct == nil {
+		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUpstreamError)
+		h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
+		writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, unavailableMessage)
+		return
+	}
+	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonProxied)
+	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonProxied)
+	h.direct.ServeHTTP(w, r)
 }
 
 func (h *cachedGitHandler) cacheScopeKey(ctx context.Context, scope *SandboxScope, upstreamHost, repoPath, requestType string) (string, bool, error) {

--- a/internal/gateway/git_cached_test.go
+++ b/internal/gateway/git_cached_test.go
@@ -32,13 +32,13 @@ func cachedGitOwnedScope(repoPrefixes ...string) *SandboxScope {
 	return scope
 }
 
-func (s *stubGitHostHandlerProvider) GitHandlerForHost(host, cacheScope string) (http.Handler, error) {
+func (s *stubGitHostHandlerProvider) GitHandlerForHost(host, cacheScope string) (http.Handler, func(), error) {
 	s.host = host
 	s.scope = cacheScope
 	if s.err != nil {
-		return nil, s.err
+		return nil, nil, s.err
 	}
-	return s.handler, nil
+	return s.handler, func() {}, nil
 }
 
 func cachedGitTestScope() *SandboxScope {
@@ -315,14 +315,17 @@ func TestCachedGitHandlerScopesCacheByCredentialAndOwnerAuthorization(t *testing
 	}
 }
 
-func TestCachedGitHandlerFallsBackForUploadPackWithNonBasicCredential(t *testing.T) {
+func TestCachedGitHandlerUsesDirectProxyForUploadPackWithNonBasicCredential(t *testing.T) {
 	t.Parallel()
 
-	var fallbackCalled bool
-	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fallbackCalled = true
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("mirror-backed fallback should not be used for non-Basic upload-pack credentials")
+	})
+	var directCalled bool
+	direct := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		directCalled = true
 		if want := "/git/github.com/org/repo.git/git-upload-pack"; r.URL.Path != want {
-			t.Fatalf("expected fallback path %q, got %q", want, r.URL.Path)
+			t.Fatalf("expected direct path %q, got %q", want, r.URL.Path)
 		}
 		w.WriteHeader(http.StatusOK)
 	})
@@ -331,7 +334,7 @@ func TestCachedGitHandlerFallsBackForUploadPackWithNonBasicCredential(t *testing
 			t.Fatal("cache handler should not be used for non-Basic upload-pack credentials")
 		}),
 	}
-	h := newCachedGitHandler(provider, fallback, nil, false, &staticCredentialProvider{headers: map[string]string{
+	h := newCachedGitHandlerWithDirectFallback(provider, fallback, direct, nil, false, &staticCredentialProvider{headers: map[string]string{
 		"https://github.com/org/repo.git": "Bearer host-token",
 	}})
 
@@ -344,13 +347,13 @@ func TestCachedGitHandlerFallsBackForUploadPackWithNonBasicCredential(t *testing
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	if !fallbackCalled {
-		t.Fatal("expected fallback to be called")
+	if !directCalled {
+		t.Fatal("expected direct proxy to be called")
 	}
 	if provider.host != "" {
 		t.Fatalf("expected cache lookup to be skipped, got host %q", provider.host)
 	}
-	requireGatewayRequestDecision(t, obs, gatewayActionAllow, reasonFallback)
+	requireGatewayRequestDecision(t, obs, gatewayActionAllow, reasonProxied)
 }
 
 func TestCachedGitHandlerFallsBackForUnconfiguredCacheHost(t *testing.T) {

--- a/internal/gateway/git_cached_test.go
+++ b/internal/gateway/git_cached_test.go
@@ -15,6 +15,7 @@ type stubGitHostHandlerProvider struct {
 	handler http.Handler
 	err     error
 	host    string
+	scope   string
 }
 
 func cachedGitOwnedScope(repoPrefixes ...string) *SandboxScope {
@@ -31,8 +32,9 @@ func cachedGitOwnedScope(repoPrefixes ...string) *SandboxScope {
 	return scope
 }
 
-func (s *stubGitHostHandlerProvider) GitHandlerForHost(host string) (http.Handler, error) {
+func (s *stubGitHostHandlerProvider) GitHandlerForHost(host, cacheScope string) (http.Handler, error) {
 	s.host = host
+	s.scope = cacheScope
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -79,7 +81,7 @@ func TestCachedGitHandlerPolicyDeniesUnallowedHost(t *testing.T) {
 	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("backend should not be called for denied host")
 	})
-	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, false)
+	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, false, nil)
 
 	req := httptest.NewRequest("GET", "/git/evil.com/org/repo.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())
@@ -102,7 +104,7 @@ func TestCachedGitHandlerRejectsReceivePack(t *testing.T) {
 	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("backend should not be called for receive-pack")
 	})
-	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, false)
+	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, false, nil)
 
 	req := httptest.NewRequest("POST", "/git/github.com/org/repo.git/git-receive-pack", nil)
 	req = withScope(req, cachedGitTestScope())
@@ -122,7 +124,7 @@ func TestCachedGitHandlerNoScope(t *testing.T) {
 	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("backend should not be called without scope")
 	})
-	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, false)
+	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, false, nil)
 
 	req := httptest.NewRequest("GET", "/git/github.com/org/repo.git/info/refs?service=git-upload-pack", nil)
 	w := httptest.NewRecorder()
@@ -139,7 +141,7 @@ func TestCachedGitHandlerRequiresOwnerWhenConfigured(t *testing.T) {
 	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("backend should not be called without owner")
 	})
-	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, true)
+	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, true, nil)
 
 	req := httptest.NewRequest("GET", "/git/github.com/org/repo.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())
@@ -164,7 +166,7 @@ func TestCachedGitHandlerDeniesRepoOutsideGatewayEnvelope(t *testing.T) {
 			t.Fatal("backend should not be called for unauthorized repo")
 		}),
 	}
-	h := newCachedGitHandler(provider, nil, nil, true)
+	h := newCachedGitHandler(provider, nil, nil, true, nil)
 
 	req := httptest.NewRequest("GET", "/git/github.com/buildkite/private.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, cachedGitOwnedScope("github.com/buildkite/cleanroom"))
@@ -189,7 +191,7 @@ func TestCachedGitHandlerAllowsRepoInGatewayEnvelope(t *testing.T) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	})
-	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, true)
+	h := newCachedGitHandler(&stubGitHostHandlerProvider{handler: backend}, nil, nil, true, nil)
 
 	req := httptest.NewRequest("GET", "/git/github.com/buildkite/cleanroom.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, cachedGitOwnedScope("github.com/buildkite/cleanroom"))
@@ -213,7 +215,7 @@ func TestCachedGitHandlerStripsGitPrefixAndDelegates(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	provider := &stubGitHostHandlerProvider{handler: backend}
-	h := newCachedGitHandler(provider, nil, nil, false)
+	h := newCachedGitHandler(provider, nil, nil, false, nil)
 
 	req := httptest.NewRequest("GET", "/git/github.com/org/repo.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())
@@ -243,7 +245,7 @@ func TestCachedGitHandlerUploadPackDelegates(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	provider := &stubGitHostHandlerProvider{handler: backend}
-	h := newCachedGitHandler(provider, nil, nil, false)
+	h := newCachedGitHandler(provider, nil, nil, false, nil)
 
 	req := httptest.NewRequest("POST", "/git/github.com/org/repo.git/git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())
@@ -266,6 +268,91 @@ func TestCachedGitHandlerUploadPackDelegates(t *testing.T) {
 	requireGatewayRequestDecision(t, obs, gatewayActionAllow, reasonCached)
 }
 
+func TestCachedGitHandlerScopesCacheByCredentialAndOwnerAuthorization(t *testing.T) {
+	t.Parallel()
+
+	h := newCachedGitHandler(nil, nil, nil, true, &staticCredentialProvider{headers: map[string]string{
+		"https://github.com/buildkite/cleanroom.git": "Basic dXNlcjpwYXNz",
+	}})
+	scopeA := cachedGitOwnedScope("github.com/buildkite/cleanroom")
+	scopeA.Policy.Hash = "policy-a"
+	keyA, cacheable, err := h.cacheScopeKey(context.Background(), scopeA, "github.com", "/buildkite/cleanroom.git/git-upload-pack", "upload-pack")
+	if err != nil {
+		t.Fatalf("cache scope A: %v", err)
+	}
+	if !cacheable {
+		t.Fatal("expected Basic credential to be cacheable")
+	}
+
+	h.credentials = &staticCredentialProvider{headers: map[string]string{
+		"https://github.com/buildkite/cleanroom.git": "Basic b3RoZXI6cGFzcw==",
+	}}
+	keyB, cacheable, err := h.cacheScopeKey(context.Background(), scopeA, "github.com", "/buildkite/cleanroom.git/git-upload-pack", "upload-pack")
+	if err != nil {
+		t.Fatalf("cache scope B: %v", err)
+	}
+	if !cacheable {
+		t.Fatal("expected second Basic credential to be cacheable")
+	}
+	if keyA == keyB {
+		t.Fatal("expected different credentials to use different git cache scopes")
+	}
+
+	h.credentials = &staticCredentialProvider{headers: map[string]string{
+		"https://github.com/buildkite/cleanroom.git": "Basic dXNlcjpwYXNz",
+	}}
+	scopeB := cachedGitOwnedScope("github.com/buildkite/")
+	scopeB.Policy.Hash = "policy-a"
+	keyC, cacheable, err := h.cacheScopeKey(context.Background(), scopeB, "github.com", "/buildkite/cleanroom.git/git-upload-pack", "upload-pack")
+	if err != nil {
+		t.Fatalf("cache scope C: %v", err)
+	}
+	if !cacheable {
+		t.Fatal("expected owner-authorized Basic credential to be cacheable")
+	}
+	if keyA == keyC {
+		t.Fatal("expected different owner authorization envelopes to use different git cache scopes")
+	}
+}
+
+func TestCachedGitHandlerFallsBackForUploadPackWithNonBasicCredential(t *testing.T) {
+	t.Parallel()
+
+	var fallbackCalled bool
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCalled = true
+		if want := "/git/github.com/org/repo.git/git-upload-pack"; r.URL.Path != want {
+			t.Fatalf("expected fallback path %q, got %q", want, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	provider := &stubGitHostHandlerProvider{
+		handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			t.Fatal("cache handler should not be used for non-Basic upload-pack credentials")
+		}),
+	}
+	h := newCachedGitHandler(provider, fallback, nil, false, &staticCredentialProvider{headers: map[string]string{
+		"https://github.com/org/repo.git": "Bearer host-token",
+	}})
+
+	req := httptest.NewRequest("POST", "/git/github.com/org/repo.git/git-upload-pack", nil)
+	req = withScope(req, cachedGitTestScope())
+	req, obs := withGatewayRequestObservability(req)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !fallbackCalled {
+		t.Fatal("expected fallback to be called")
+	}
+	if provider.host != "" {
+		t.Fatalf("expected cache lookup to be skipped, got host %q", provider.host)
+	}
+	requireGatewayRequestDecision(t, obs, gatewayActionAllow, reasonFallback)
+}
+
 func TestCachedGitHandlerFallsBackForUnconfiguredCacheHost(t *testing.T) {
 	t.Parallel()
 
@@ -278,7 +365,7 @@ func TestCachedGitHandlerFallsBackForUnconfiguredCacheHost(t *testing.T) {
 	provider := &stubGitHostHandlerProvider{
 		err: fmt.Errorf("%w: github.enterprise.test", errGitHostNotConfiguredForCaching),
 	}
-	h := newCachedGitHandler(provider, fallback, nil, false)
+	h := newCachedGitHandler(provider, fallback, nil, false, nil)
 
 	req := httptest.NewRequest("GET", "/git/github.enterprise.test/org/repo.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, &SandboxScope{
@@ -325,7 +412,7 @@ func TestCachedGitHandlerFallsBackForNonDotGitRemotes(t *testing.T) {
 			t.Fatal("cache handler should not be used for non-.git remotes")
 		}),
 	}
-	h := newCachedGitHandler(provider, fallback, nil, false)
+	h := newCachedGitHandler(provider, fallback, nil, false, nil)
 
 	req := httptest.NewRequest("GET", "/git/github.com/org/repo/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, cachedGitTestScope())

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -220,7 +220,7 @@ func NewServer(cfg ServerConfig) *Server {
 	// Git: prefer content-cache, fall back to mirror-backed proxy.
 	fallbackGit := newGitHandlerWithMirrors(cfg.Credentials, cfg.GitMirrors, cfg.Logger, cfg.RequireOwner)
 	if cfg.ContentCache != nil && cfg.ContentCache.HasGitHandler() {
-		mux.Handle(RouteGit, newCachedGitHandler(cfg.ContentCache, fallbackGit, cfg.Logger, cfg.RequireOwner))
+		mux.Handle(RouteGit, newCachedGitHandler(cfg.ContentCache, fallbackGit, cfg.Logger, cfg.RequireOwner, cfg.Credentials))
 	} else {
 		mux.Handle(RouteGit, fallbackGit)
 	}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -217,10 +217,12 @@ func NewServer(cfg ServerConfig) *Server {
 
 	mux := http.NewServeMux()
 
-	// Git: prefer content-cache, fall back to mirror-backed proxy.
+	// Git: prefer content-cache, fall back to mirror-backed proxy. Upload-pack
+	// requests that cannot safely use the pack cache use a direct proxy.
 	fallbackGit := newGitHandlerWithMirrors(cfg.Credentials, cfg.GitMirrors, cfg.Logger, cfg.RequireOwner)
 	if cfg.ContentCache != nil && cfg.ContentCache.HasGitHandler() {
-		mux.Handle(RouteGit, newCachedGitHandler(cfg.ContentCache, fallbackGit, cfg.Logger, cfg.RequireOwner, cfg.Credentials))
+		directGit := newGitHandlerWithMirrors(cfg.Credentials, nil, cfg.Logger, cfg.RequireOwner)
+		mux.Handle(RouteGit, newCachedGitHandlerWithDirectFallback(cfg.ContentCache, fallbackGit, directGit, cfg.Logger, cfg.RequireOwner, cfg.Credentials))
 	} else {
 		mux.Handle(RouteGit, fallbackGit)
 	}


### PR DESCRIPTION
Git upload-pack responses are cached by content-cache using the repository, Git protocol, and request body hash. That left a gap after the remote-control-plane fixes: an ownerless or differently credentialed sandbox could reach a cached pack entry filled under another authorization context.

This changes the embedded Git cache wrapper to derive a cache scope from the effective policy, owner authorization envelope, and resolved upstream credential, then passes that scope into content-cache so Git pack metadata is partitioned. Non-Basic upload-pack credentials now use a direct Git proxy instead of the embedded pack cache or mirror-backed fallback, because content-cache can only re-check Basic credentials on cache hits and repository mirrors are keyed by remote URL.

The scoped Git handler cache now uses a bounded lease-and-LRU path like the other dynamic gateway handlers. DeepSec revalidated both remaining Git findings as fixed, and `deepsec status` reports 27/27 findings fixed with 0 true positives.