### PR TITLE
ci: Add Buildkite OIDC auth smoke

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ steps:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
           install_args: shellcheck
-    command: shellcheck -x .buildkite/hooks/pre-command scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-with-host-lock.sh scripts/ci-go-test-engine.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/ci-buildkite-release.sh
+    command: shellcheck -x .buildkite/hooks/pre-command scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-with-host-lock.sh scripts/ci-go-test-engine.sh scripts/ci-auth-oidc-smoke.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/ci-buildkite-release.sh
     cache:
       paths:
         - "~/.local/share/mise"
@@ -40,6 +40,13 @@ steps:
         - "~/.cache/cleanroom/test-engine"
       size: "20g"
       name: "mise-cache"
+    agents:
+      queue: hosted
+
+  - label: ":closed_lock_with_key: Auth OIDC smoke"
+    plugins:
+      - github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91:
+    command: scripts/ci-auth-oidc-smoke.sh
     agents:
       queue: hosted
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,6 +6,7 @@ The public repo owns the pipeline definition and the product-facing CI scripts:
 
 - `.buildkite/pipeline.yml`
 - `scripts/ci-with-host-lock.sh`
+- `scripts/ci-auth-oidc-smoke.sh`
 - `scripts/ci-cleanroom-e2e.sh`
 - `scripts/ci-darwin-vz-e2e.sh`
 - `scripts/ci-darwin-vz-filehandle-e2e.sh`
@@ -23,6 +24,15 @@ default; set `CLEANROOM_BUILDKITE_LOCK_WAIT_TIMEOUT` or
 `BUILDKITE_LOCK_WAIT_TIMEOUT` to override that duration.
 CI agent configuration is responsible for giving concurrent jobs distinct
 checkout directories before the command wrapper starts.
+
+The auth OIDC smoke runs on hosted agents and requests a short-lived token from
+the Buildkite agent issuer. By default it derives the expected organization and
+pipeline IDs from the minted token, then validates the same token through
+`cleanroom auth check` using the live Buildkite JWKS. It also checks
+owner-scoped `sandbox.get` allow/deny decisions with supplied owner metadata.
+Set
+`CLEANROOM_AUTH_OIDC_ORGANIZATION_ID` or `CLEANROOM_AUTH_OIDC_PIPELINE_ID` if
+the pipeline should fail when those immutable IDs drift.
 
 Cleanroom no longer builds managed `darwin-vz` kernels during its release
 pipeline. The experimental Apple Silicon `darwin-vz` minimal rootfs-profile

--- a/docs/plans/multi-principal-control-server.md
+++ b/docs/plans/multi-principal-control-server.md
@@ -1,7 +1,7 @@
 # Multi-Principal Control Server Authorization Plan
 
 **Spec reference:** `docs/spec.md` sections 5.4, 6.1, and 6.2; `docs/api.md`; `docs/tls.md`
-**Status:** Buildkite OIDC operator path documented; controlled sharing follow-ups next
+**Status:** Buildkite OIDC CI smoke implemented; controlled sharing follow-ups next
 **Last reviewed:** 2026-05-30
 
 ## Summary
@@ -74,6 +74,10 @@ Slice 2 is split into PR-sized enforcement work:
   trust `https://agent.buildkite.com`, require immutable Buildkite organization
   and pipeline IDs, and treat slugs or branches as optional grant constraints
   rather than ownership identity.
+- Buildkite CI now has an OIDC auth smoke that requests a real Buildkite agent
+  token, validates it with the live Buildkite JWKS, and checks allow/deny
+  decisions for sandbox creation and owner-scoped existing-resource diagnostics
+  using `cleanroom auth check`.
 
 Focused validation run on 2026-05-25:
 
@@ -168,6 +172,15 @@ Result: passed.
 Runtime exact-principal repository validation run on 2026-05-29:
 
 ```text
+mise run check
+```
+
+Result: passed.
+
+Buildkite OIDC CI smoke validation run on 2026-05-30:
+
+```text
+mise exec -- go test ./scripts -count=1
 mise run check
 ```
 

--- a/mise.toml
+++ b/mise.toml
@@ -15,7 +15,7 @@ run = "go test ./..."
 
 [tasks.lint-shell]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/hooks/pre-command scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-with-host-lock.sh scripts/ci-go-test-engine.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/ci-buildkite-release.sh"
+run = "shellcheck -x .buildkite/hooks/pre-command scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-with-host-lock.sh scripts/ci-go-test-engine.sh scripts/ci-auth-oidc-smoke.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/ci-buildkite-release.sh"
 
 [tasks.test-full]
 description = "Run full Go test suite"

--- a/scripts/buildkite_pipeline_test.go
+++ b/scripts/buildkite_pipeline_test.go
@@ -47,6 +47,10 @@ func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
     plugins:
       - ` + setupGoBuildkitePluginRef + `:
     command: go test ./...`,
+		`- label: ":closed_lock_with_key: Auth OIDC smoke"
+    plugins:
+      - ` + setupGoBuildkitePluginRef + `:
+    command: scripts/ci-auth-oidc-smoke.sh`,
 		`- label: ":apple: E2E (darwin-vz)"
     plugins:
       - ` + setupGoBuildkitePluginRef + `:
@@ -94,6 +98,9 @@ func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
 	if !strings.Contains(pipeline, "command: scripts/ci-buildkite-release.sh") {
 		t.Fatalf("expected .buildkite/pipeline.yml to include the Buildkite release publish step")
 	}
+	if !strings.Contains(pipeline, "command: scripts/ci-auth-oidc-smoke.sh") {
+		t.Fatalf("expected .buildkite/pipeline.yml to include the Buildkite OIDC auth smoke step")
+	}
 	for _, needle := range []string{
 		".buildkite/hooks/pre-command",
 		"scripts/base-image-tag.sh",
@@ -101,6 +108,7 @@ func TestBuildkitePipelineUsesSetupGoForGoSteps(t *testing.T) {
 		"scripts/e2e-observability.sh",
 		"scripts/ci-with-host-lock.sh",
 		"scripts/ci-go-test-engine.sh",
+		"scripts/ci-auth-oidc-smoke.sh",
 		"scripts/ci-example-smoke.sh",
 		"scripts/ci-examples-firecracker.sh",
 		"scripts/ci-examples-darwin-vz.sh",
@@ -202,6 +210,51 @@ func TestBuildkitePreCommandHookMintsTestEngineOIDCToken(t *testing.T) {
 	} {
 		if !strings.Contains(hook, needle) {
 			t.Fatalf("expected .buildkite/hooks/pre-command to contain %q", needle)
+		}
+	}
+}
+
+func TestBuildkiteAuthOIDCSmokeUsesRealBuildkiteToken(t *testing.T) {
+	t.Parallel()
+
+	info, err := os.Stat("ci-auth-oidc-smoke.sh")
+	if err != nil {
+		t.Fatalf("stat ci-auth-oidc-smoke.sh: %v", err)
+	}
+	if info.Mode()&0111 == 0 {
+		t.Fatalf("expected ci-auth-oidc-smoke.sh to be executable")
+	}
+
+	content, err := os.ReadFile("ci-auth-oidc-smoke.sh")
+	if err != nil {
+		t.Fatalf("read ci-auth-oidc-smoke.sh: %v", err)
+	}
+
+	script := string(content)
+	for _, needle := range []string{
+		`buildkite-agent oidc request-token`,
+		`--subject-claim pipeline_id`,
+		`--claim organization_id,pipeline_id`,
+		`https://agent.buildkite.com/.well-known/jwks`,
+		`required_claims:`,
+		`resource.owner.principal_id == principal.id`,
+		`resource.owner.scope == principal.scope`,
+		`expect_auth_check "allowed sandbox create" true`,
+		`expect_auth_check "denied sandbox create for another repository" false`,
+		`expect_auth_check "allowed same-owner sandbox get" true`,
+		`expect_auth_check "denied cross-principal sandbox get" false`,
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("expected ci-auth-oidc-smoke.sh to contain %q", needle)
+		}
+	}
+	for _, needle := range []string{
+		`cat "$token_path"`,
+		`echo "$token`,
+		`set -x`,
+	} {
+		if strings.Contains(script, needle) {
+			t.Fatalf("expected ci-auth-oidc-smoke.sh not to expose the token through %q", needle)
 		}
 	}
 }
@@ -335,6 +388,7 @@ func TestBuildkiteCIScriptsDoNotInvokeMiseDirectly(t *testing.T) {
 		"ci-cleanroom-e2e.sh",
 		"ci-with-host-lock.sh",
 		"ci-go-test-engine.sh",
+		"ci-auth-oidc-smoke.sh",
 		"ci-example-smoke.sh",
 		"ci-examples-firecracker.sh",
 		"ci-examples-darwin-vz.sh",
@@ -398,6 +452,7 @@ func TestMiseLintShellCoversSharedE2EObservabilityHelper(t *testing.T) {
 		`scripts/e2e-observability.sh`,
 		`scripts/ci-with-host-lock.sh`,
 		`scripts/ci-go-test-engine.sh`,
+		`scripts/ci-auth-oidc-smoke.sh`,
 		`scripts/ci-example-smoke.sh`,
 		`scripts/ci-examples-firecracker.sh`,
 		`scripts/ci-examples-darwin-vz.sh`,

--- a/scripts/ci-auth-oidc-smoke.sh
+++ b/scripts/ci-auth-oidc-smoke.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+die() {
+  echo "ci-auth-oidc-smoke: $*" >&2
+  exit 1
+}
+
+require_command() {
+  local name="$1"
+  command -v "$name" >/dev/null 2>&1 || die "$name is required"
+}
+
+jwt_claim() {
+  local claim="$1"
+  python3 - "$claims_path" "$claim" <<'PY'
+import json
+import sys
+
+claims_path, claim = sys.argv[1], sys.argv[2]
+with open(claims_path, encoding="utf-8") as fh:
+    claims = json.load(fh)
+
+value = claims.get(claim)
+if value is None or value == "":
+    raise SystemExit(f"missing {claim} claim")
+if not isinstance(value, str):
+    raise SystemExit(f"{claim} claim must be a string")
+
+print(value)
+PY
+}
+
+assert_safe_identifier() {
+  local name="$1"
+  local value="$2"
+
+  [[ "$value" =~ ^[A-Za-z0-9._:-]+$ ]] || die "$name contains unexpected characters"
+}
+
+assert_safe_audience() {
+  local value="$1"
+
+  [[ "$value" =~ ^[A-Za-z0-9._:/-]+$ ]] || die "audience contains unexpected characters"
+}
+
+expect_auth_check() {
+  local label="$1"
+  local expected_allowed="$2"
+  shift 2
+
+  decision_index=$((decision_index + 1))
+  local output_path="$tmpdir/decision-${decision_index}.json"
+  local error_path="$tmpdir/decision-${decision_index}.stderr"
+  local status
+
+  set +e
+  "$cleanroom_bin" auth check \
+    --config "$config_path" \
+    --token-file "$token_path" \
+    "$@" \
+    --json \
+    >"$output_path" \
+    2>"$error_path"
+  status=$?
+  set -e
+
+  if [[ "$expected_allowed" == "true" && "$status" -ne 0 ]]; then
+    cat "$error_path" >&2
+    cat "$output_path" >&2
+    die "$label should have been allowed"
+  fi
+  if [[ "$expected_allowed" == "false" && "$status" -ne 1 ]]; then
+    cat "$error_path" >&2
+    cat "$output_path" >&2
+    die "$label should have been denied"
+  fi
+
+  python3 - "$output_path" "$expected_allowed" "$label" <<'PY'
+import json
+import sys
+
+output_path, expected, label = sys.argv[1], sys.argv[2] == "true", sys.argv[3]
+with open(output_path, encoding="utf-8") as fh:
+    decision = json.load(fh)
+
+if decision.get("allowed") is not expected:
+    raise SystemExit(f"{label}: expected allowed={expected}, got {decision.get('allowed')}")
+PY
+
+  echo "auth check passed: $label"
+}
+
+require_command buildkite-agent
+require_command go
+require_command python3
+
+audience="${CLEANROOM_AUTH_OIDC_AUDIENCE:-https://cleanroom.buildkite.com/ci-auth-smoke}"
+assert_safe_audience "$audience"
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/cleanroom-auth-oidc.XXXXXXXXXX")"
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+cleanroom_bin="$tmpdir/cleanroom"
+token_path="$tmpdir/buildkite.jwt"
+claims_path="$tmpdir/claims.json"
+config_path="$tmpdir/config.yaml"
+allowed_request_path="$tmpdir/create-allowed.json"
+denied_request_path="$tmpdir/create-denied.json"
+decision_index=0
+
+go build -o "$cleanroom_bin" ./cmd/cleanroom
+
+buildkite-agent oidc request-token \
+  --audience "$audience" \
+  --lifetime 300 \
+  --subject-claim pipeline_id \
+  --claim organization_id,pipeline_id \
+  >"$token_path"
+chmod 0600 "$token_path"
+[[ -s "$token_path" ]] || die "Buildkite OIDC token request produced an empty token"
+
+python3 - "$token_path" >"$claims_path" <<'PY'
+import base64
+import json
+import pathlib
+import sys
+
+token = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").strip()
+parts = token.split(".")
+if len(parts) != 3:
+    raise SystemExit("token is not a compact JWT")
+
+payload = parts[1] + "=" * (-len(parts[1]) % 4)
+claims = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+json.dump(claims, sys.stdout, sort_keys=True)
+PY
+
+organization_id="$(jwt_claim organization_id)"
+pipeline_id="$(jwt_claim pipeline_id)"
+expected_organization_id="${CLEANROOM_AUTH_OIDC_ORGANIZATION_ID:-$organization_id}"
+expected_pipeline_id="${CLEANROOM_AUTH_OIDC_PIPELINE_ID:-$pipeline_id}"
+
+assert_safe_identifier organization_id "$organization_id"
+assert_safe_identifier pipeline_id "$pipeline_id"
+assert_safe_identifier expected_organization_id "$expected_organization_id"
+assert_safe_identifier expected_pipeline_id "$expected_pipeline_id"
+
+[[ "$organization_id" == "$expected_organization_id" ]] || die "organization_id claim did not match CLEANROOM_AUTH_OIDC_ORGANIZATION_ID"
+[[ "$pipeline_id" == "$expected_pipeline_id" ]] || die "pipeline_id claim did not match CLEANROOM_AUTH_OIDC_PIPELINE_ID"
+
+owner_principal_id="oidc:buildkite:org:${organization_id}:pipeline:${pipeline_id}"
+owner_scope="org:${organization_id}"
+other_principal_id="oidc:buildkite:org:${organization_id}:pipeline:other-pipeline"
+
+cat >"$config_path" <<YAML
+default_backend: firecracker
+auth:
+  required: true
+  oidc:
+    issuers:
+      - name: buildkite
+        issuer: https://agent.buildkite.com
+        audiences:
+          - "$audience"
+        jwks_url: https://agent.buildkite.com/.well-known/jwks
+        required_claims:
+          organization_id: "$expected_organization_id"
+        clock_skew_seconds: 60
+        max_token_lifetime_seconds: 600
+  policy:
+    bindings:
+      - name: buildkite-ci
+        when: >
+          token.issuer == "buildkite" &&
+          claims.pipeline_id == "$expected_pipeline_id"
+        principal:
+          id: "oidc:\${token.issuer}:org:\${claims.organization_id}:pipeline:\${claims.pipeline_id}"
+          scope: "org:\${claims.organization_id}"
+        grants:
+          - name: create-cleanroom-sandbox
+            actions: [sandbox.create]
+            resources: [sandbox]
+            condition: >
+              request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" &&
+              request.backend == "firecracker" &&
+              request.policy.resources.vcpus <= 4 &&
+              request.policy.resources.memory_bytes <= 8589934592 &&
+              request.policy.docker.required == false &&
+              request.policy.network_default == "deny"
+          - name: manage-owned-sandboxes
+            actions: [sandbox.get]
+            resources: [sandbox]
+            # auth check only sees supplied owner metadata, so keep this grant
+            # owner-scoped to exercise existing-resource diagnostics locally.
+            condition: >
+              resource.owner.principal_id == principal.id &&
+              resource.owner.scope == principal.scope
+YAML
+
+cat >"$allowed_request_path" <<'JSON'
+{
+  "repository": {"remote_url": "https://github.com/buildkite/cleanroom.git"},
+  "backend": "firecracker",
+  "policy": {
+    "resources": {"vcpus": 4, "memory_bytes": 8589934592},
+    "docker": {"required": false},
+    "network_default": "deny"
+  }
+}
+JSON
+
+cat >"$denied_request_path" <<'JSON'
+{
+  "repository": {"remote_url": "https://github.com/buildkite/other.git"},
+  "backend": "firecracker",
+  "policy": {
+    "resources": {"vcpus": 4, "memory_bytes": 8589934592},
+    "docker": {"required": false},
+    "network_default": "deny"
+  }
+}
+JSON
+
+expect_auth_check "allowed sandbox create" true \
+  --action sandbox.create \
+  --request "$allowed_request_path"
+
+expect_auth_check "denied sandbox create for another repository" false \
+  --action sandbox.create \
+  --request "$denied_request_path"
+
+expect_auth_check "allowed same-owner sandbox get" true \
+  --action sandbox.get \
+  --resource-id sbx_auth_oidc_smoke \
+  --owner-principal-id "$owner_principal_id" \
+  --owner-scope "$owner_scope"
+
+expect_auth_check "denied cross-principal sandbox get" false \
+  --action sandbox.get \
+  --resource-id sbx_auth_oidc_smoke \
+  --owner-principal-id "$other_principal_id" \
+  --owner-scope "$owner_scope"
+
+echo "Buildkite OIDC auth smoke passed for organization_id=$organization_id pipeline_id=$pipeline_id"


### PR DESCRIPTION
We have local auth-check coverage and documented Buildkite OIDC examples, but CI was not proving that a real Buildkite agent token validates against the live issuer metadata. That leaves the operator path vulnerable to drift in token shape, required claims, or JWKS handling.

This adds a hosted Buildkite smoke step that requests a short-lived OIDC token with `pipeline_id` as the subject claim and both `organization_id` and `pipeline_id` as immutable payload claims. The step builds the local `cleanroom` CLI, generates a temporary runtime config for the minted token, and runs `cleanroom auth check` for allowed and denied sandbox-create requests plus owner-scoped `sandbox.get` diagnostics.

The smoke does not print the token, includes the new script in both Buildkite and local shellcheck coverage, and documents the optional `CLEANROOM_AUTH_OIDC_ORGANIZATION_ID` / `CLEANROOM_AUTH_OIDC_PIPELINE_ID` pins for pipelines that want drift to fail explicitly.