### PR TITLE
feat: Load sandbox policy from repository checkouts

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -113,6 +114,26 @@ func testPolicy() *Policy {
 		ImageDigest:    "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 		NetworkDefault: "deny",
 	}
+}
+
+func testRepositoryPolicyYAML(destinationDir string, submodules, allowGitHub bool) string {
+	allowBlock := ""
+	if allowGitHub {
+		allowBlock = `
+    allow:
+      - host: github.com
+        ports: [443]`
+	}
+	return fmt.Sprintf(`version: 1
+repository:
+  path: %s
+  submodules: %t
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  network:
+    default: deny%s
+`, destinationDir, submodules, allowBlock)
 }
 
 func TestClientLifecycle(t *testing.T) {

--- a/client/ergonomics.go
+++ b/client/ergonomics.go
@@ -158,10 +158,13 @@ func PolicyFromAllowlist(imageRef, imageDigest string, entries ...HostPort) *Pol
 
 // EnsureSandboxOptions controls EnsureSandbox behavior.
 type EnsureSandboxOptions struct {
-	Backend   string
-	Policy    *Policy
-	Options   *SandboxOptions
-	SandboxID string
+	Backend                string
+	Policy                 *Policy
+	Options                *SandboxOptions
+	RepositoryCheckout     *RepositoryCheckout
+	RepositoryChangeset    *RepositoryChangeset
+	RepositoryCommitBundle *RepositoryCommitBundle
+	SandboxID              string
 }
 
 // SandboxHandle is a concise reusable sandbox descriptor.
@@ -220,12 +223,15 @@ func (c *Client) EnsureSandbox(ctx context.Context, key string, opts EnsureSandb
 	}
 
 	createReq := &CreateSandboxRequest{
-		Backend: requestedBackend,
-		Options: opts.Options,
-		Policy:  opts.Policy,
+		Backend:                requestedBackend,
+		Options:                opts.Options,
+		Policy:                 opts.Policy,
+		RepositoryCheckout:     opts.RepositoryCheckout,
+		RepositoryChangeset:    opts.RepositoryChangeset,
+		RepositoryCommitBundle: opts.RepositoryCommitBundle,
 	}
-	if createReq.Policy == nil {
-		return nil, errors.New("missing policy")
+	if createReq.Policy == nil && createReq.RepositoryCheckout == nil {
+		return nil, errors.New("missing policy or repository checkout")
 	}
 
 	resp, err := c.CreateSandbox(ctx, createReq)

--- a/client/ergonomics_test.go
+++ b/client/ergonomics_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -245,6 +247,28 @@ func TestPolicyFromAllowlistSkipsEntriesWithoutPorts(t *testing.T) {
 	}
 	if got := policy.GetAllow()[0].GetPorts(); len(got) != 1 || got[0] != 443 {
 		t.Fatalf("unexpected allow ports: %#v", got)
+	}
+}
+
+func TestLoadPolicy(t *testing.T) {
+	root := t.TempDir()
+	policyPath := filepath.Join(root, PrimaryPolicyPath)
+	if err := os.WriteFile(policyPath, []byte(testRepositoryPolicyYAML("/workspace", false, true)), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	policy, source, err := LoadPolicy(root)
+	if err != nil {
+		t.Fatalf("LoadPolicy returned error: %v", err)
+	}
+	if source != policyPath {
+		t.Fatalf("unexpected source: got %q want %q", source, policyPath)
+	}
+	if policy.GetVersion() != 1 {
+		t.Fatalf("unexpected policy version: got %d", policy.GetVersion())
+	}
+	if got := policy.GetImageRef(); !strings.Contains(got, "ghcr.io/buildkite/cleanroom-base/alpine@sha256:") {
+		t.Fatalf("unexpected image ref: %q", got)
 	}
 }
 

--- a/client/policy.go
+++ b/client/policy.go
@@ -1,0 +1,22 @@
+package client
+
+import internalpolicy "github.com/buildkite/cleanroom/internal/policy"
+
+const (
+	// PrimaryPolicyPath is the canonical repository policy path.
+	PrimaryPolicyPath = internalpolicy.PrimaryPolicyPath
+	// FallbackPolicyPath is the legacy Buildkite-local repository policy path.
+	FallbackPolicyPath = internalpolicy.FallbackPolicyPath
+)
+
+// ErrPolicyNotFound is returned when no Cleanroom policy file is present.
+var ErrPolicyNotFound = internalpolicy.ErrPolicyNotFound
+
+// LoadPolicy loads and compiles a Cleanroom policy from root.
+func LoadPolicy(root string) (*Policy, string, error) {
+	compiled, source, err := internalpolicy.Loader{}.LoadAndCompile(root)
+	if err != nil {
+		return nil, source, err
+	}
+	return compiled.ToProto(), source, nil
+}

--- a/client/types.go
+++ b/client/types.go
@@ -19,11 +19,24 @@ const (
 )
 
 type PolicyAllowRule = cleanroomv1.PolicyAllowRule
+type PolicyDocker = cleanroomv1.PolicyDocker
+type PolicyBlockInputs = cleanroomv1.PolicyBlockInputs
+type PolicyBlockOutputs = cleanroomv1.PolicyBlockOutputs
+type PolicyBlock = cleanroomv1.PolicyBlock
+type PolicyServices = cleanroomv1.PolicyServices
+type PolicyDependencies = cleanroomv1.PolicyDependencies
+type PolicyRun = cleanroomv1.PolicyRun
+type PolicyNetwork = cleanroomv1.PolicyNetwork
+type PolicyNetworkStages = cleanroomv1.PolicyNetworkStages
 type PolicyResources = cleanroomv1.PolicyResources
 type SandboxResources = cleanroomv1.SandboxResources
 type Policy = cleanroomv1.Policy
 type Snapshot = cleanroomv1.Snapshot
 type SandboxOptions = cleanroomv1.SandboxOptions
+type RepositoryCheckout = cleanroomv1.RepositoryCheckout
+type RepositoryChangesetFile = cleanroomv1.RepositoryChangesetFile
+type RepositoryChangeset = cleanroomv1.RepositoryChangeset
+type RepositoryCommitBundle = cleanroomv1.RepositoryCommitBundle
 type CreateSandboxRequest = cleanroomv1.CreateSandboxRequest
 type CreateSandboxResponse = cleanroomv1.CreateSandboxResponse
 type CreateSandboxPhase = cleanroomv1.CreateSandboxPhase

--- a/internal/authz/cel.go
+++ b/internal/authz/cel.go
@@ -128,6 +128,20 @@ func (e *compiledBoolExpression) repositorySourceAuthorized(vars map[string]any,
 	return false
 }
 
+func (e *compiledBoolExpression) repositorySourceSatisfiable(vars map[string]any, unknownPaths ...string) bool {
+	if e == nil || strings.TrimSpace(e.source) == "" {
+		return true
+	}
+	ok, known, err := e.evalPartial(vars, unknownPaths...)
+	if err != nil {
+		return false
+	}
+	if known {
+		return ok
+	}
+	return e.repositorySourceAuthorized(vars, unknownPaths...)
+}
+
 func celAttributePattern(path string) *interpreter.AttributePattern {
 	parts := strings.Split(strings.TrimSpace(path), ".")
 	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {

--- a/internal/authz/cel.go
+++ b/internal/authz/cel.go
@@ -265,7 +265,7 @@ func referencesCELPath(source, target string) bool {
 			continue
 		}
 		path, next := readPath(source, i)
-		if path == target {
+		if path == target || strings.HasPrefix(path, target+".") {
 			return true
 		}
 		i = next

--- a/internal/authz/cel.go
+++ b/internal/authz/cel.go
@@ -8,6 +8,8 @@ import (
 	"unicode"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/interpreter"
 )
 
 const celRuntimeCostLimit uint64 = 10_000
@@ -43,7 +45,7 @@ func compileBoolExpression(source string, rules celPathRules) (*compiledBoolExpr
 	if !ast.OutputType().IsExactType(cel.BoolType) {
 		return nil, fmt.Errorf("expression must return bool, got %s", ast.OutputType())
 	}
-	program, err := env.Program(ast, cel.CostLimit(celRuntimeCostLimit))
+	program, err := env.Program(ast, cel.CostLimit(celRuntimeCostLimit), cel.EvalOptions(cel.OptPartialEval))
 	if err != nil {
 		return nil, err
 	}
@@ -66,6 +68,50 @@ func (e *compiledBoolExpression) eval(vars map[string]any) (bool, error) {
 		return false, fmt.Errorf("expression returned %T, expected bool", val.Value())
 	}
 	return native, nil
+}
+
+func (e *compiledBoolExpression) evalPartial(vars map[string]any, unknownPaths ...string) (bool, bool, error) {
+	if e == nil || strings.TrimSpace(e.source) == "" {
+		return true, true, nil
+	}
+	unknowns := make([]*interpreter.AttributePattern, 0, len(unknownPaths))
+	for _, path := range unknownPaths {
+		if pattern := celAttributePattern(path); pattern != nil {
+			unknowns = append(unknowns, pattern)
+		}
+	}
+	activation, err := cel.PartialVars(vars, unknowns...)
+	if err != nil {
+		return false, false, err
+	}
+	val, _, err := e.program.Eval(activation)
+	if err != nil {
+		return false, false, err
+	}
+	if types.IsUnknown(val) {
+		return false, false, nil
+	}
+	native, ok := val.Value().(bool)
+	if !ok {
+		return false, false, fmt.Errorf("expression returned %T, expected bool", val.Value())
+	}
+	return native, true, nil
+}
+
+func celAttributePattern(path string) *interpreter.AttributePattern {
+	parts := strings.Split(strings.TrimSpace(path), ".")
+	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
+		return nil
+	}
+	pattern := cel.AttributePattern(parts[0])
+	for _, part := range parts[1:] {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil
+		}
+		pattern = pattern.QualString(part)
+	}
+	return pattern
 }
 
 type celPathRules struct {

--- a/internal/authz/cel.go
+++ b/internal/authz/cel.go
@@ -102,17 +102,27 @@ func (e *compiledBoolExpression) repositorySourceAuthorized(vars map[string]any,
 	if e == nil || strings.TrimSpace(e.source) == "" {
 		return true
 	}
-	for _, conjunct := range sourceConjuncts(e.source) {
-		if !referencesCELPath(conjunct, "request.repository.remote_url") {
-			continue
-		}
-		compiled, err := compileBoolExpression(conjunct, grantCELRules())
+	for _, disjunct := range sourceDisjuncts(e.source) {
+		disjunctExpr, err := compileBoolExpression(disjunct, grantCELRules())
 		if err != nil {
 			continue
 		}
-		ok, known, err := compiled.evalPartial(vars, unknownPaths...)
-		if err == nil && known && ok {
-			return true
+		ok, known, err := disjunctExpr.evalPartial(vars, unknownPaths...)
+		if err != nil || (known && !ok) {
+			continue
+		}
+		for _, conjunct := range sourceConjuncts(disjunct) {
+			if !referencesCELPath(conjunct, "request.repository.remote_url") {
+				continue
+			}
+			compiled, err := compileBoolExpression(conjunct, grantCELRules())
+			if err != nil {
+				continue
+			}
+			ok, known, err := compiled.evalPartial(vars, unknownPaths...)
+			if err == nil && known && ok {
+				return true
+			}
 		}
 	}
 	return false
@@ -134,6 +144,19 @@ func celAttributePattern(path string) *interpreter.AttributePattern {
 	return pattern
 }
 
+func sourceDisjuncts(source string) []string {
+	source = stripOuterParens(strings.TrimSpace(source))
+	parts := splitTopLevelOr(source)
+	if len(parts) == 1 && parts[0] == source {
+		return []string{source}
+	}
+	var out []string
+	for _, part := range parts {
+		out = append(out, sourceDisjuncts(part)...)
+	}
+	return out
+}
+
 func sourceConjuncts(source string) []string {
 	source = stripOuterParens(strings.TrimSpace(source))
 	parts := splitTopLevelAnd(source)
@@ -147,7 +170,15 @@ func sourceConjuncts(source string) []string {
 	return out
 }
 
+func splitTopLevelOr(source string) []string {
+	return splitTopLevelOperator(source, '|')
+}
+
 func splitTopLevelAnd(source string) []string {
+	return splitTopLevelOperator(source, '&')
+}
+
+func splitTopLevelOperator(source string, op byte) []string {
 	var parts []string
 	start := 0
 	depth := 0
@@ -166,8 +197,8 @@ func splitTopLevelAnd(source string) []string {
 			if depth > 0 {
 				depth--
 			}
-		case '&':
-			if depth == 0 && i+1 < len(source) && source[i+1] == '&' {
+		case op:
+			if depth == 0 && i+1 < len(source) && source[i+1] == op {
 				parts = append(parts, strings.TrimSpace(source[start:i]))
 				i += 2
 				start = i

--- a/internal/authz/cel.go
+++ b/internal/authz/cel.go
@@ -98,6 +98,26 @@ func (e *compiledBoolExpression) evalPartial(vars map[string]any, unknownPaths .
 	return native, true, nil
 }
 
+func (e *compiledBoolExpression) repositorySourceAuthorized(vars map[string]any, unknownPaths ...string) bool {
+	if e == nil || strings.TrimSpace(e.source) == "" {
+		return true
+	}
+	for _, conjunct := range sourceConjuncts(e.source) {
+		if !referencesCELPath(conjunct, "request.repository.remote_url") {
+			continue
+		}
+		compiled, err := compileBoolExpression(conjunct, grantCELRules())
+		if err != nil {
+			continue
+		}
+		ok, known, err := compiled.evalPartial(vars, unknownPaths...)
+		if err == nil && known && ok {
+			return true
+		}
+	}
+	return false
+}
+
 func celAttributePattern(path string) *interpreter.AttributePattern {
 	parts := strings.Split(strings.TrimSpace(path), ".")
 	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
@@ -112,6 +132,114 @@ func celAttributePattern(path string) *interpreter.AttributePattern {
 		pattern = pattern.QualString(part)
 	}
 	return pattern
+}
+
+func sourceConjuncts(source string) []string {
+	source = stripOuterParens(strings.TrimSpace(source))
+	parts := splitTopLevelAnd(source)
+	if len(parts) == 1 && parts[0] == source {
+		return []string{source}
+	}
+	var out []string
+	for _, part := range parts {
+		out = append(out, sourceConjuncts(part)...)
+	}
+	return out
+}
+
+func splitTopLevelAnd(source string) []string {
+	var parts []string
+	start := 0
+	depth := 0
+	for i := 0; i < len(source); {
+		switch source[i] {
+		case '\'', '"':
+			next, err := skipQuoted(source, i)
+			if err != nil {
+				return []string{strings.TrimSpace(source)}
+			}
+			i = next
+			continue
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case '&':
+			if depth == 0 && i+1 < len(source) && source[i+1] == '&' {
+				parts = append(parts, strings.TrimSpace(source[start:i]))
+				i += 2
+				start = i
+				continue
+			}
+		}
+		i++
+	}
+	parts = append(parts, strings.TrimSpace(source[start:]))
+	return parts
+}
+
+func stripOuterParens(source string) string {
+	for {
+		source = strings.TrimSpace(source)
+		if len(source) < 2 || source[0] != '(' || source[len(source)-1] != ')' {
+			return source
+		}
+		depth := 0
+		wrapped := true
+		for i := 0; i < len(source); {
+			switch source[i] {
+			case '\'', '"':
+				next, err := skipQuoted(source, i)
+				if err != nil {
+					return source
+				}
+				i = next
+				continue
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 && i != len(source)-1 {
+					wrapped = false
+				}
+			}
+			i++
+		}
+		if !wrapped || depth != 0 {
+			return source
+		}
+		source = source[1 : len(source)-1]
+	}
+}
+
+func referencesCELPath(source, target string) bool {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return false
+	}
+	for i := 0; i < len(source); {
+		r := rune(source[i])
+		if source[i] == '"' || source[i] == '\'' {
+			next, err := skipQuoted(source, i)
+			if err != nil {
+				return false
+			}
+			i = next
+			continue
+		}
+		if !isIdentStart(r) || (i > 0 && source[i-1] == '.') {
+			i++
+			continue
+		}
+		path, next := readPath(source, i)
+		if path == target {
+			return true
+		}
+		i = next
+	}
+	return false
 }
 
 type celPathRules struct {

--- a/internal/authz/policy.go
+++ b/internal/authz/policy.go
@@ -299,6 +299,110 @@ func (b BoundPrincipal) Authorize(req DecisionRequest) Decision {
 	return decision
 }
 
+// AuthorizeRepositoryPolicySource evaluates the part of a sandbox.create request
+// that is known before a repository policy is loaded. The boolean return value is
+// false when matching grants depend on policy/image/cache fields that are not
+// available yet, so callers should defer the final decision until after policy
+// resolution.
+func (b BoundPrincipal) AuthorizeRepositoryPolicySource(req DecisionRequest) (Decision, bool) {
+	req.Principal = b.Principal
+	if req.Claims == nil {
+		req.Claims = b.Claims
+	}
+	req.Action = strings.TrimSpace(req.Action)
+	req.Resource.Kind = strings.TrimSpace(req.Resource.Kind)
+	decision := Decision{
+		Allowed:   false,
+		Principal: b.Principal,
+		Action:    req.Action,
+		Resource:  req.Resource,
+		Binding:   b.Binding,
+		Reason:    ReasonNoGrant,
+	}
+	if b.binding == nil {
+		decision.Reason = ReasonNoBinding
+		return decision, true
+	}
+
+	matchedGrant := false
+	skippedUnavailableGrant := false
+	var conditionErrorDecision *Decision
+	for _, grant := range b.binding.grants {
+		if !grant.matches(decision.Action, req.Resource.Kind) {
+			continue
+		}
+		if repositoryPolicySourceGrantNeedsLoadedPolicy(grant) {
+			skippedUnavailableGrant = true
+			continue
+		}
+		matchedGrant = true
+		ok, err := grant.condition.eval(grantActivation(req))
+		if err != nil {
+			if conditionErrorDecision == nil {
+				errorDecision := decision
+				errorDecision.Grant = grant.name
+				errorDecision.Reason = ReasonConditionError
+				conditionErrorDecision = &errorDecision
+			}
+			continue
+		}
+		if !ok {
+			decision.Grant = grant.name
+			decision.Reason = ReasonConditionFalse
+			continue
+		}
+		decision.Allowed = true
+		decision.Grant = grant.name
+		decision.Reason = ReasonAllowed
+		return decision, true
+	}
+	if skippedUnavailableGrant {
+		return decision, false
+	}
+	if conditionErrorDecision != nil {
+		return *conditionErrorDecision, true
+	}
+	if matchedGrant && decision.Reason == ReasonNoGrant {
+		decision.Reason = ReasonConditionFalse
+	}
+	return decision, true
+}
+
+func repositoryPolicySourceGrantNeedsLoadedPolicy(grant compiledGrant) bool {
+	if grant.condition == nil {
+		return false
+	}
+	source := grant.condition.source
+	unavailablePrefixes := []string{
+		"request.image",
+		"request.policy",
+		"request.cache",
+		"request.snapshot",
+	}
+	for i := 0; i < len(source); {
+		if source[i] == '"' || source[i] == '\'' {
+			next, err := skipQuoted(source, i)
+			if err != nil {
+				return true
+			}
+			i = next
+			continue
+		}
+		if !isIdentStart(rune(source[i])) || (i > 0 && source[i-1] == '.') {
+			i++
+			continue
+		}
+		path, next := readPath(source, i)
+		i = next
+		for _, prefix := range unavailablePrefixes {
+			if path == prefix || strings.HasPrefix(path, prefix+".") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func grantActivation(req DecisionRequest) map[string]any {
 	return map[string]any{
 		"principal": map[string]any{

--- a/internal/authz/policy.go
+++ b/internal/authz/policy.go
@@ -328,6 +328,7 @@ func (b BoundPrincipal) AuthorizeRepositoryPolicySource(req DecisionRequest) (De
 	deferredSourceGrant := false
 	var conditionErrorDecision *Decision
 	unknownPaths := repositoryPolicySourceUnknownPaths(req)
+	sourceAuthorizationUnknownPaths := repositoryPolicySourceAuthorizationUnknownPaths(req)
 	activation := grantActivation(req)
 	for _, grant := range b.binding.grants {
 		if !grant.matches(decision.Action, req.Resource.Kind) {
@@ -345,12 +346,17 @@ func (b BoundPrincipal) AuthorizeRepositoryPolicySource(req DecisionRequest) (De
 			continue
 		}
 		if !known {
-			if grant.condition.repositorySourceAuthorized(activation, unknownPaths...) {
+			if grant.condition.repositorySourceAuthorized(activation, sourceAuthorizationUnknownPaths...) {
 				deferredSourceGrant = true
 			}
 			continue
 		}
 		if !ok {
+			decision.Grant = grant.name
+			decision.Reason = ReasonConditionFalse
+			continue
+		}
+		if !grant.condition.repositorySourceSatisfiable(activation, sourceAuthorizationUnknownPaths...) {
 			decision.Grant = grant.name
 			decision.Reason = ReasonConditionFalse
 			continue
@@ -392,6 +398,12 @@ func repositoryPolicySourceUnknownPaths(req DecisionRequest) []string {
 	if requestString(repository, "branch") == "" {
 		paths = append(paths, "request.repository.branch")
 	}
+	return paths
+}
+
+func repositoryPolicySourceAuthorizationUnknownPaths(req DecisionRequest) []string {
+	paths := repositoryPolicySourceUnknownPaths(req)
+	repository, _ := req.Request["repository"].(map[string]any)
 	changeset, _ := repository["changeset"].(map[string]any)
 	if changesetPresent, _ := changeset["present"].(bool); changesetPresent {
 		paths = append(paths,

--- a/internal/authz/policy.go
+++ b/internal/authz/policy.go
@@ -384,7 +384,6 @@ func repositoryPolicySourceUnknownPaths(req DecisionRequest) []string {
 		"request.policy.network.hosts",
 		"request.policy.network.ports",
 		"request.cache.reuse",
-		"request.snapshot.id",
 	}
 	repository, _ := req.Request["repository"].(map[string]any)
 	if requestString(repository, "commit") == "" {

--- a/internal/authz/policy.go
+++ b/internal/authz/policy.go
@@ -325,15 +325,16 @@ func (b BoundPrincipal) AuthorizeRepositoryPolicySource(req DecisionRequest) (De
 	}
 
 	matchedGrant := false
-	unknownGrant := false
+	deferredSourceGrant := false
 	var conditionErrorDecision *Decision
 	unknownPaths := repositoryPolicySourceUnknownPaths(req)
+	activation := grantActivation(req)
 	for _, grant := range b.binding.grants {
 		if !grant.matches(decision.Action, req.Resource.Kind) {
 			continue
 		}
 		matchedGrant = true
-		ok, known, err := grant.condition.evalPartial(grantActivation(req), unknownPaths...)
+		ok, known, err := grant.condition.evalPartial(activation, unknownPaths...)
 		if err != nil {
 			if conditionErrorDecision == nil {
 				errorDecision := decision
@@ -344,7 +345,9 @@ func (b BoundPrincipal) AuthorizeRepositoryPolicySource(req DecisionRequest) (De
 			continue
 		}
 		if !known {
-			unknownGrant = true
+			if grant.condition.repositorySourceAuthorized(activation, unknownPaths...) {
+				deferredSourceGrant = true
+			}
 			continue
 		}
 		if !ok {
@@ -357,7 +360,7 @@ func (b BoundPrincipal) AuthorizeRepositoryPolicySource(req DecisionRequest) (De
 		decision.Reason = ReasonAllowed
 		return decision, true
 	}
-	if unknownGrant {
+	if deferredSourceGrant {
 		return decision, false
 	}
 	if conditionErrorDecision != nil {
@@ -371,6 +374,8 @@ func (b BoundPrincipal) AuthorizeRepositoryPolicySource(req DecisionRequest) (De
 
 func repositoryPolicySourceUnknownPaths(req DecisionRequest) []string {
 	paths := []string{
+		"request.repository.commit",
+		"request.repository.branch",
 		"request.image.ref",
 		"request.image.digest",
 		"request.policy.resources.vcpus",
@@ -384,11 +389,12 @@ func repositoryPolicySourceUnknownPaths(req DecisionRequest) []string {
 		"request.snapshot.id",
 	}
 	repository, _ := req.Request["repository"].(map[string]any)
-	if requestString(repository, "commit") == "" {
-		paths = append(paths, "request.repository.commit")
-	}
-	if requestString(repository, "branch") == "" {
-		paths = append(paths, "request.repository.branch")
+	changeset, _ := repository["changeset"].(map[string]any)
+	if changesetPresent, _ := changeset["present"].(bool); changesetPresent {
+		paths = append(paths,
+			"request.repository.changeset.digest",
+			"request.repository.changeset.tree_digest",
+		)
 	}
 	return paths
 }

--- a/internal/authz/policy.go
+++ b/internal/authz/policy.go
@@ -374,8 +374,6 @@ func (b BoundPrincipal) AuthorizeRepositoryPolicySource(req DecisionRequest) (De
 
 func repositoryPolicySourceUnknownPaths(req DecisionRequest) []string {
 	paths := []string{
-		"request.repository.commit",
-		"request.repository.branch",
 		"request.image.ref",
 		"request.image.digest",
 		"request.policy.resources.vcpus",
@@ -389,6 +387,12 @@ func repositoryPolicySourceUnknownPaths(req DecisionRequest) []string {
 		"request.snapshot.id",
 	}
 	repository, _ := req.Request["repository"].(map[string]any)
+	if requestString(repository, "commit") == "" {
+		paths = append(paths, "request.repository.commit")
+	}
+	if requestString(repository, "branch") == "" {
+		paths = append(paths, "request.repository.branch")
+	}
 	changeset, _ := repository["changeset"].(map[string]any)
 	if changesetPresent, _ := changeset["present"].(bool); changesetPresent {
 		paths = append(paths,

--- a/internal/authz/policy.go
+++ b/internal/authz/policy.go
@@ -325,18 +325,15 @@ func (b BoundPrincipal) AuthorizeRepositoryPolicySource(req DecisionRequest) (De
 	}
 
 	matchedGrant := false
-	skippedUnavailableGrant := false
+	unknownGrant := false
 	var conditionErrorDecision *Decision
+	unknownPaths := repositoryPolicySourceUnknownPaths(req)
 	for _, grant := range b.binding.grants {
 		if !grant.matches(decision.Action, req.Resource.Kind) {
 			continue
 		}
-		if repositoryPolicySourceGrantNeedsLoadedPolicy(grant) {
-			skippedUnavailableGrant = true
-			continue
-		}
 		matchedGrant = true
-		ok, err := grant.condition.eval(grantActivation(req))
+		ok, known, err := grant.condition.evalPartial(grantActivation(req), unknownPaths...)
 		if err != nil {
 			if conditionErrorDecision == nil {
 				errorDecision := decision
@@ -344,6 +341,10 @@ func (b BoundPrincipal) AuthorizeRepositoryPolicySource(req DecisionRequest) (De
 				errorDecision.Reason = ReasonConditionError
 				conditionErrorDecision = &errorDecision
 			}
+			continue
+		}
+		if !known {
+			unknownGrant = true
 			continue
 		}
 		if !ok {
@@ -356,7 +357,7 @@ func (b BoundPrincipal) AuthorizeRepositoryPolicySource(req DecisionRequest) (De
 		decision.Reason = ReasonAllowed
 		return decision, true
 	}
-	if skippedUnavailableGrant {
+	if unknownGrant {
 		return decision, false
 	}
 	if conditionErrorDecision != nil {
@@ -368,39 +369,39 @@ func (b BoundPrincipal) AuthorizeRepositoryPolicySource(req DecisionRequest) (De
 	return decision, true
 }
 
-func repositoryPolicySourceGrantNeedsLoadedPolicy(grant compiledGrant) bool {
-	if grant.condition == nil {
-		return false
+func repositoryPolicySourceUnknownPaths(req DecisionRequest) []string {
+	paths := []string{
+		"request.image.ref",
+		"request.image.digest",
+		"request.policy.resources.vcpus",
+		"request.policy.resources.memory_bytes",
+		"request.policy.resources.disk_bytes",
+		"request.policy.docker.required",
+		"request.policy.network_default",
+		"request.policy.network.hosts",
+		"request.policy.network.ports",
+		"request.cache.reuse",
+		"request.snapshot.id",
 	}
-	source := grant.condition.source
-	unavailablePrefixes := []string{
-		"request.image",
-		"request.policy",
-		"request.cache",
-		"request.snapshot",
+	repository, _ := req.Request["repository"].(map[string]any)
+	if requestString(repository, "commit") == "" {
+		paths = append(paths, "request.repository.commit")
 	}
-	for i := 0; i < len(source); {
-		if source[i] == '"' || source[i] == '\'' {
-			next, err := skipQuoted(source, i)
-			if err != nil {
-				return true
-			}
-			i = next
-			continue
-		}
-		if !isIdentStart(rune(source[i])) || (i > 0 && source[i-1] == '.') {
-			i++
-			continue
-		}
-		path, next := readPath(source, i)
-		i = next
-		for _, prefix := range unavailablePrefixes {
-			if path == prefix || strings.HasPrefix(path, prefix+".") {
-				return true
-			}
-		}
+	if requestString(repository, "branch") == "" {
+		paths = append(paths, "request.repository.branch")
 	}
-	return false
+	return paths
+}
+
+func requestString(values map[string]any, key string) string {
+	if values == nil {
+		return ""
+	}
+	value, ok := values[key]
+	if !ok || value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
 }
 
 func grantActivation(req DecisionRequest) map[string]any {

--- a/internal/controlservice/authz.go
+++ b/internal/controlservice/authz.go
@@ -49,6 +49,22 @@ func (s *Service) authorizeCreate(ctx context.Context, action, resourceKind stri
 	return owner, nil
 }
 
+func (s *Service) authorizeRepositoryPolicySource(ctx context.Context, backendName string, repository *repositorycheckout.Checkout, changeset *repositorychangeset.Changeset) error {
+	bound, ok := authz.BoundPrincipalFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	decision, decisive := bound.AuthorizeRepositoryPolicySource(authz.DecisionRequest{
+		Action:   "sandbox.create",
+		Resource: authz.Resource{Kind: "sandbox"},
+		Request:  createSandboxAuthorizationRequest(backendName, nil, repository, changeset, "", policy.Resources{}),
+	})
+	if !decisive || decision.Allowed {
+		return nil
+	}
+	return s.denyAuthorization(ctx, decision)
+}
+
 func (s *Service) authorizeOwnedResource(ctx context.Context, action, resourceKind, resourceID string, owner authz.ResourceOwner, request map[string]any) error {
 	bound, ok := authz.BoundPrincipalFromContext(ctx)
 	if !ok {

--- a/internal/controlservice/authz_test.go
+++ b/internal/controlservice/authz_test.go
@@ -708,6 +708,42 @@ func TestAuthzRepositoryPolicyCreateDeniesDisallowedBranchBeforeRepositoryStoreA
 	}
 }
 
+func TestAuthzRepositoryPolicyCreateDeniesKnownSnapshotConditionBeforeRepositoryStoreAccess(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "snapshot-policy",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: `request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" && request.snapshot.id == "trusted-snapshot" && request.policy.network_default == "deny"`,
+		}},
+	}}})
+
+	_, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: &cleanroomv1.RepositoryCheckout{
+			RemoteUrl: "https://github.com/buildkite/cleanroom.git",
+			Branch:    "main",
+		},
+	})
+	if !errors.Is(err, ErrAuthorizationDenied) {
+		t.Fatalf("CreateSandbox error = %v, want authorization denied", err)
+	}
+	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls + mirrors.calls; got != 0 {
+		t.Fatalf("repository store calls = %d, want 0", got)
+	}
+	if got := adapter.provisionCalls; got != 0 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 0", got)
+	}
+}
+
 func TestAuthzRepositoryPolicyCreateDefersPolicyDependentGrant(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
@@ -727,6 +763,42 @@ func TestAuthzRepositoryPolicyCreateDefersPolicyDependentGrant(t *testing.T) {
 			Actions:   []string{"sandbox.create"},
 			Resources: []string{"sandbox"},
 			Condition: `request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" && request.policy.network_default == "deny"`,
+		}},
+	}}})
+
+	_, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls; got == 0 {
+		t.Fatalf("repository store was not used")
+	}
+	if got := adapter.provisionCalls; got != 1 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 1", got)
+	}
+}
+
+func TestAuthzRepositoryPolicyCreateDefersRepositoryMethodGrant(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"cleanroom.yaml": testRepositoryPolicyYAML("/workspace", false, true),
+	})
+	repositoryCheckout.CommitSha = ""
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "repo-policy",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: `request.repository.remote_url.startsWith("https://github.com/buildkite/") && request.policy.network_default == "deny"`,
 		}},
 	}}})
 
@@ -774,6 +846,43 @@ func TestAuthzRepositoryPolicyCreateDefersDisjunctiveRepositoryGrant(t *testing.
 	}
 	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls; got == 0 {
 		t.Fatalf("repository store was not used")
+	}
+	if got := adapter.provisionCalls; got != 1 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 1", got)
+	}
+}
+
+func TestAuthzRepositoryPolicyCreateAuthorizesDisabledRepositoryPolicySource(t *testing.T) {
+	adapter := &stubAdapter{}
+	disabledPolicy := strings.ReplaceAll(testRepositoryPolicyYAML("/workspace", false, true), "  path: /workspace\n  submodules: false", "  enabled: false")
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"cleanroom.yaml": disabledPolicy,
+	})
+	repositoryCheckout.CommitSha = ""
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "repo-policy",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: `request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" && request.policy.network_default == "deny"`,
+		}},
+	}}})
+
+	resp, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if resp.GetSandbox().GetRepositoryCheckout() != nil {
+		t.Fatal("expected disabled repository policy to skip runtime repository checkout")
 	}
 	if got := adapter.provisionCalls; got != 1 {
 		t.Fatalf("ProvisionSandbox calls = %d, want 1", got)

--- a/internal/controlservice/authz_test.go
+++ b/internal/controlservice/authz_test.go
@@ -672,6 +672,42 @@ func TestAuthzRepositoryPolicyCreateDeniesChangesetDigestGrantBeforeRepositorySt
 	}
 }
 
+func TestAuthzRepositoryPolicyCreateDeniesDisallowedBranchBeforeRepositoryStoreAccess(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "main-branch-policy",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: `request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" && request.repository.branch == "main" && request.policy.network_default == "deny"`,
+		}},
+	}}})
+
+	_, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: &cleanroomv1.RepositoryCheckout{
+			RemoteUrl: "https://github.com/buildkite/cleanroom.git",
+			Branch:    "private",
+		},
+	})
+	if !errors.Is(err, ErrAuthorizationDenied) {
+		t.Fatalf("CreateSandbox error = %v, want authorization denied", err)
+	}
+	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls + mirrors.calls; got != 0 {
+		t.Fatalf("repository store calls = %d, want 0", got)
+	}
+	if got := adapter.provisionCalls; got != 0 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 0", got)
+	}
+}
+
 func TestAuthzRepositoryPolicyCreateDefersPolicyDependentGrant(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
@@ -691,6 +727,42 @@ func TestAuthzRepositoryPolicyCreateDefersPolicyDependentGrant(t *testing.T) {
 			Actions:   []string{"sandbox.create"},
 			Resources: []string{"sandbox"},
 			Condition: `request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" && request.policy.network_default == "deny"`,
+		}},
+	}}})
+
+	_, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls; got == 0 {
+		t.Fatalf("repository store was not used")
+	}
+	if got := adapter.provisionCalls; got != 1 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 1", got)
+	}
+}
+
+func TestAuthzRepositoryPolicyCreateDefersDisjunctiveRepositoryGrant(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"cleanroom.yaml": testRepositoryPolicyYAML("/workspace", false, true),
+	})
+	repositoryCheckout.CommitSha = ""
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "repo-policy",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: `(request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" && request.policy.network_default == "deny") || (request.repository.remote_url == "https://github.com/buildkite/other.git" && request.policy.network_default == "deny")`,
 		}},
 	}}})
 

--- a/internal/controlservice/authz_test.go
+++ b/internal/controlservice/authz_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -18,6 +19,7 @@ import (
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorybundle"
 	"github.com/buildkite/cleanroom/internal/repositorychangeset"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
@@ -555,6 +557,42 @@ func TestAuthzRepositoryPolicyCreateDeniesBeforeRepositoryStoreAccess(t *testing
 	}
 }
 
+func TestAuthzRepositoryPolicyCreateDeniesCombinedRepositoryConditionBeforeRepositoryStoreAccess(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "known-repo-policy",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: `request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" && request.policy.network_default == "deny"`,
+		}},
+	}}})
+
+	_, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: &cleanroomv1.RepositoryCheckout{
+			RemoteUrl: "https://github.com/buildkite/private.git",
+			Branch:    "main",
+		},
+	})
+	if !errors.Is(err, ErrAuthorizationDenied) {
+		t.Fatalf("CreateSandbox error = %v, want authorization denied", err)
+	}
+	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls + mirrors.calls; got != 0 {
+		t.Fatalf("repository store calls = %d, want 0", got)
+	}
+	if got := adapter.provisionCalls; got != 0 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 0", got)
+	}
+}
+
 func TestAuthzRepositoryPolicyCreateDefersPolicyDependentGrant(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
@@ -585,6 +623,67 @@ func TestAuthzRepositoryPolicyCreateDefersPolicyDependentGrant(t *testing.T) {
 	}
 	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls; got == 0 {
 		t.Fatalf("repository store was not used")
+	}
+	if got := adapter.provisionCalls; got != 1 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 1", got)
+	}
+}
+
+func TestAuthzRepositoryPolicyCreateUsesCommitBundleTargetInPreflight(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"cleanroom.yaml": testRepositoryPolicyYAML("/base", false, true),
+	})
+	baseCommit := repositoryCheckout.GetCommitSha()
+
+	localRepo := filepath.Join(t.TempDir(), "local")
+	runTestGit(t, t.TempDir(), "clone", mirrors.mirrorPath, localRepo)
+	runTestGit(t, localRepo, "config", "user.email", "test@example.com")
+	runTestGit(t, localRepo, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(localRepo, "cleanroom.yaml"), []byte(testRepositoryPolicyYAML("/bundle", false, true)), 0o644); err != nil {
+		t.Fatalf("WriteFile(cleanroom.yaml) returned error: %v", err)
+	}
+	runTestGit(t, localRepo, "add", "cleanroom.yaml")
+	runTestGit(t, localRepo, "commit", "-m", "local policy")
+	localCommit := strings.TrimSpace(runTestGit(t, localRepo, "rev-parse", "HEAD"))
+
+	commitBundle, err := repositorybundle.BuildFromRepository(localRepo, "origin", &repositorycheckout.Checkout{CommitSHA: localCommit})
+	if err != nil {
+		t.Fatalf("BuildFromRepository returned error: %v", err)
+	}
+	if commitBundle == nil {
+		t.Fatal("expected repository commit bundle")
+	}
+	repositoryCheckout.CommitSha = ""
+	mirrors.ensureContainsFn = func(_ string, commitSHA string) error {
+		if strings.TrimSpace(commitSHA) != baseCommit {
+			return fmt.Errorf("unexpected mirror commit %q", commitSHA)
+		}
+		return nil
+	}
+
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "known-commit",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: fmt.Sprintf(`request.repository.commit == %q`, localCommit),
+		}},
+	}}})
+
+	_, err = svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout:     repositoryCheckout,
+		RepositoryCommitBundle: commitBundle.ToProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
 	}
 	if got := adapter.provisionCalls; got != 1 {
 		t.Fatalf("ProvisionSandbox calls = %d, want 1", got)

--- a/internal/controlservice/authz_test.go
+++ b/internal/controlservice/authz_test.go
@@ -593,6 +593,85 @@ func TestAuthzRepositoryPolicyCreateDeniesCombinedRepositoryConditionBeforeRepos
 	}
 }
 
+func TestAuthzRepositoryPolicyCreateDeniesPolicyOnlyGrantBeforeRepositoryStoreAccess(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "policy-only",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: `request.policy.network_default == "deny"`,
+		}},
+	}}})
+
+	_, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: &cleanroomv1.RepositoryCheckout{
+			RemoteUrl: "https://github.com/buildkite/private.git",
+			Branch:    "main",
+		},
+	})
+	if !errors.Is(err, ErrAuthorizationDenied) {
+		t.Fatalf("CreateSandbox error = %v, want authorization denied", err)
+	}
+	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls + mirrors.calls; got != 0 {
+		t.Fatalf("repository store calls = %d, want 0", got)
+	}
+	if got := adapter.provisionCalls; got != 0 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 0", got)
+	}
+}
+
+func TestAuthzRepositoryPolicyCreateDeniesChangesetDigestGrantBeforeRepositoryStoreAccess(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "changeset-digest-only",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: `request.repository.changeset.digest == "allowed"`,
+		}},
+	}}})
+
+	_, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: &cleanroomv1.RepositoryCheckout{
+			RemoteUrl: "https://github.com/buildkite/private.git",
+			Branch:    "main",
+		},
+		RepositoryChangeset: &cleanroomv1.RepositoryChangeset{
+			Format:        repositorychangeset.FormatGitDiffV1,
+			BaseCommitSha: strings.Repeat("0", 40),
+			Digest:        "allowed",
+			TreeDigest:    strings.Repeat("1", 40),
+			Patch:         []byte("not a valid changeset"),
+		},
+	})
+	if !errors.Is(err, ErrAuthorizationDenied) {
+		t.Fatalf("CreateSandbox error = %v, want authorization denied", err)
+	}
+	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls + mirrors.calls; got != 0 {
+		t.Fatalf("repository store calls = %d, want 0", got)
+	}
+	if got := adapter.provisionCalls; got != 0 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 0", got)
+	}
+}
+
 func TestAuthzRepositoryPolicyCreateDefersPolicyDependentGrant(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
@@ -674,7 +753,7 @@ func TestAuthzRepositoryPolicyCreateUsesCommitBundleTargetInPreflight(t *testing
 			Name:      "known-commit",
 			Actions:   []string{"sandbox.create"},
 			Resources: []string{"sandbox"},
-			Condition: fmt.Sprintf(`request.repository.commit == %q`, localCommit),
+			Condition: fmt.Sprintf(`request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" && request.repository.commit == %q`, localCommit),
 		}},
 	}}})
 

--- a/internal/controlservice/authz_test.go
+++ b/internal/controlservice/authz_test.go
@@ -672,6 +672,49 @@ func TestAuthzRepositoryPolicyCreateDeniesChangesetDigestGrantBeforeRepositorySt
 	}
 }
 
+func TestAuthzRepositoryPolicyCreateDeniesMismatchedChangesetDigestBeforeRepositoryStoreAccess(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "approved-changeset",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: `request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" && request.repository.changeset.digest == "approved" && request.policy.network_default == "deny"`,
+		}},
+	}}})
+
+	_, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: &cleanroomv1.RepositoryCheckout{
+			RemoteUrl: "https://github.com/buildkite/cleanroom.git",
+			Branch:    "main",
+		},
+		RepositoryChangeset: &cleanroomv1.RepositoryChangeset{
+			Format:        repositorychangeset.FormatGitDiffV1,
+			BaseCommitSha: strings.Repeat("0", 40),
+			Digest:        "rejected",
+			TreeDigest:    strings.Repeat("1", 40),
+			Patch:         []byte("not a valid changeset"),
+		},
+	})
+	if !errors.Is(err, ErrAuthorizationDenied) {
+		t.Fatalf("CreateSandbox error = %v, want authorization denied", err)
+	}
+	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls + mirrors.calls; got != 0 {
+		t.Fatalf("repository store calls = %d, want 0", got)
+	}
+	if got := adapter.provisionCalls; got != 0 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 0", got)
+	}
+}
+
 func TestAuthzRepositoryPolicyCreateDeniesDisallowedBranchBeforeRepositoryStoreAccess(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors := &stubRepositoryMirrorStore{}
@@ -799,6 +842,43 @@ func TestAuthzRepositoryPolicyCreateDefersRepositoryMethodGrant(t *testing.T) {
 			Actions:   []string{"sandbox.create"},
 			Resources: []string{"sandbox"},
 			Condition: `request.repository.remote_url.startsWith("https://github.com/buildkite/") && request.policy.network_default == "deny"`,
+		}},
+	}}})
+
+	_, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls; got == 0 {
+		t.Fatalf("repository store was not used")
+	}
+	if got := adapter.provisionCalls; got != 1 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 1", got)
+	}
+}
+
+func TestAuthzRepositoryPolicyCreateDefersGroupedRepositoryBranchGrant(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"cleanroom.yaml": testRepositoryPolicyYAML("/workspace", false, true),
+	})
+	baseBranch := strings.TrimSpace(runTestGit(t, mirrors.mirrorPath, "rev-parse", "--abbrev-ref", "HEAD"))
+	repositoryCheckout.CommitSha = ""
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "repo-branch-policy",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: fmt.Sprintf(`(request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" && request.repository.branch == %q) && request.policy.network_default == "deny"`, baseBranch),
 		}},
 	}}})
 

--- a/internal/controlservice/authz_test.go
+++ b/internal/controlservice/authz_test.go
@@ -547,11 +547,47 @@ func TestAuthzRepositoryPolicyCreateDeniesBeforeRepositoryStoreAccess(t *testing
 	if !errors.Is(err, ErrAuthorizationDenied) {
 		t.Fatalf("CreateSandbox error = %v, want authorization denied", err)
 	}
-	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.calls; got != 0 {
+	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls + mirrors.calls; got != 0 {
 		t.Fatalf("repository store calls = %d, want 0", got)
 	}
 	if got := adapter.provisionCalls; got != 0 {
 		t.Fatalf("ProvisionSandbox calls = %d, want 0", got)
+	}
+}
+
+func TestAuthzRepositoryPolicyCreateDefersPolicyDependentGrant(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"cleanroom.yaml": testRepositoryPolicyYAML("/workspace", false, true),
+	})
+	repositoryCheckout.CommitSha = ""
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "repo-policy",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: `request.repository.remote_url == "https://github.com/buildkite/cleanroom.git" && request.policy.network_default == "deny"`,
+		}},
+	}}})
+
+	_, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.refreshCalls; got == 0 {
+		t.Fatalf("repository store was not used")
+	}
+	if got := adapter.provisionCalls; got != 1 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 1", got)
 	}
 }
 

--- a/internal/controlservice/authz_test.go
+++ b/internal/controlservice/authz_test.go
@@ -519,6 +519,42 @@ func TestAuthzCreateExecutionExposesRequestedRepository(t *testing.T) {
 	}
 }
 
+func TestAuthzRepositoryPolicyCreateDeniesBeforeRepositoryStoreAccess(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors := &stubRepositoryMirrorStore{}
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+	ctx := testAuthContextWithPolicy(t, "alice", authz.Policy{Bindings: []authz.Binding{{
+		Name: "test",
+		Principal: authz.PrincipalTemplate{
+			ID:    "oidc:${token.issuer}:${token.subject}",
+			Scope: "scope:${token.subject}",
+		},
+		Grants: []authz.Grant{{
+			Name:      "known-repo-only",
+			Actions:   []string{"sandbox.create"},
+			Resources: []string{"sandbox"},
+			Condition: `request.repository.remote_url == "https://github.com/buildkite/cleanroom.git"`,
+		}},
+	}}})
+
+	_, err := svc.CreateSandbox(ctx, &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: &cleanroomv1.RepositoryCheckout{
+			RemoteUrl: "https://github.com/buildkite/private.git",
+			Branch:    "main",
+		},
+	})
+	if !errors.Is(err, ErrAuthorizationDenied) {
+		t.Fatalf("CreateSandbox error = %v, want authorization denied", err)
+	}
+	if got := mirrors.mirrorPathCalls + mirrors.ensureMirrorCalls + mirrors.calls; got != 0 {
+		t.Fatalf("repository store calls = %d, want 0", got)
+	}
+	if got := adapter.provisionCalls; got != 0 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 0", got)
+	}
+}
+
 func TestAuthzDeniesOwnerlessSnapshotWhenAuthenticated(t *testing.T) {
 	store := newMemorySnapshotStore()
 	if err := store.Create(context.Background(), snapshotstoreRecord("snap-ownerless")); err != nil {

--- a/internal/controlservice/dependency_stage_test.go
+++ b/internal/controlservice/dependency_stage_test.go
@@ -157,6 +157,10 @@ func (s *testSubmoduleStore) ReadFileAtCommit(_ context.Context, _, _, _ string)
 	return nil, nil
 }
 
+func (s *testSubmoduleStore) Refresh(_ context.Context, _ string, _ repositorystore.FetchHints) error {
+	return nil
+}
+
 func (s *testSubmoduleStore) WithRepository(_ context.Context, _, _ string, _ repositorystore.FetchHints, fn func(string) error) error {
 	return fn(s.mirrorDir)
 }

--- a/internal/controlservice/repository_commit_bundle.go
+++ b/internal/controlservice/repository_commit_bundle.go
@@ -2,6 +2,7 @@ package controlservice
 
 import (
 	"errors"
+	"strings"
 
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/repositorybundle"
@@ -33,4 +34,11 @@ func validateRepositoryCommitBundleForCheckout(repository *repositorycheckout.Ch
 		return err
 	}
 	return nil
+}
+
+func validateRepositoryCommitBundleForResolvedCheckout(repository *repositorycheckout.Checkout, bundle *repositorybundle.Bundle, policySource string) error {
+	if bundle != nil && repository == nil && strings.HasPrefix(strings.TrimSpace(policySource), "repository:") {
+		return nil
+	}
+	return validateRepositoryCommitBundleForCheckout(repository, bundle)
 }

--- a/internal/controlservice/repository_policy.go
+++ b/internal/controlservice/repository_policy.go
@@ -193,6 +193,9 @@ func gitShowFileAtCommit(ctx context.Context, repoDir, commitSHA, path string) (
 		if message == "" {
 			message = err.Error()
 		}
+		if isGitShowFileMissingError(message, path) {
+			return nil, repositorystore.NewFileNotFoundError(commitSHA, path)
+		}
 		return nil, fmt.Errorf("git show %s:%s: %s", strings.TrimSpace(commitSHA), path, message)
 	}
 	return output, nil
@@ -213,11 +216,17 @@ func gitOutputContext(ctx context.Context, repoDir string, args ...string) (stri
 }
 
 func isRepositoryFileMissingError(err error) bool {
-	if err == nil {
+	return errors.Is(err, repositorystore.ErrFileNotFound)
+}
+
+func isGitShowFileMissingError(message, path string) bool {
+	message = strings.ToLower(strings.TrimSpace(message))
+	path = strings.ToLower(strings.TrimSpace(path))
+	if path == "" {
 		return false
 	}
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "does not exist") ||
-		strings.Contains(message, "exists on disk, but not in") ||
-		strings.Contains(message, "pathspec")
+	quotedPath := "'" + path + "'"
+	return strings.Contains(message, "path "+quotedPath+" does not exist") ||
+		strings.Contains(message, "path "+quotedPath+" exists on disk, but not in") ||
+		strings.Contains(message, "pathspec "+quotedPath)
 }

--- a/internal/controlservice/repository_policy.go
+++ b/internal/controlservice/repository_policy.go
@@ -1,0 +1,150 @@
+package controlservice
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
+	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorycheckout"
+	"github.com/buildkite/cleanroom/internal/repositorystore"
+)
+
+func (s *Service) resolveCreateSandboxPolicy(ctx context.Context, pb *cleanroomv1.Policy, repository *repositorycheckout.Checkout) (*policy.CompiledPolicy, string, *repositorycheckout.Checkout, error) {
+	if pb != nil {
+		compiled, err := policy.FromCreateRequestProto(pb)
+		if err != nil {
+			return nil, "", nil, fmt.Errorf("invalid policy: %w", err)
+		}
+		return compiled, "", repository, nil
+	}
+	if repository == nil {
+		return nil, "", nil, errors.New("missing policy")
+	}
+	return s.resolveRepositoryCreateSandboxPolicy(ctx, repository)
+}
+
+func (s *Service) resolveRepositoryCreateSandboxPolicy(ctx context.Context, repository *repositorycheckout.Checkout) (*policy.CompiledPolicy, string, *repositorycheckout.Checkout, error) {
+	if s.RepositoryStore == nil {
+		return nil, "", nil, errors.New("repository checkout without policy requires repository store")
+	}
+	resolvedRepository := cloneRepositoryCheckout(repository)
+	if _, err := resolvedRepository.NormalizeRemoteURL(); err != nil {
+		return nil, "", nil, err
+	}
+	if err := s.resolveRepositoryCheckoutCommit(ctx, resolvedRepository); err != nil {
+		return nil, "", nil, err
+	}
+
+	compiled, source, repositoryConfig, err := s.loadRepositoryPolicyAtCommit(ctx, resolvedRepository)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	if repositoryConfig.Enabled() {
+		if strings.TrimSpace(repositoryConfig.Path) != "" {
+			resolvedRepository.DestinationDir = repositoryConfig.Path
+		}
+		resolvedRepository.Submodules = repositoryConfig.Submodules
+	}
+	return compiled, "repository:" + source, resolvedRepository, nil
+}
+
+func (s *Service) resolveRepositoryCheckoutCommit(ctx context.Context, repository *repositorycheckout.Checkout) error {
+	if commitSHA, ok := normalizeRepositoryCommitSHA(repository.CommitSHA); ok {
+		repository.CommitSHA = commitSHA
+		return nil
+	}
+	if strings.TrimSpace(repository.CommitSHA) != "" {
+		return fmt.Errorf("repository commit_sha %q must be a full 40-character hexadecimal commit SHA", strings.TrimSpace(repository.CommitSHA))
+	}
+	return s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, "", repositorystore.FetchHints{}, func(repoDir string) error {
+		branch := strings.TrimSpace(repository.Branch)
+		if branch != "" {
+			if err := validateRepositoryBranch(ctx, repoDir, branch); err != nil {
+				return err
+			}
+			commitSHA, err := gitOutputContext(ctx, repoDir, "rev-parse", "--verify", "refs/heads/"+branch+"^{commit}")
+			if err != nil {
+				return fmt.Errorf("resolve repository branch %q: %w", branch, err)
+			}
+			repository.CommitSHA = commitSHA
+			repository.Branch = branch
+			return nil
+		}
+
+		if headBranch, err := gitOutputContext(ctx, repoDir, "symbolic-ref", "--quiet", "--short", "HEAD"); err == nil {
+			repository.Branch = strings.TrimSpace(headBranch)
+		}
+		commitSHA, err := gitOutputContext(ctx, repoDir, "rev-parse", "--verify", "HEAD^{commit}")
+		if err != nil {
+			return fmt.Errorf("resolve repository HEAD: %w", err)
+		}
+		repository.CommitSHA = commitSHA
+		return nil
+	})
+}
+
+func (s *Service) loadRepositoryPolicyAtCommit(ctx context.Context, repository *repositorycheckout.Checkout) (*policy.CompiledPolicy, string, policy.RepositoryConfig, error) {
+	for _, path := range []string{policy.PrimaryPolicyPath, policy.FallbackPolicyPath} {
+		content, err := s.RepositoryStore.ReadFileAtCommit(ctx, repository.RemoteURL, repository.CommitSHA, path)
+		if err != nil {
+			if isRepositoryFileMissingError(err) {
+				continue
+			}
+			return nil, "", policy.RepositoryConfig{}, fmt.Errorf("read repository policy %s: %w", path, err)
+		}
+		compiled, repositoryConfig, err := policy.CompileBytesWithRepositoryConfig(content, path)
+		if err != nil {
+			return nil, path, policy.RepositoryConfig{}, err
+		}
+		return compiled, path, repositoryConfig, nil
+	}
+	return nil, "", policy.RepositoryConfig{}, fmt.Errorf("%w: expected %s or %s in repository %s at %s", policy.ErrPolicyNotFound, policy.PrimaryPolicyPath, policy.FallbackPolicyPath, repository.RemoteURL, repository.CommitSHA)
+}
+
+func normalizeRepositoryCommitSHA(revision string) (string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(revision))
+	if len(normalized) != 40 {
+		return "", false
+	}
+	if _, err := hex.DecodeString(normalized); err != nil {
+		return "", false
+	}
+	return normalized, true
+}
+
+func validateRepositoryBranch(ctx context.Context, repoDir, branch string) error {
+	if _, err := gitOutputContext(ctx, repoDir, "check-ref-format", "--branch", branch); err != nil {
+		return fmt.Errorf("invalid repository branch %q: %w", branch, err)
+	}
+	return nil
+}
+
+func gitOutputContext(ctx context.Context, repoDir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repoDir}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return "", errors.New(message)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func isRepositoryFileMissingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "does not exist") ||
+		strings.Contains(message, "exists on disk, but not in") ||
+		strings.Contains(message, "pathspec")
+}

--- a/internal/controlservice/repository_policy.go
+++ b/internal/controlservice/repository_policy.go
@@ -11,11 +11,12 @@ import (
 
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/policy"
+	"github.com/buildkite/cleanroom/internal/repositorybundle"
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 	"github.com/buildkite/cleanroom/internal/repositorystore"
 )
 
-func (s *Service) resolveCreateSandboxPolicy(ctx context.Context, pb *cleanroomv1.Policy, repository *repositorycheckout.Checkout) (*policy.CompiledPolicy, string, *repositorycheckout.Checkout, error) {
+func (s *Service) resolveCreateSandboxPolicy(ctx context.Context, pb *cleanroomv1.Policy, repository *repositorycheckout.Checkout, commitBundle *repositorybundle.Bundle) (*policy.CompiledPolicy, string, *repositorycheckout.Checkout, error) {
 	if pb != nil {
 		compiled, err := policy.FromCreateRequestProto(pb)
 		if err != nil {
@@ -26,10 +27,10 @@ func (s *Service) resolveCreateSandboxPolicy(ctx context.Context, pb *cleanroomv
 	if repository == nil {
 		return nil, "", nil, errors.New("missing policy")
 	}
-	return s.resolveRepositoryCreateSandboxPolicy(ctx, repository)
+	return s.resolveRepositoryCreateSandboxPolicy(ctx, repository, commitBundle)
 }
 
-func (s *Service) resolveRepositoryCreateSandboxPolicy(ctx context.Context, repository *repositorycheckout.Checkout) (*policy.CompiledPolicy, string, *repositorycheckout.Checkout, error) {
+func (s *Service) resolveRepositoryCreateSandboxPolicy(ctx context.Context, repository *repositorycheckout.Checkout, commitBundle *repositorybundle.Bundle) (*policy.CompiledPolicy, string, *repositorycheckout.Checkout, error) {
 	if s.RepositoryStore == nil {
 		return nil, "", nil, errors.New("repository checkout without policy requires repository store")
 	}
@@ -37,11 +38,17 @@ func (s *Service) resolveRepositoryCreateSandboxPolicy(ctx context.Context, repo
 	if _, err := resolvedRepository.NormalizeRemoteURL(); err != nil {
 		return nil, "", nil, err
 	}
+	if commitBundle != nil && strings.TrimSpace(resolvedRepository.CommitSHA) == "" {
+		resolvedRepository.CommitSHA = strings.ToLower(strings.TrimSpace(commitBundle.TargetCommitSHA))
+	}
 	if err := s.resolveRepositoryCheckoutCommit(ctx, resolvedRepository); err != nil {
 		return nil, "", nil, err
 	}
+	if err := validateRepositoryCommitBundleForCheckout(resolvedRepository, commitBundle); err != nil {
+		return nil, "", nil, err
+	}
 
-	compiled, source, repositoryConfig, err := s.loadRepositoryPolicyAtCommit(ctx, resolvedRepository)
+	compiled, source, repositoryConfig, err := s.loadRepositoryPolicy(ctx, resolvedRepository, commitBundle)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -64,8 +71,15 @@ func (s *Service) resolveRepositoryCheckoutCommit(ctx context.Context, repositor
 	if strings.TrimSpace(repository.CommitSHA) != "" {
 		return fmt.Errorf("repository commit_sha %q must be a full 40-character hexadecimal commit SHA", strings.TrimSpace(repository.CommitSHA))
 	}
-	return s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, "", repositorystore.FetchHints{}, func(repoDir string) error {
-		branch := strings.TrimSpace(repository.Branch)
+	branch := strings.TrimSpace(repository.Branch)
+	hints := repositorystore.FetchHints{}
+	if branch != "" {
+		hints.Branches = []string{branch}
+	}
+	if err := s.RepositoryStore.Refresh(ctx, repository.RemoteURL, hints); err != nil {
+		return err
+	}
+	return s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, "", hints, func(repoDir string) error {
 		if branch != "" {
 			if err := validateRepositoryBranch(ctx, repoDir, branch); err != nil {
 				return err
@@ -91,9 +105,48 @@ func (s *Service) resolveRepositoryCheckoutCommit(ctx context.Context, repositor
 	})
 }
 
+func (s *Service) loadRepositoryPolicy(ctx context.Context, repository *repositorycheckout.Checkout, commitBundle *repositorybundle.Bundle) (*policy.CompiledPolicy, string, policy.RepositoryConfig, error) {
+	if commitBundle != nil {
+		return s.loadRepositoryPolicyFromCommitBundle(ctx, repository, commitBundle)
+	}
+	return s.loadRepositoryPolicyAtCommit(ctx, repository)
+}
+
 func (s *Service) loadRepositoryPolicyAtCommit(ctx context.Context, repository *repositorycheckout.Checkout) (*policy.CompiledPolicy, string, policy.RepositoryConfig, error) {
+	return loadRepositoryPolicyFiles(func(path string) ([]byte, error) {
+		return s.RepositoryStore.ReadFileAtCommit(ctx, repository.RemoteURL, repository.CommitSHA, path)
+	}, repositoryPolicyNotFoundError(repository))
+}
+
+func (s *Service) loadRepositoryPolicyFromCommitBundle(ctx context.Context, repository *repositorycheckout.Checkout, commitBundle *repositorybundle.Bundle) (*policy.CompiledPolicy, string, policy.RepositoryConfig, error) {
+	prerequisiteCommit, err := s.ensureRepositoryCommitBundlePrerequisites(ctx, repository, commitBundle)
+	if err != nil {
+		return nil, "", policy.RepositoryConfig{}, err
+	}
+
+	var (
+		compiled         *policy.CompiledPolicy
+		source           string
+		repositoryConfig policy.RepositoryConfig
+	)
+	err = s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, prerequisiteCommit, repositorystore.FetchHints{}, func(repoDir string) error {
+		return commitBundle.WithRepository(ctx, repoDir, func(bundleRepoDir string) error {
+			var err error
+			compiled, source, repositoryConfig, err = loadRepositoryPolicyFiles(func(path string) ([]byte, error) {
+				return gitShowFileAtCommit(ctx, bundleRepoDir, commitBundle.TargetCommitSHA, path)
+			}, repositoryPolicyNotFoundError(repository))
+			return err
+		})
+	})
+	if err != nil {
+		return nil, "", policy.RepositoryConfig{}, err
+	}
+	return compiled, source, repositoryConfig, nil
+}
+
+func loadRepositoryPolicyFiles(readFile func(path string) ([]byte, error), notFound error) (*policy.CompiledPolicy, string, policy.RepositoryConfig, error) {
 	for _, path := range []string{policy.PrimaryPolicyPath, policy.FallbackPolicyPath} {
-		content, err := s.RepositoryStore.ReadFileAtCommit(ctx, repository.RemoteURL, repository.CommitSHA, path)
+		content, err := readFile(path)
 		if err != nil {
 			if isRepositoryFileMissingError(err) {
 				continue
@@ -106,7 +159,11 @@ func (s *Service) loadRepositoryPolicyAtCommit(ctx context.Context, repository *
 		}
 		return compiled, path, repositoryConfig, nil
 	}
-	return nil, "", policy.RepositoryConfig{}, fmt.Errorf("%w: expected %s or %s in repository %s at %s", policy.ErrPolicyNotFound, policy.PrimaryPolicyPath, policy.FallbackPolicyPath, repository.RemoteURL, repository.CommitSHA)
+	return nil, "", policy.RepositoryConfig{}, notFound
+}
+
+func repositoryPolicyNotFoundError(repository *repositorycheckout.Checkout) error {
+	return fmt.Errorf("%w: expected %s or %s in repository %s at %s", policy.ErrPolicyNotFound, policy.PrimaryPolicyPath, policy.FallbackPolicyPath, repository.RemoteURL, repository.CommitSHA)
 }
 
 func normalizeRepositoryCommitSHA(revision string) (string, bool) {
@@ -125,6 +182,20 @@ func validateRepositoryBranch(ctx context.Context, repoDir, branch string) error
 		return fmt.Errorf("invalid repository branch %q: %w", branch, err)
 	}
 	return nil
+}
+
+func gitShowFileAtCommit(ctx context.Context, repoDir, commitSHA, path string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "show", strings.TrimSpace(commitSHA)+":"+path)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("git show %s:%s: %s", strings.TrimSpace(commitSHA), path, message)
+	}
+	return output, nil
 }
 
 func gitOutputContext(ctx context.Context, repoDir string, args ...string) (string, error) {

--- a/internal/controlservice/repository_policy.go
+++ b/internal/controlservice/repository_policy.go
@@ -85,7 +85,7 @@ func (s *Service) resolveRepositoryCheckoutCommit(ctx context.Context, repositor
 			}
 		}
 		return s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, branchValidationCommits[0], hints, func(repoDir string) error {
-			if err := validateRepositoryBranchContainsAnyCommit(ctx, repoDir, branch, branchValidationCommits); err != nil {
+			if err := validateRepositoryBranchContainsAllCommits(ctx, repoDir, branch, branchValidationCommits); err != nil {
 				return err
 			}
 			repository.Branch = branch
@@ -224,10 +224,10 @@ func validateRepositoryBranch(ctx context.Context, repoDir, branch string) error
 }
 
 func validateRepositoryBranchContainsCommit(ctx context.Context, repoDir, branch, commitSHA string) error {
-	return validateRepositoryBranchContainsAnyCommit(ctx, repoDir, branch, []string{commitSHA})
+	return validateRepositoryBranchContainsAllCommits(ctx, repoDir, branch, []string{commitSHA})
 }
 
-func validateRepositoryBranchContainsAnyCommit(ctx context.Context, repoDir, branch string, commitSHAs []string) error {
+func validateRepositoryBranchContainsAllCommits(ctx context.Context, repoDir, branch string, commitSHAs []string) error {
 	if err := validateRepositoryBranch(ctx, repoDir, branch); err != nil {
 		return err
 	}
@@ -236,11 +236,15 @@ func validateRepositoryBranchContainsAnyCommit(ctx context.Context, repoDir, bra
 		return fmt.Errorf("resolve repository branch %q: %w", branch, err)
 	}
 	for _, commitSHA := range commitSHAs {
-		if _, err := gitOutputContext(ctx, repoDir, "merge-base", "--is-ancestor", commitSHA, branchCommit); err == nil {
-			return nil
+		commitSHA = strings.TrimSpace(commitSHA)
+		if commitSHA == "" {
+			return fmt.Errorf("repository branch %q validation commit is empty", branch)
+		}
+		if _, err := gitOutputContext(ctx, repoDir, "merge-base", "--is-ancestor", commitSHA, branchCommit); err != nil {
+			return fmt.Errorf("repository branch %q does not contain commit %s", branch, commitSHA)
 		}
 	}
-	return fmt.Errorf("repository branch %q does not contain any candidate commit", branch)
+	return nil
 }
 
 func gitShowFileAtCommit(ctx context.Context, repoDir, commitSHA, path string) ([]byte, error) {

--- a/internal/controlservice/repository_policy.go
+++ b/internal/controlservice/repository_policy.go
@@ -50,6 +50,8 @@ func (s *Service) resolveRepositoryCreateSandboxPolicy(ctx context.Context, repo
 			resolvedRepository.DestinationDir = repositoryConfig.Path
 		}
 		resolvedRepository.Submodules = repositoryConfig.Submodules
+	} else {
+		resolvedRepository = nil
 	}
 	return compiled, "repository:" + source, resolvedRepository, nil
 }

--- a/internal/controlservice/repository_policy.go
+++ b/internal/controlservice/repository_policy.go
@@ -16,42 +16,43 @@ import (
 	"github.com/buildkite/cleanroom/internal/repositorystore"
 )
 
-func (s *Service) resolveCreateSandboxPolicy(ctx context.Context, pb *cleanroomv1.Policy, repository *repositorycheckout.Checkout, commitBundle *repositorybundle.Bundle) (*policy.CompiledPolicy, string, *repositorycheckout.Checkout, error) {
+func (s *Service) resolveCreateSandboxPolicy(ctx context.Context, pb *cleanroomv1.Policy, repository *repositorycheckout.Checkout, commitBundle *repositorybundle.Bundle) (*policy.CompiledPolicy, string, *repositorycheckout.Checkout, *repositorycheckout.Checkout, error) {
 	if pb != nil {
 		compiled, err := policy.FromCreateRequestProto(pb)
 		if err != nil {
-			return nil, "", nil, fmt.Errorf("invalid policy: %w", err)
+			return nil, "", nil, nil, fmt.Errorf("invalid policy: %w", err)
 		}
-		return compiled, "", repository, nil
+		return compiled, "", repository, repository, nil
 	}
 	if repository == nil {
-		return nil, "", nil, errors.New("missing policy")
+		return nil, "", nil, nil, errors.New("missing policy")
 	}
 	return s.resolveRepositoryCreateSandboxPolicy(ctx, repository, commitBundle)
 }
 
-func (s *Service) resolveRepositoryCreateSandboxPolicy(ctx context.Context, repository *repositorycheckout.Checkout, commitBundle *repositorybundle.Bundle) (*policy.CompiledPolicy, string, *repositorycheckout.Checkout, error) {
+func (s *Service) resolveRepositoryCreateSandboxPolicy(ctx context.Context, repository *repositorycheckout.Checkout, commitBundle *repositorybundle.Bundle) (*policy.CompiledPolicy, string, *repositorycheckout.Checkout, *repositorycheckout.Checkout, error) {
 	if s.RepositoryStore == nil {
-		return nil, "", nil, errors.New("repository checkout without policy requires repository store")
+		return nil, "", nil, nil, errors.New("repository checkout without policy requires repository store")
 	}
 	resolvedRepository := cloneRepositoryCheckout(repository)
 	if _, err := resolvedRepository.NormalizeRemoteURL(); err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, nil, err
 	}
 	if commitBundle != nil && strings.TrimSpace(resolvedRepository.CommitSHA) == "" {
 		resolvedRepository.CommitSHA = strings.ToLower(strings.TrimSpace(commitBundle.TargetCommitSHA))
 	}
 	if err := s.resolveRepositoryCheckoutCommit(ctx, resolvedRepository, commitBundle); err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, nil, err
 	}
 	if err := validateRepositoryCommitBundleForCheckout(resolvedRepository, commitBundle); err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, nil, err
 	}
 
 	compiled, source, repositoryConfig, err := s.loadRepositoryPolicy(ctx, resolvedRepository, commitBundle)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, nil, err
 	}
+	authorizationRepository := cloneRepositoryCheckout(resolvedRepository)
 	if repositoryConfig.Enabled() {
 		if strings.TrimSpace(repositoryConfig.Path) != "" {
 			resolvedRepository.DestinationDir = repositoryConfig.Path
@@ -60,7 +61,7 @@ func (s *Service) resolveRepositoryCreateSandboxPolicy(ctx context.Context, repo
 	} else {
 		resolvedRepository = nil
 	}
-	return compiled, "repository:" + source, resolvedRepository, nil
+	return compiled, "repository:" + source, resolvedRepository, authorizationRepository, nil
 }
 
 func (s *Service) resolveRepositoryCheckoutCommit(ctx context.Context, repository *repositorycheckout.Checkout, commitBundle *repositorybundle.Bundle) error {
@@ -70,7 +71,7 @@ func (s *Service) resolveRepositoryCheckoutCommit(ctx context.Context, repositor
 		if branch == "" {
 			return nil
 		}
-		branchValidationCommit, err := repositoryBranchValidationCommit(commitSHA, commitBundle)
+		branchValidationCommits, err := repositoryBranchValidationCommits(commitSHA, commitBundle)
 		if err != nil {
 			return err
 		}
@@ -78,8 +79,13 @@ func (s *Service) resolveRepositoryCheckoutCommit(ctx context.Context, repositor
 		if err := s.RepositoryStore.Refresh(ctx, repository.RemoteURL, hints); err != nil {
 			return err
 		}
-		return s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, branchValidationCommit, hints, func(repoDir string) error {
-			if err := validateRepositoryBranchContainsCommit(ctx, repoDir, branch, branchValidationCommit); err != nil {
+		for _, branchValidationCommit := range branchValidationCommits {
+			if err := s.RepositoryStore.EnsureCommit(ctx, repository.RemoteURL, branchValidationCommit, hints); err != nil {
+				return err
+			}
+		}
+		return s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, branchValidationCommits[0], hints, func(repoDir string) error {
+			if err := validateRepositoryBranchContainsAnyCommit(ctx, repoDir, branch, branchValidationCommits); err != nil {
 				return err
 			}
 			repository.Branch = branch
@@ -123,19 +129,19 @@ func (s *Service) resolveRepositoryCheckoutCommit(ctx context.Context, repositor
 	})
 }
 
-func repositoryBranchValidationCommit(commitSHA string, commitBundle *repositorybundle.Bundle) (string, error) {
+func repositoryBranchValidationCommits(commitSHA string, commitBundle *repositorybundle.Bundle) ([]string, error) {
 	commitSHA = strings.ToLower(strings.TrimSpace(commitSHA))
 	if commitBundle == nil || !strings.EqualFold(strings.TrimSpace(commitBundle.TargetCommitSHA), commitSHA) {
-		return commitSHA, nil
+		return []string{commitSHA}, nil
 	}
 	prerequisites, err := commitBundle.PrerequisiteCommits()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if len(prerequisites) == 0 {
-		return commitSHA, nil
+		return []string{commitSHA}, nil
 	}
-	return prerequisites[0], nil
+	return prerequisites, nil
 }
 
 func (s *Service) loadRepositoryPolicy(ctx context.Context, repository *repositorycheckout.Checkout, commitBundle *repositorybundle.Bundle) (*policy.CompiledPolicy, string, policy.RepositoryConfig, error) {
@@ -218,6 +224,10 @@ func validateRepositoryBranch(ctx context.Context, repoDir, branch string) error
 }
 
 func validateRepositoryBranchContainsCommit(ctx context.Context, repoDir, branch, commitSHA string) error {
+	return validateRepositoryBranchContainsAnyCommit(ctx, repoDir, branch, []string{commitSHA})
+}
+
+func validateRepositoryBranchContainsAnyCommit(ctx context.Context, repoDir, branch string, commitSHAs []string) error {
 	if err := validateRepositoryBranch(ctx, repoDir, branch); err != nil {
 		return err
 	}
@@ -225,10 +235,12 @@ func validateRepositoryBranchContainsCommit(ctx context.Context, repoDir, branch
 	if err != nil {
 		return fmt.Errorf("resolve repository branch %q: %w", branch, err)
 	}
-	if _, err := gitOutputContext(ctx, repoDir, "merge-base", "--is-ancestor", commitSHA, branchCommit); err != nil {
-		return fmt.Errorf("repository commit %q is not reachable from branch %q", commitSHA, branch)
+	for _, commitSHA := range commitSHAs {
+		if _, err := gitOutputContext(ctx, repoDir, "merge-base", "--is-ancestor", commitSHA, branchCommit); err == nil {
+			return nil
+		}
 	}
-	return nil
+	return fmt.Errorf("repository branch %q does not contain any candidate commit", branch)
 }
 
 func gitShowFileAtCommit(ctx context.Context, repoDir, commitSHA, path string) ([]byte, error) {

--- a/internal/controlservice/repository_policy.go
+++ b/internal/controlservice/repository_policy.go
@@ -41,7 +41,7 @@ func (s *Service) resolveRepositoryCreateSandboxPolicy(ctx context.Context, repo
 	if commitBundle != nil && strings.TrimSpace(resolvedRepository.CommitSHA) == "" {
 		resolvedRepository.CommitSHA = strings.ToLower(strings.TrimSpace(commitBundle.TargetCommitSHA))
 	}
-	if err := s.resolveRepositoryCheckoutCommit(ctx, resolvedRepository); err != nil {
+	if err := s.resolveRepositoryCheckoutCommit(ctx, resolvedRepository, commitBundle); err != nil {
 		return nil, "", nil, err
 	}
 	if err := validateRepositoryCommitBundleForCheckout(resolvedRepository, commitBundle); err != nil {
@@ -63,19 +63,23 @@ func (s *Service) resolveRepositoryCreateSandboxPolicy(ctx context.Context, repo
 	return compiled, "repository:" + source, resolvedRepository, nil
 }
 
-func (s *Service) resolveRepositoryCheckoutCommit(ctx context.Context, repository *repositorycheckout.Checkout) error {
+func (s *Service) resolveRepositoryCheckoutCommit(ctx context.Context, repository *repositorycheckout.Checkout, commitBundle *repositorybundle.Bundle) error {
 	if commitSHA, ok := normalizeRepositoryCommitSHA(repository.CommitSHA); ok {
 		repository.CommitSHA = commitSHA
 		branch := strings.TrimSpace(repository.Branch)
 		if branch == "" {
 			return nil
 		}
+		branchValidationCommit, err := repositoryBranchValidationCommit(commitSHA, commitBundle)
+		if err != nil {
+			return err
+		}
 		hints := repositorystore.FetchHints{Branches: []string{branch}}
 		if err := s.RepositoryStore.Refresh(ctx, repository.RemoteURL, hints); err != nil {
 			return err
 		}
-		return s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, commitSHA, hints, func(repoDir string) error {
-			if err := validateRepositoryBranchContainsCommit(ctx, repoDir, branch, commitSHA); err != nil {
+		return s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, branchValidationCommit, hints, func(repoDir string) error {
+			if err := validateRepositoryBranchContainsCommit(ctx, repoDir, branch, branchValidationCommit); err != nil {
 				return err
 			}
 			repository.Branch = branch
@@ -117,6 +121,21 @@ func (s *Service) resolveRepositoryCheckoutCommit(ctx context.Context, repositor
 		repository.CommitSHA = commitSHA
 		return nil
 	})
+}
+
+func repositoryBranchValidationCommit(commitSHA string, commitBundle *repositorybundle.Bundle) (string, error) {
+	commitSHA = strings.ToLower(strings.TrimSpace(commitSHA))
+	if commitBundle == nil || !strings.EqualFold(strings.TrimSpace(commitBundle.TargetCommitSHA), commitSHA) {
+		return commitSHA, nil
+	}
+	prerequisites, err := commitBundle.PrerequisiteCommits()
+	if err != nil {
+		return "", err
+	}
+	if len(prerequisites) == 0 {
+		return commitSHA, nil
+	}
+	return prerequisites[0], nil
 }
 
 func (s *Service) loadRepositoryPolicy(ctx context.Context, repository *repositorycheckout.Checkout, commitBundle *repositorybundle.Bundle) (*policy.CompiledPolicy, string, policy.RepositoryConfig, error) {

--- a/internal/controlservice/repository_policy.go
+++ b/internal/controlservice/repository_policy.go
@@ -66,7 +66,21 @@ func (s *Service) resolveRepositoryCreateSandboxPolicy(ctx context.Context, repo
 func (s *Service) resolveRepositoryCheckoutCommit(ctx context.Context, repository *repositorycheckout.Checkout) error {
 	if commitSHA, ok := normalizeRepositoryCommitSHA(repository.CommitSHA); ok {
 		repository.CommitSHA = commitSHA
-		return nil
+		branch := strings.TrimSpace(repository.Branch)
+		if branch == "" {
+			return nil
+		}
+		hints := repositorystore.FetchHints{Branches: []string{branch}}
+		if err := s.RepositoryStore.Refresh(ctx, repository.RemoteURL, hints); err != nil {
+			return err
+		}
+		return s.RepositoryStore.WithRepository(ctx, repository.RemoteURL, commitSHA, hints, func(repoDir string) error {
+			if err := validateRepositoryBranchContainsCommit(ctx, repoDir, branch, commitSHA); err != nil {
+				return err
+			}
+			repository.Branch = branch
+			return nil
+		})
 	}
 	if strings.TrimSpace(repository.CommitSHA) != "" {
 		return fmt.Errorf("repository commit_sha %q must be a full 40-character hexadecimal commit SHA", strings.TrimSpace(repository.CommitSHA))
@@ -180,6 +194,20 @@ func normalizeRepositoryCommitSHA(revision string) (string, bool) {
 func validateRepositoryBranch(ctx context.Context, repoDir, branch string) error {
 	if _, err := gitOutputContext(ctx, repoDir, "check-ref-format", "--branch", branch); err != nil {
 		return fmt.Errorf("invalid repository branch %q: %w", branch, err)
+	}
+	return nil
+}
+
+func validateRepositoryBranchContainsCommit(ctx context.Context, repoDir, branch, commitSHA string) error {
+	if err := validateRepositoryBranch(ctx, repoDir, branch); err != nil {
+		return err
+	}
+	branchCommit, err := gitOutputContext(ctx, repoDir, "rev-parse", "--verify", "refs/heads/"+branch+"^{commit}")
+	if err != nil {
+		return fmt.Errorf("resolve repository branch %q: %w", branch, err)
+	}
+	if _, err := gitOutputContext(ctx, repoDir, "merge-base", "--is-ancestor", commitSHA, branchCommit); err != nil {
+		return fmt.Errorf("repository commit %q is not reachable from branch %q", commitSHA, branch)
 	}
 	return nil
 }

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -483,6 +483,15 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		return s.createSandboxFromSnapshot(ctx, req, snapshotID, reporter)
 	}
 	repository := repositorycheckout.FromProto(req.GetRepositoryCheckout())
+	if req.GetPolicy() == nil && repository != nil {
+		repositoryForAuth := cloneRepositoryCheckout(repository)
+		if _, err := repositoryForAuth.NormalizeRemoteURL(); err != nil {
+			return nil, err
+		}
+		if _, err := s.authorizeCreate(ctx, "sandbox.create", "sandbox", createSandboxAuthorizationRequest(backendName, nil, repositoryForAuth, changeset, "", policy.Resources{})); err != nil {
+			return nil, err
+		}
+	}
 	compiled, resolvedPolicySource, repository, err := s.resolveCreateSandboxPolicy(ctx, req.GetPolicy(), repository)
 	if err != nil {
 		return nil, err

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -488,11 +488,11 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		if _, err := repositoryForAuth.NormalizeRemoteURL(); err != nil {
 			return nil, err
 		}
-		if _, err := s.authorizeCreate(ctx, "sandbox.create", "sandbox", createSandboxAuthorizationRequest(backendName, nil, repositoryForAuth, changeset, "", policy.Resources{})); err != nil {
+		if err := s.authorizeRepositoryPolicySource(ctx, backendName, repositoryForAuth, changeset); err != nil {
 			return nil, err
 		}
 	}
-	compiled, resolvedPolicySource, repository, err := s.resolveCreateSandboxPolicy(ctx, req.GetPolicy(), repository)
+	compiled, resolvedPolicySource, repository, err := s.resolveCreateSandboxPolicy(ctx, req.GetPolicy(), repository, commitBundle)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -417,6 +417,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	snapshotID := strings.TrimSpace(req.GetSnapshotId())
 	opts := req.GetOptions()
 	metricSourceKind := ""
+	policySource := ""
 	changeset := repositoryChangesetFromProto(req.GetRepositoryChangeset())
 	commitBundle := repositoryCommitBundleFromProto(req.GetRepositoryCommitBundle())
 	backendName := resolveBackendName(strings.TrimSpace(req.GetBackend()), s.Config.DefaultBackend)
@@ -432,6 +433,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	)
 	logger := observability.WithTraceContext(s.Logger, ctx)
 	defer func() {
+		if resp != nil && policySource != "" {
+			resp.PolicySource = policySource
+		}
 		metricBackendName := backendName
 		if resp != nil && resp.GetSandbox() != nil {
 			span.SetAttributes(
@@ -478,21 +482,18 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 		}
 		return s.createSandboxFromSnapshot(ctx, req, snapshotID, reporter)
 	}
-	if req.GetPolicy() == nil {
-		return nil, errors.New("missing policy")
-	}
-
-	compiled, err := policy.FromCreateRequestProto(req.GetPolicy())
+	repository := repositorycheckout.FromProto(req.GetRepositoryCheckout())
+	compiled, resolvedPolicySource, repository, err := s.resolveCreateSandboxPolicy(ctx, req.GetPolicy(), repository)
 	if err != nil {
-		return nil, fmt.Errorf("invalid policy: %w", err)
+		return nil, err
 	}
+	policySource = resolvedPolicySource
 	if opts.GetDangerouslyAllowAllEgress() {
 		compiled, err = policy.DangerouslyAllowAllEgress(compiled)
 		if err != nil {
 			return nil, fmt.Errorf("apply dangerously allow-all egress: %w", err)
 		}
 	}
-	repository := repositorycheckout.FromProto(req.GetRepositoryCheckout())
 	if err := validateRepositoryScopedCreatePolicy(compiled, repository); err != nil {
 		return nil, err
 	}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -495,7 +495,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 			return nil, err
 		}
 	}
-	compiled, resolvedPolicySource, repository, err := s.resolveCreateSandboxPolicy(ctx, req.GetPolicy(), repository, commitBundle)
+	compiled, resolvedPolicySource, repository, authorizationRepository, err := s.resolveCreateSandboxPolicy(ctx, req.GetPolicy(), repository, commitBundle)
 	if err != nil {
 		return nil, err
 	}
@@ -541,7 +541,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	firecrackerCfg = withBackendLaunchResourceDefaults(firecrackerCfg)
 	firecrackerCfg = withRepositoryBootstrapRootFSMinimum(firecrackerCfg, compiled, repository)
 	span.SetAttributes(rootFSMinimumTraceAttributes(firecrackerCfg)...)
-	owner, err := s.authorizeCreate(ctx, "sandbox.create", "sandbox", createSandboxAuthorizationRequest(backendName, compiled, repository, changeset, "", effectiveAuthorizationResources(firecrackerCfg)))
+	owner, err := s.authorizeCreate(ctx, "sandbox.create", "sandbox", createSandboxAuthorizationRequest(backendName, compiled, authorizationRepository, changeset, "", effectiveAuthorizationResources(firecrackerCfg)))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -528,7 +528,7 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	if err := validateRepositoryChangesetForCheckout(repository, changeset); err != nil {
 		return nil, err
 	}
-	if err := validateRepositoryCommitBundleForCheckout(repository, commitBundle); err != nil {
+	if err := validateRepositoryCommitBundleForResolvedCheckout(repository, commitBundle, policySource); err != nil {
 		return nil, err
 	}
 	execOpts := executionOptions{}

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -485,6 +485,9 @@ func (s *Service) createSandbox(ctx context.Context, req *cleanroomv1.CreateSand
 	repository := repositorycheckout.FromProto(req.GetRepositoryCheckout())
 	if req.GetPolicy() == nil && repository != nil {
 		repositoryForAuth := cloneRepositoryCheckout(repository)
+		if commitBundle != nil && strings.TrimSpace(repositoryForAuth.CommitSHA) == "" {
+			repositoryForAuth.CommitSHA = strings.ToLower(strings.TrimSpace(commitBundle.TargetCommitSHA))
+		}
 		if _, err := repositoryForAuth.NormalizeRemoteURL(); err != nil {
 			return nil, err
 		}

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -366,6 +366,8 @@ type stubRepositoryMirrorStore struct {
 	mirrorPathErr             error
 	ensureMirrorCalls         int
 	ensureMirrorErr           error
+	refreshCalls              int
+	refreshErr                error
 	ensureSubmoduleMirrorFunc func(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (string, error)
 }
 
@@ -402,6 +404,22 @@ func (s *stubRepositoryMirrorStore) EnsureMirror(_ context.Context, remoteURL st
 	s.ensureMirrorCalls++
 	if s.ensureMirrorErr != nil {
 		return "", s.ensureMirrorErr
+	}
+	return s.mirrorPath, nil
+}
+
+func (s *stubRepositoryMirrorStore) Refresh(_ context.Context, remoteURL string, _ repositorystore.FetchHints) error {
+	s.remoteURL = remoteURL
+	s.refreshCalls++
+	if s.refreshErr != nil {
+		return s.refreshErr
+	}
+	return nil
+}
+
+func (s *stubRepositoryMirrorStore) RefreshMirror(ctx context.Context, remoteURL string) (string, error) {
+	if err := s.Refresh(ctx, remoteURL, repositorystore.FetchHints{}); err != nil {
+		return "", err
 	}
 	return s.mirrorPath, nil
 }
@@ -2786,6 +2804,82 @@ func TestCreateSandboxRepositoryPolicyResolvesBranch(t *testing.T) {
 	}
 	if got := repository.GetDestinationDir(); got != "/feature" {
 		t.Fatalf("unexpected destination dir: got %q", got)
+	}
+	if got := mirrors.refreshCalls; got != 1 {
+		t.Fatalf("expected one mirror refresh before resolving branch, got %d", got)
+	}
+}
+
+func TestCreateSandboxLoadsRepositoryPolicyFromCommitBundle(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"README.md":      "hello\n",
+		"cleanroom.yaml": testRepositoryPolicyYAML("/base", false, true),
+	})
+	baseCommit := repositoryCheckout.GetCommitSha()
+
+	localRepo := filepath.Join(t.TempDir(), "local")
+	runTestGit(t, t.TempDir(), "clone", mirrors.mirrorPath, localRepo)
+	runTestGit(t, localRepo, "config", "user.email", "test@example.com")
+	runTestGit(t, localRepo, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(localRepo, "cleanroom.yaml"), []byte(testRepositoryPolicyYAML("/bundle", true, true)), 0o644); err != nil {
+		t.Fatalf("WriteFile(cleanroom.yaml) returned error: %v", err)
+	}
+	runTestGit(t, localRepo, "add", "cleanroom.yaml")
+	runTestGit(t, localRepo, "commit", "-m", "local policy")
+	localCommit := strings.TrimSpace(runTestGit(t, localRepo, "rev-parse", "HEAD"))
+
+	commitBundle, err := repositorybundle.BuildFromRepository(localRepo, "origin", &repositorycheckout.Checkout{CommitSHA: localCommit})
+	if err != nil {
+		t.Fatalf("BuildFromRepository returned error: %v", err)
+	}
+	if commitBundle == nil {
+		t.Fatal("expected repository commit bundle")
+	}
+	repositoryCheckout.CommitSha = localCommit
+	repositoryCheckout.DestinationDir = ""
+	mirrors.ensureContainsFn = func(_ string, commitSHA string) error {
+		switch strings.TrimSpace(commitSHA) {
+		case baseCommit:
+			return nil
+		case localCommit:
+			return errors.New("local-only commit should be supplied by commit bundle")
+		default:
+			return fmt.Errorf("unexpected mirror commit %q", commitSHA)
+		}
+	}
+
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+
+	resp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout:     repositoryCheckout,
+		RepositoryCommitBundle: commitBundle.ToProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetPolicySource(), "repository:cleanroom.yaml"; got != want {
+		t.Fatalf("unexpected policy source: got %q want %q", got, want)
+	}
+	repository := resp.GetSandbox().GetRepositoryCheckout()
+	if repository == nil {
+		t.Fatal("expected repository checkout on sandbox")
+	}
+	if got := repository.GetCommitSha(); got != localCommit {
+		t.Fatalf("unexpected resolved commit: got %q want %q", got, localCommit)
+	}
+	if got := repository.GetDestinationDir(); got != "/bundle" {
+		t.Fatalf("unexpected destination dir: got %q", got)
+	}
+	if !repository.GetSubmodules() {
+		t.Fatal("expected repository submodules to come from bundled policy")
+	}
+	if !slices.Contains(mirrors.commitSHAs, baseCommit) {
+		t.Fatalf("expected bundle prerequisite %q to be ensured, got %v", baseCommit, mirrors.commitSHAs)
+	}
+	if slices.Contains(mirrors.commitSHAs, localCommit) {
+		t.Fatalf("expected local-only commit %q to avoid direct mirror ensure, got %v", localCommit, mirrors.commitSHAs)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -434,6 +434,9 @@ func (s *stubRepositoryMirrorStore) ReadFileAtCommit(ctx context.Context, remote
 			if message == "" {
 				message = err.Error()
 			}
+			if isGitShowFileMissingError(message, path) {
+				return repositorystore.NewFileNotFoundError(commitSHA, path)
+			}
 			return errors.New(message)
 		}
 		content = output
@@ -2921,6 +2924,32 @@ func TestCreateSandboxRepositoryPolicyRequiresRepositoryStore(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "requires repository store") {
 		t.Fatalf("expected repository store error, got %v", err)
+	}
+}
+
+func TestCreateSandboxRepositoryPolicyPreservesRepositoryAccessError(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors := &stubRepositoryMirrorStore{
+		mirrorPathErr:   errors.New("no cached mirror"),
+		ensureMirrorErr: errors.New("repository https://github.com/buildkite/missing.git does not exist"),
+	}
+	repositoryCheckout := testRepositoryCheckoutProto()
+	repositoryCheckout.RemoteUrl = "https://github.com/buildkite/missing.git"
+
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+
+	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err == nil {
+		t.Fatal("expected CreateSandbox to fail")
+	}
+	if !strings.Contains(err.Error(), "repository https://github.com/buildkite/missing.git does not exist") {
+		t.Fatalf("expected repository access error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "policy not found") {
+		t.Fatalf("expected repository access error to be preserved, got %v", err)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2835,7 +2835,7 @@ func TestCreateSandboxRepositoryPolicyRejectsCommitOutsideBranch(t *testing.T) {
 	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		RepositoryCheckout: repositoryCheckout,
 	})
-	if err == nil || !strings.Contains(err.Error(), "does not contain any candidate commit") {
+	if err == nil || !strings.Contains(err.Error(), "does not contain commit") {
 		t.Fatalf("CreateSandbox error = %v, want commit outside branch error", err)
 	}
 	if got := adapter.provisionCalls; got != 0 {
@@ -2843,7 +2843,7 @@ func TestCreateSandboxRepositoryPolicyRejectsCommitOutsideBranch(t *testing.T) {
 	}
 }
 
-func TestValidateRepositoryBranchContainsAnyCommitAcceptsReachableCandidate(t *testing.T) {
+func TestValidateRepositoryBranchContainsAllCommitsRejectsUnreachableCandidate(t *testing.T) {
 	repoDir := t.TempDir()
 	runTestGit(t, repoDir, "init")
 	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
@@ -2863,8 +2863,9 @@ func TestValidateRepositoryBranchContainsAnyCommitAcceptsReachableCandidate(t *t
 	runTestGit(t, repoDir, "commit", "-m", "feature")
 	featureCommit := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
 
-	if err := validateRepositoryBranchContainsAnyCommit(context.Background(), repoDir, mainBranch, []string{featureCommit, mainCommit}); err != nil {
-		t.Fatalf("validateRepositoryBranchContainsAnyCommit returned error: %v", err)
+	err := validateRepositoryBranchContainsAllCommits(context.Background(), repoDir, mainBranch, []string{featureCommit, mainCommit})
+	if err == nil || !strings.Contains(err.Error(), "does not contain commit "+featureCommit) {
+		t.Fatalf("validateRepositoryBranchContainsAllCommits error = %v, want unreachable candidate error", err)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2886,6 +2886,63 @@ func TestCreateSandboxLoadsRepositoryPolicyFromCommitBundle(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxLoadsDisabledRepositoryPolicyFromCommitBundle(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"README.md":      "hello\n",
+		"cleanroom.yaml": testRepositoryPolicyYAML("/base", false, true),
+	})
+	baseCommit := repositoryCheckout.GetCommitSha()
+
+	localRepo := filepath.Join(t.TempDir(), "local")
+	runTestGit(t, t.TempDir(), "clone", mirrors.mirrorPath, localRepo)
+	runTestGit(t, localRepo, "config", "user.email", "test@example.com")
+	runTestGit(t, localRepo, "config", "user.name", "Test User")
+	disabledPolicy := strings.ReplaceAll(testRepositoryPolicyYAML("/bundle", false, true), "  path: /bundle\n  submodules: false", "  enabled: false")
+	if err := os.WriteFile(filepath.Join(localRepo, "cleanroom.yaml"), []byte(disabledPolicy), 0o644); err != nil {
+		t.Fatalf("WriteFile(cleanroom.yaml) returned error: %v", err)
+	}
+	runTestGit(t, localRepo, "add", "cleanroom.yaml")
+	runTestGit(t, localRepo, "commit", "-m", "disable checkout")
+	localCommit := strings.TrimSpace(runTestGit(t, localRepo, "rev-parse", "HEAD"))
+
+	commitBundle, err := repositorybundle.BuildFromRepository(localRepo, "origin", &repositorycheckout.Checkout{CommitSHA: localCommit})
+	if err != nil {
+		t.Fatalf("BuildFromRepository returned error: %v", err)
+	}
+	if commitBundle == nil {
+		t.Fatal("expected repository commit bundle")
+	}
+	repositoryCheckout.CommitSha = localCommit
+	repositoryCheckout.DestinationDir = ""
+	mirrors.ensureContainsFn = func(_ string, commitSHA string) error {
+		if strings.TrimSpace(commitSHA) != baseCommit {
+			return fmt.Errorf("unexpected mirror commit %q", commitSHA)
+		}
+		return nil
+	}
+
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+
+	resp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout:     repositoryCheckout,
+		RepositoryCommitBundle: commitBundle.ToProto(),
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetPolicySource(), "repository:cleanroom.yaml"; got != want {
+		t.Fatalf("unexpected policy source: got %q want %q", got, want)
+	}
+	if repository := resp.GetSandbox().GetRepositoryCheckout(); repository != nil {
+		t.Fatalf("expected repository bootstrap to be disabled, got %#v", repository)
+	}
+	if got := adapter.runCalls; got != 0 {
+		t.Fatalf("expected no repository bootstrap execution, got %d", got)
+	}
+}
+
 func TestCreateSandboxRepositoryPolicyHonorsDisabledRepositoryBootstrap(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2835,11 +2835,36 @@ func TestCreateSandboxRepositoryPolicyRejectsCommitOutsideBranch(t *testing.T) {
 	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
 		RepositoryCheckout: repositoryCheckout,
 	})
-	if err == nil || !strings.Contains(err.Error(), "is not reachable from branch") {
+	if err == nil || !strings.Contains(err.Error(), "does not contain any candidate commit") {
 		t.Fatalf("CreateSandbox error = %v, want commit outside branch error", err)
 	}
 	if got := adapter.provisionCalls; got != 0 {
 		t.Fatalf("ProvisionSandbox calls = %d, want 0", got)
+	}
+}
+
+func TestValidateRepositoryBranchContainsAnyCommitAcceptsReachableCandidate(t *testing.T) {
+	repoDir := t.TempDir()
+	runTestGit(t, repoDir, "init")
+	runTestGit(t, repoDir, "config", "user.email", "test@example.com")
+	runTestGit(t, repoDir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runTestGit(t, repoDir, "add", "README.md")
+	runTestGit(t, repoDir, "commit", "-m", "base")
+	mainBranch := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "--abbrev-ref", "HEAD"))
+	mainCommit := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
+	runTestGit(t, repoDir, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatalf("write feature file: %v", err)
+	}
+	runTestGit(t, repoDir, "add", "feature.txt")
+	runTestGit(t, repoDir, "commit", "-m", "feature")
+	featureCommit := strings.TrimSpace(runTestGit(t, repoDir, "rev-parse", "HEAD"))
+
+	if err := validateRepositoryBranchContainsAnyCommit(context.Background(), repoDir, mainBranch, []string{featureCommit, mainCommit}); err != nil {
+		t.Fatalf("validateRepositoryBranchContainsAnyCommit returned error: %v", err)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2789,6 +2789,31 @@ func TestCreateSandboxRepositoryPolicyResolvesBranch(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxRepositoryPolicyHonorsDisabledRepositoryBootstrap(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"cleanroom.yaml": strings.ReplaceAll(testRepositoryPolicyYAML("/workspace", false, true), "  path: /workspace\n  submodules: false", "  enabled: false"),
+	})
+	repositoryCheckout.CommitSha = ""
+	repositoryCheckout.DestinationDir = ""
+
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+
+	resp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if repository := resp.GetSandbox().GetRepositoryCheckout(); repository != nil {
+		t.Fatalf("expected repository bootstrap to be disabled, got %#v", repository)
+	}
+	if got := adapter.runCalls; got != 0 {
+		t.Fatalf("expected no repository bootstrap execution, got %d", got)
+	}
+}
+
 func TestCreateSandboxRepositoryPolicyRequiresRepositoryStore(t *testing.T) {
 	svc := newTestService(&stubAdapter{})
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2813,6 +2813,36 @@ func TestCreateSandboxRepositoryPolicyResolvesBranch(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxRepositoryPolicyRejectsCommitOutsideBranch(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"cleanroom.yaml": testRepositoryPolicyYAML("/main", false, true),
+	})
+	baseBranch := strings.TrimSpace(runTestGit(t, mirrors.mirrorPath, "rev-parse", "--abbrev-ref", "HEAD"))
+	runTestGit(t, mirrors.mirrorPath, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(mirrors.mirrorPath, "feature.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatalf("write feature file: %v", err)
+	}
+	runTestGit(t, mirrors.mirrorPath, "add", "feature.txt")
+	runTestGit(t, mirrors.mirrorPath, "commit", "-m", "feature commit")
+	featureCommit := strings.TrimSpace(runTestGit(t, mirrors.mirrorPath, "rev-parse", "HEAD"))
+	repositoryCheckout.CommitSha = featureCommit
+	repositoryCheckout.Branch = baseBranch
+
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+
+	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err == nil || !strings.Contains(err.Error(), "is not reachable from branch") {
+		t.Fatalf("CreateSandbox error = %v, want commit outside branch error", err)
+	}
+	if got := adapter.provisionCalls; got != 0 {
+		t.Fatalf("ProvisionSandbox calls = %d, want 0", got)
+	}
+}
+
 func TestCreateSandboxLoadsRepositoryPolicyFromCommitBundle(t *testing.T) {
 	adapter := &stubAdapter{}
 	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -531,6 +531,26 @@ func testRepositoryDependencyAndServicesPolicy() *cleanroomv1.Policy {
 	return policyProto
 }
 
+func testRepositoryPolicyYAML(destinationDir string, submodules, allowGitHub bool) string {
+	allowBlock := ""
+	if allowGitHub {
+		allowBlock = `
+    allow:
+      - host: github.com
+        ports: [443]`
+	}
+	return fmt.Sprintf(`version: 1
+repository:
+  path: %s
+  submodules: %t
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  network:
+    default: deny%s
+`, destinationDir, submodules, allowBlock)
+}
+
 func testRepositoryPortableDependencyPolicy() *cleanroomv1.Policy {
 	policyProto := testRepositoryDependencyPolicy()
 	policyProto.Dependencies.Reuse = policy.DependencyReusePortable
@@ -2669,6 +2689,141 @@ func runTestGit(t *testing.T, dir string, args ...string) string {
 		t.Fatalf("git %s returned error: %v\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
 	}
 	return string(output)
+}
+
+func TestCreateSandboxLoadsPolicyFromRepositoryCheckout(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"cleanroom.yaml": testRepositoryPolicyYAML("/repo", true, true),
+	})
+	wantCommit := repositoryCheckout.GetCommitSha()
+	repositoryCheckout.CommitSha = ""
+	repositoryCheckout.DestinationDir = ""
+
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+
+	resp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetPolicySource(), "repository:cleanroom.yaml"; got != want {
+		t.Fatalf("unexpected policy source: got %q want %q", got, want)
+	}
+	repository := resp.GetSandbox().GetRepositoryCheckout()
+	if repository == nil {
+		t.Fatal("expected repository checkout on sandbox")
+	}
+	if got := repository.GetCommitSha(); got != wantCommit {
+		t.Fatalf("unexpected resolved commit: got %q want %q", got, wantCommit)
+	}
+	if got := repository.GetDestinationDir(); got != "/repo" {
+		t.Fatalf("unexpected destination dir: got %q", got)
+	}
+	if !repository.GetSubmodules() {
+		t.Fatal("expected repository submodules to come from policy")
+	}
+	if adapter.provisionCalls != 1 {
+		t.Fatalf("expected one provision call, got %d", adapter.provisionCalls)
+	}
+}
+
+func TestCreateSandboxLoadsFallbackPolicyFromRepositoryCheckout(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		".buildkite/cleanroom.yaml": testRepositoryPolicyYAML("/workspace", false, true),
+	})
+	repositoryCheckout.CommitSha = ""
+	repositoryCheckout.DestinationDir = ""
+
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+
+	resp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	if got, want := resp.GetPolicySource(), "repository:.buildkite/cleanroom.yaml"; got != want {
+		t.Fatalf("unexpected policy source: got %q want %q", got, want)
+	}
+}
+
+func TestCreateSandboxRepositoryPolicyResolvesBranch(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"cleanroom.yaml": testRepositoryPolicyYAML("/main", false, true),
+	})
+	runTestGit(t, mirrors.mirrorPath, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(mirrors.mirrorPath, "cleanroom.yaml"), []byte(testRepositoryPolicyYAML("/feature", false, true)), 0o644); err != nil {
+		t.Fatalf("write branch policy: %v", err)
+	}
+	runTestGit(t, mirrors.mirrorPath, "add", "cleanroom.yaml")
+	runTestGit(t, mirrors.mirrorPath, "commit", "-m", "feature policy")
+	wantCommit := strings.TrimSpace(runTestGit(t, mirrors.mirrorPath, "rev-parse", "HEAD"))
+	repositoryCheckout.CommitSha = ""
+	repositoryCheckout.Branch = "feature"
+	repositoryCheckout.DestinationDir = ""
+
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+
+	resp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	repository := resp.GetSandbox().GetRepositoryCheckout()
+	if got := repository.GetCommitSha(); got != wantCommit {
+		t.Fatalf("unexpected resolved commit: got %q want %q", got, wantCommit)
+	}
+	if got := repository.GetBranch(); got != "feature" {
+		t.Fatalf("unexpected branch: got %q", got)
+	}
+	if got := repository.GetDestinationDir(); got != "/feature" {
+		t.Fatalf("unexpected destination dir: got %q", got)
+	}
+}
+
+func TestCreateSandboxRepositoryPolicyRequiresRepositoryStore(t *testing.T) {
+	svc := newTestService(&stubAdapter{})
+
+	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: &cleanroomv1.RepositoryCheckout{
+			RemoteUrl: "https://github.com/buildkite/cleanroom.git",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected CreateSandbox to fail")
+	}
+	if !strings.Contains(err.Error(), "requires repository store") {
+		t.Fatalf("expected repository store error, got %v", err)
+	}
+}
+
+func TestCreateSandboxRepositoryPolicyRejectsDisallowedRemote(t *testing.T) {
+	adapter := &stubAdapter{}
+	mirrors, repositoryCheckout := testRepositoryMirror(t, map[string]string{
+		"cleanroom.yaml": testRepositoryPolicyYAML("/workspace", false, false),
+	})
+	repositoryCheckout.CommitSha = ""
+
+	svc := newTestService(adapter)
+	svc.RepositoryStore = mirrors
+
+	_, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{
+		RepositoryCheckout: repositoryCheckout,
+	})
+	if err == nil {
+		t.Fatal("expected CreateSandbox to fail")
+	}
+	if !strings.Contains(err.Error(), `repository remote host "github.com" is not allowed`) {
+		t.Fatalf("expected host allowlist error, got %v", err)
+	}
 }
 
 type memorySnapshotStore struct {

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -2850,6 +2850,7 @@ func TestCreateSandboxLoadsRepositoryPolicyFromCommitBundle(t *testing.T) {
 		"cleanroom.yaml": testRepositoryPolicyYAML("/base", false, true),
 	})
 	baseCommit := repositoryCheckout.GetCommitSha()
+	baseBranch := strings.TrimSpace(runTestGit(t, mirrors.mirrorPath, "rev-parse", "--abbrev-ref", "HEAD"))
 
 	localRepo := filepath.Join(t.TempDir(), "local")
 	runTestGit(t, t.TempDir(), "clone", mirrors.mirrorPath, localRepo)
@@ -2870,6 +2871,7 @@ func TestCreateSandboxLoadsRepositoryPolicyFromCommitBundle(t *testing.T) {
 		t.Fatal("expected repository commit bundle")
 	}
 	repositoryCheckout.CommitSha = localCommit
+	repositoryCheckout.Branch = baseBranch
 	repositoryCheckout.DestinationDir = ""
 	mirrors.ensureContainsFn = func(_ string, commitSHA string) error {
 		switch strings.TrimSpace(commitSHA) {

--- a/internal/gateway/git_test.go
+++ b/internal/gateway/git_test.go
@@ -567,6 +567,11 @@ func (s *staticMirrorStore) EnsureMirror(_ context.Context, remoteURL string) (s
 	return s.mirrorDir, nil
 }
 
+func (s *staticMirrorStore) RefreshMirror(_ context.Context, remoteURL string) (string, error) {
+	s.gotRemoteURL = remoteURL
+	return s.mirrorDir, nil
+}
+
 func (s *staticMirrorStore) EnsureMirrorContains(_ context.Context, remoteURL, _ string) error {
 	s.gotRemoteURL = remoteURL
 	return nil

--- a/internal/gateway/mirror.go
+++ b/internal/gateway/mirror.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -281,8 +282,53 @@ func (s *gitMirrorStore) fetchMirror(ctx context.Context, remoteURL, mirrorDir s
 	if err != nil {
 		return fmt.Errorf("git fetch --prune origin: %s: %w", output, err)
 	}
+	if err := s.updateMirrorHEAD(ctx, remoteURL, mirrorDir); err != nil {
+		return err
+	}
 	s.markFetched(remoteURL)
 	return nil
+}
+
+func (s *gitMirrorStore) updateMirrorHEAD(ctx context.Context, remoteURL, mirrorDir string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", mirrorDir, "ls-remote", "--symref", "origin", "HEAD")
+	env, err := s.gitEnvWithAuth(ctx, remoteURL, append(os.Environ(), "GIT_TERMINAL_PROMPT=0"))
+	if err != nil {
+		return err
+	}
+	cmd.Env = env
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git ls-remote --symref origin HEAD: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	headRef := parseRemoteHEADSymref(string(output))
+	if headRef == "" {
+		return nil
+	}
+	if _, err := gitOutputContext(ctx, mirrorDir, "show-ref", "--verify", "--quiet", headRef); err != nil {
+		return nil
+	}
+	if _, err := gitOutputContext(ctx, mirrorDir, "symbolic-ref", "HEAD", headRef); err != nil {
+		return fmt.Errorf("update mirror HEAD: %w", err)
+	}
+	return nil
+}
+
+func parseRemoteHEADSymref(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "ref:") || !strings.HasSuffix(line, "\tHEAD") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		ref := strings.TrimSpace(fields[1])
+		if strings.HasPrefix(ref, "refs/heads/") {
+			return ref
+		}
+	}
+	return ""
 }
 
 func runGitCommandWithBoundedOutput(cmd *exec.Cmd) (string, error) {
@@ -368,6 +414,20 @@ func gitConfigCount(env []string) (int, bool) {
 		found = true
 	}
 	return count, found
+}
+
+func gitOutputContext(ctx context.Context, repoDir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repoDir}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return "", errors.New(message)
+	}
+	return strings.TrimSpace(string(output)), nil
 }
 
 func gitCommitExists(ctx context.Context, repoDir, commitSHA string) (bool, error) {

--- a/internal/gateway/mirror.go
+++ b/internal/gateway/mirror.go
@@ -37,8 +37,9 @@ type gitMirrorStore struct {
 
 	group singleflight.Group
 
-	mu        sync.RWMutex
-	lastFetch map[string]time.Time
+	mu          sync.RWMutex
+	lastFetch   map[string]time.Time
+	mirrorLocks map[string]*sync.Mutex
 }
 
 func NewGitMirrorStore(baseDir string, maxAge time.Duration, credentials CredentialProvider) *gitMirrorStore {
@@ -47,6 +48,7 @@ func NewGitMirrorStore(baseDir string, maxAge time.Duration, credentials Credent
 		maxAge:      maxAge,
 		credentials: credentials,
 		lastFetch:   make(map[string]time.Time),
+		mirrorLocks: make(map[string]*sync.Mutex),
 	}
 }
 
@@ -82,18 +84,10 @@ func (s *gitMirrorStore) EnsureMirror(ctx context.Context, remoteURL string) (st
 	key := canonicalRemoteURL
 
 	result, err, _ := s.group.Do(key, func() (any, error) {
-		if _, statErr := os.Stat(filepath.Join(mirrorDir, "HEAD")); os.IsNotExist(statErr) {
-			if err := s.cloneMirror(ctx, canonicalRemoteURL, mirrorDir); err != nil {
-				return "", err
-			}
-			return mirrorDir, nil
-		}
-		if s.isStale(canonicalRemoteURL) {
-			if err := s.fetchMirror(ctx, canonicalRemoteURL, mirrorDir); err != nil {
-				return "", err
-			}
-		}
-		return mirrorDir, nil
+		lock := s.lockForMirror(canonicalRemoteURL)
+		lock.Lock()
+		defer lock.Unlock()
+		return s.ensureMirrorLocked(ctx, canonicalRemoteURL, mirrorDir, false)
 	})
 	if err != nil {
 		return "", err
@@ -114,16 +108,10 @@ func (s *gitMirrorStore) RefreshMirror(ctx context.Context, remoteURL string) (s
 	key := canonicalRemoteURL + "#refresh"
 
 	result, err, _ := s.group.Do(key, func() (any, error) {
-		if _, statErr := os.Stat(filepath.Join(mirrorDir, "HEAD")); os.IsNotExist(statErr) {
-			if err := s.cloneMirror(ctx, canonicalRemoteURL, mirrorDir); err != nil {
-				return "", err
-			}
-			return mirrorDir, nil
-		}
-		if err := s.fetchMirror(ctx, canonicalRemoteURL, mirrorDir); err != nil {
-			return "", err
-		}
-		return mirrorDir, nil
+		lock := s.lockForMirror(canonicalRemoteURL)
+		lock.Lock()
+		defer lock.Unlock()
+		return s.ensureMirrorLocked(ctx, canonicalRemoteURL, mirrorDir, true)
 	})
 	if err != nil {
 		return "", err
@@ -147,7 +135,11 @@ func (s *gitMirrorStore) EnsureMirrorContains(ctx context.Context, remoteURL, co
 	key := canonicalRemoteURL + "#" + trimmedCommit
 
 	_, err, _ = s.group.Do(key, func() (any, error) {
-		mirrorDir, err := s.EnsureMirror(ctx, canonicalRemoteURL)
+		mirrorDir := s.mirrorPath(canonicalRemoteURL)
+		lock := s.lockForMirror(canonicalRemoteURL)
+		lock.Lock()
+		defer lock.Unlock()
+		mirrorDir, err := s.ensureMirrorLocked(ctx, canonicalRemoteURL, mirrorDir, false)
 		if err != nil {
 			return nil, err
 		}
@@ -171,6 +163,32 @@ func (s *gitMirrorStore) EnsureMirrorContains(ctx context.Context, remoteURL, co
 		return nil, nil
 	})
 	return err
+}
+
+func (s *gitMirrorStore) lockForMirror(remoteURL string) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lock := s.mirrorLocks[remoteURL]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		s.mirrorLocks[remoteURL] = lock
+	}
+	return lock
+}
+
+func (s *gitMirrorStore) ensureMirrorLocked(ctx context.Context, remoteURL, mirrorDir string, forceRefresh bool) (string, error) {
+	if _, statErr := os.Stat(filepath.Join(mirrorDir, "HEAD")); os.IsNotExist(statErr) {
+		if err := s.cloneMirror(ctx, remoteURL, mirrorDir); err != nil {
+			return "", err
+		}
+		return mirrorDir, nil
+	}
+	if forceRefresh || s.isStale(remoteURL) {
+		if err := s.fetchMirror(ctx, remoteURL, mirrorDir); err != nil {
+			return "", err
+		}
+	}
+	return mirrorDir, nil
 }
 
 func normalizeMirrorRemoteURL(raw string) (*url.URL, error) {

--- a/internal/gateway/mirror.go
+++ b/internal/gateway/mirror.go
@@ -26,6 +26,7 @@ const defaultGitMirrorMaxAge = 30 * time.Second
 type GitMirrorStore interface {
 	MirrorPath(remoteURL string) (string, error)
 	EnsureMirror(ctx context.Context, remoteURL string) (string, error)
+	RefreshMirror(ctx context.Context, remoteURL string) (string, error)
 	EnsureMirrorContains(ctx context.Context, remoteURL, commitSHA string) error
 }
 
@@ -91,6 +92,36 @@ func (s *gitMirrorStore) EnsureMirror(ctx context.Context, remoteURL string) (st
 			if err := s.fetchMirror(ctx, canonicalRemoteURL, mirrorDir); err != nil {
 				return "", err
 			}
+		}
+		return mirrorDir, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return result.(string), nil
+}
+
+func (s *gitMirrorStore) RefreshMirror(ctx context.Context, remoteURL string) (string, error) {
+	if s == nil {
+		return "", fmt.Errorf("mirror store is nil")
+	}
+	parsed, err := normalizeMirrorRemoteURL(remoteURL)
+	if err != nil {
+		return "", err
+	}
+	canonicalRemoteURL := parsed.String()
+	mirrorDir := s.mirrorPath(canonicalRemoteURL)
+	key := canonicalRemoteURL + "#refresh"
+
+	result, err, _ := s.group.Do(key, func() (any, error) {
+		if _, statErr := os.Stat(filepath.Join(mirrorDir, "HEAD")); os.IsNotExist(statErr) {
+			if err := s.cloneMirror(ctx, canonicalRemoteURL, mirrorDir); err != nil {
+				return "", err
+			}
+			return mirrorDir, nil
+		}
+		if err := s.fetchMirror(ctx, canonicalRemoteURL, mirrorDir); err != nil {
+			return "", err
 		}
 		return mirrorDir, nil
 	})

--- a/internal/gateway/mirror_test.go
+++ b/internal/gateway/mirror_test.go
@@ -173,6 +173,7 @@ func TestGitMirrorStoreRefreshMirrorUpdatesDefaultBranchHEAD(t *testing.T) {
 	runGitCommand(t, workDir, "commit", "-m", "initial")
 	runGitCommand(t, workDir, "remote", "add", "origin", originDir)
 	runGitCommand(t, workDir, "push", "-u", "origin", "main")
+	runGitCommand(t, originDir, "symbolic-ref", "HEAD", "refs/heads/main")
 
 	store := NewGitMirrorStore(t.TempDir(), time.Hour, nil)
 	mirrorDir, err := store.EnsureMirror(context.Background(), "file://"+originDir)

--- a/internal/gateway/mirror_test.go
+++ b/internal/gateway/mirror_test.go
@@ -104,6 +104,57 @@ func TestGitMirrorStoreEnsureMirrorContainsFetchesRequestedCommit(t *testing.T) 
 	}
 }
 
+func TestGitMirrorStoreRefreshMirrorFetchesWithinMaxAge(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	originDir := filepath.Join(t.TempDir(), "origin.git")
+
+	runGitCommand(t, "", "init", "--bare", originDir)
+	runGitCommand(t, workDir, "init")
+	runGitCommand(t, workDir, "config", "user.email", "test@example.com")
+	runGitCommand(t, workDir, "config", "user.name", "Test")
+	runGitCommand(t, workDir, "branch", "-M", "main")
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("one\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runGitCommand(t, workDir, "add", "README.md")
+	runGitCommand(t, workDir, "commit", "-m", "initial")
+	runGitCommand(t, workDir, "remote", "add", "origin", originDir)
+	runGitCommand(t, workDir, "push", "-u", "origin", "main")
+
+	store := NewGitMirrorStore(t.TempDir(), time.Hour, nil)
+	mirrorDir, err := store.EnsureMirror(context.Background(), "file://"+originDir)
+	if err != nil {
+		t.Fatalf("ensure mirror: %v", err)
+	}
+	head1 := gitRevParse(t, mirrorDir, "refs/heads/main")
+
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("two\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runGitCommand(t, workDir, "add", "README.md")
+	runGitCommand(t, workDir, "commit", "-m", "second")
+	runGitCommand(t, workDir, "push", "origin", "main")
+	head2 := strings.TrimSpace(runGitCommand(t, workDir, "rev-parse", "HEAD"))
+	if head2 == head1 {
+		t.Fatalf("expected a new commit after second push")
+	}
+
+	mirrorDir2, err := store.RefreshMirror(context.Background(), "file://"+originDir)
+	if err != nil {
+		t.Fatalf("refresh mirror: %v", err)
+	}
+	if mirrorDir2 != mirrorDir {
+		t.Fatalf("mirror directory changed: got %q want %q", mirrorDir2, mirrorDir)
+	}
+
+	got := gitRevParse(t, mirrorDir, "refs/heads/main")
+	if got != head2 {
+		t.Fatalf("expected mirror head %q after refresh, got %q", head2, got)
+	}
+}
+
 func runGitCommand(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 

--- a/internal/gateway/mirror_test.go
+++ b/internal/gateway/mirror_test.go
@@ -155,6 +155,47 @@ func TestGitMirrorStoreRefreshMirrorFetchesWithinMaxAge(t *testing.T) {
 	}
 }
 
+func TestGitMirrorStoreRefreshMirrorSerializesWithEnsureMirror(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	originDir := filepath.Join(t.TempDir(), "origin.git")
+
+	runGitCommand(t, "", "init", "--bare", originDir)
+	runGitCommand(t, workDir, "init")
+	runGitCommand(t, workDir, "config", "user.email", "test@example.com")
+	runGitCommand(t, workDir, "config", "user.name", "Test")
+	runGitCommand(t, workDir, "branch", "-M", "main")
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("one\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runGitCommand(t, workDir, "add", "README.md")
+	runGitCommand(t, workDir, "commit", "-m", "initial")
+	runGitCommand(t, workDir, "remote", "add", "origin", originDir)
+	runGitCommand(t, workDir, "push", "-u", "origin", "main")
+
+	store := NewGitMirrorStore(t.TempDir(), time.Hour, nil)
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	go func() {
+		<-start
+		_, err := store.EnsureMirror(context.Background(), "file://"+originDir)
+		errs <- err
+	}()
+	go func() {
+		<-start
+		_, err := store.RefreshMirror(context.Background(), "file://"+originDir)
+		errs <- err
+	}()
+	close(start)
+
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("concurrent mirror operation returned error: %v", err)
+		}
+	}
+}
+
 func runGitCommand(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 

--- a/internal/gateway/mirror_test.go
+++ b/internal/gateway/mirror_test.go
@@ -155,6 +155,51 @@ func TestGitMirrorStoreRefreshMirrorFetchesWithinMaxAge(t *testing.T) {
 	}
 }
 
+func TestGitMirrorStoreRefreshMirrorUpdatesDefaultBranchHEAD(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	originDir := filepath.Join(t.TempDir(), "origin.git")
+
+	runGitCommand(t, "", "init", "--bare", originDir)
+	runGitCommand(t, workDir, "init")
+	runGitCommand(t, workDir, "config", "user.email", "test@example.com")
+	runGitCommand(t, workDir, "config", "user.name", "Test")
+	runGitCommand(t, workDir, "branch", "-M", "main")
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("one\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runGitCommand(t, workDir, "add", "README.md")
+	runGitCommand(t, workDir, "commit", "-m", "initial")
+	runGitCommand(t, workDir, "remote", "add", "origin", originDir)
+	runGitCommand(t, workDir, "push", "-u", "origin", "main")
+
+	store := NewGitMirrorStore(t.TempDir(), time.Hour, nil)
+	mirrorDir, err := store.EnsureMirror(context.Background(), "file://"+originDir)
+	if err != nil {
+		t.Fatalf("ensure mirror: %v", err)
+	}
+	if got, want := strings.TrimSpace(runGitCommand(t, mirrorDir, "symbolic-ref", "--short", "HEAD")), "main"; got != want {
+		t.Fatalf("unexpected initial mirror HEAD: got %q want %q", got, want)
+	}
+
+	runGitCommand(t, workDir, "checkout", "-b", "newdefault")
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("two\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runGitCommand(t, workDir, "add", "README.md")
+	runGitCommand(t, workDir, "commit", "-m", "new default")
+	runGitCommand(t, workDir, "push", "-u", "origin", "newdefault")
+	runGitCommand(t, originDir, "symbolic-ref", "HEAD", "refs/heads/newdefault")
+
+	if _, err := store.RefreshMirror(context.Background(), "file://"+originDir); err != nil {
+		t.Fatalf("refresh mirror: %v", err)
+	}
+	if got, want := strings.TrimSpace(runGitCommand(t, mirrorDir, "symbolic-ref", "--short", "HEAD")), "newdefault"; got != want {
+		t.Fatalf("unexpected refreshed mirror HEAD: got %q want %q", got, want)
+	}
+}
+
 func TestGitMirrorStoreRefreshMirrorSerializesWithEnsureMirror(t *testing.T) {
 	t.Parallel()
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1012,16 +1012,47 @@ func readPolicy(path string) (rawPolicy, error) {
 		return rawPolicy{}, err
 	}
 
+	return parsePolicyBytes(b, path)
+}
+
+func parsePolicyBytes(b []byte, source string) (rawPolicy, error) {
 	var raw rawPolicy
 	dec := yaml.NewDecoder(bytes.NewReader(b))
 	dec.KnownFields(true)
 	if err := dec.Decode(&raw); err != nil {
 		if !errors.Is(err, io.EOF) {
-			return rawPolicy{}, fmt.Errorf("parse %s: %w", path, err)
+			return rawPolicy{}, fmt.Errorf("parse %s: %w", source, err)
 		}
 	}
 
 	return raw, nil
+}
+
+// CompileBytes parses and compiles policy YAML loaded from source.
+func CompileBytes(b []byte, source string) (*CompiledPolicy, error) {
+	raw, err := parsePolicyBytes(b, source)
+	if err != nil {
+		return nil, err
+	}
+	return Compile(raw)
+}
+
+// CompileBytesWithRepositoryConfig parses policy YAML and returns both the
+// compiled policy and normalized repository configuration.
+func CompileBytesWithRepositoryConfig(b []byte, source string) (*CompiledPolicy, RepositoryConfig, error) {
+	raw, err := parsePolicyBytes(b, source)
+	if err != nil {
+		return nil, RepositoryConfig{}, err
+	}
+	compiled, err := Compile(raw)
+	if err != nil {
+		return nil, RepositoryConfig{}, err
+	}
+	repository, err := normalizeRepositoryConfig(raw.Repository)
+	if err != nil {
+		return nil, RepositoryConfig{}, err
+	}
+	return compiled, repository, nil
 }
 
 func exists(path string) (bool, error) {

--- a/internal/repositorystore/store.go
+++ b/internal/repositorystore/store.go
@@ -2,9 +2,11 @@ package repositorystore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
@@ -112,9 +114,23 @@ func (s *mirrorBackedRepositoryStore) EnsureSubmoduleMirror(ctx context.Context,
 func (s *mirrorBackedRepositoryStore) repositoryPath(ctx context.Context, remoteURL string) (string, error) {
 	repoDir, err := s.mirrors.MirrorPath(remoteURL)
 	if err == nil {
-		return repoDir, nil
+		if _, statErr := os.Stat(filepath.Join(repoDir, "HEAD")); statErr == nil {
+			return repoDir, nil
+		} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			return "", statErr
+		}
 	}
-	return s.mirrors.EnsureMirror(ctx, remoteURL)
+	if err != nil {
+		return s.mirrors.EnsureMirror(ctx, remoteURL)
+	}
+	repoDir, err = s.mirrors.EnsureMirror(ctx, remoteURL)
+	if err != nil {
+		return "", err
+	}
+	if _, statErr := os.Stat(filepath.Join(repoDir, "HEAD")); statErr != nil {
+		return "", statErr
+	}
+	return repoDir, nil
 }
 
 func gitShowFileAtCommit(ctx context.Context, repoDir, commitSHA, path string) ([]byte, error) {

--- a/internal/repositorystore/store.go
+++ b/internal/repositorystore/store.go
@@ -2,6 +2,7 @@ package repositorystore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,6 +11,31 @@ import (
 
 	"github.com/buildkite/cleanroom/internal/repositorycheckout"
 )
+
+var ErrFileNotFound = errors.New("repository file not found")
+
+type FileNotFoundError struct {
+	CommitSHA string
+	Path      string
+}
+
+func NewFileNotFoundError(commitSHA, path string) error {
+	return &FileNotFoundError{
+		CommitSHA: strings.TrimSpace(commitSHA),
+		Path:      strings.TrimSpace(path),
+	}
+}
+
+func (e *FileNotFoundError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("repository file %s not found at %s", e.Path, e.CommitSHA)
+}
+
+func (e *FileNotFoundError) Is(target error) bool {
+	return target == ErrFileNotFound
+}
 
 type FetchHints struct {
 	Branches []string
@@ -140,7 +166,22 @@ func gitShowFileAtCommit(ctx context.Context, repoDir, commitSHA, path string) (
 		if message == "" {
 			message = err.Error()
 		}
+		if isGitShowFileMissingError(message, path) {
+			return nil, NewFileNotFoundError(commitSHA, path)
+		}
 		return nil, fmt.Errorf("git show %s:%s: %s", strings.TrimSpace(commitSHA), path, message)
 	}
 	return output, nil
+}
+
+func isGitShowFileMissingError(message, path string) bool {
+	message = strings.ToLower(strings.TrimSpace(message))
+	path = strings.ToLower(strings.TrimSpace(path))
+	if path == "" {
+		return false
+	}
+	quotedPath := "'" + path + "'"
+	return strings.Contains(message, "path "+quotedPath+" does not exist") ||
+		strings.Contains(message, "path "+quotedPath+" exists on disk, but not in") ||
+		strings.Contains(message, "pathspec "+quotedPath)
 }

--- a/internal/repositorystore/store.go
+++ b/internal/repositorystore/store.go
@@ -147,7 +147,23 @@ func (s *mirrorBackedRepositoryStore) EnsureSubmoduleMirror(ctx context.Context,
 }
 
 func (s *mirrorBackedRepositoryStore) repositoryPath(ctx context.Context, remoteURL string) (string, error) {
+	if repoDir, err := s.cachedRepositoryPath(remoteURL); err == nil {
+		return repoDir, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
 	repoDir, err := s.mirrors.EnsureMirror(ctx, remoteURL)
+	if err != nil {
+		return "", err
+	}
+	if _, statErr := os.Stat(filepath.Join(repoDir, "HEAD")); statErr != nil {
+		return "", statErr
+	}
+	return repoDir, nil
+}
+
+func (s *mirrorBackedRepositoryStore) cachedRepositoryPath(remoteURL string) (string, error) {
+	repoDir, err := s.mirrors.MirrorPath(remoteURL)
 	if err != nil {
 		return "", err
 	}

--- a/internal/repositorystore/store.go
+++ b/internal/repositorystore/store.go
@@ -2,7 +2,6 @@ package repositorystore
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -112,18 +111,7 @@ func (s *mirrorBackedRepositoryStore) EnsureSubmoduleMirror(ctx context.Context,
 }
 
 func (s *mirrorBackedRepositoryStore) repositoryPath(ctx context.Context, remoteURL string) (string, error) {
-	repoDir, err := s.mirrors.MirrorPath(remoteURL)
-	if err == nil {
-		if _, statErr := os.Stat(filepath.Join(repoDir, "HEAD")); statErr == nil {
-			return repoDir, nil
-		} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
-			return "", statErr
-		}
-	}
-	if err != nil {
-		return s.mirrors.EnsureMirror(ctx, remoteURL)
-	}
-	repoDir, err = s.mirrors.EnsureMirror(ctx, remoteURL)
+	repoDir, err := s.mirrors.EnsureMirror(ctx, remoteURL)
 	if err != nil {
 		return "", err
 	}

--- a/internal/repositorystore/store.go
+++ b/internal/repositorystore/store.go
@@ -23,6 +23,7 @@ type TransportHints struct {
 type RepositoryStore interface {
 	EnsureCommit(ctx context.Context, remoteURL, commitSHA string, hints FetchHints) error
 	ReadFileAtCommit(ctx context.Context, remoteURL, commitSHA, path string) ([]byte, error)
+	Refresh(ctx context.Context, remoteURL string, hints FetchHints) error
 	WithRepository(ctx context.Context, remoteURL, commitSHA string, hints FetchHints, fn func(repoDir string) error) error
 	TransportHints(ctx context.Context, remoteURL, commitSHA string, hints FetchHints) (TransportHints, error)
 	EnsureSubmoduleMirror(ctx context.Context, submoduleRemoteURL, gitlinkSHA string) (mirrorDir string, err error)
@@ -31,6 +32,7 @@ type RepositoryStore interface {
 type mirrorSource interface {
 	MirrorPath(remoteURL string) (string, error)
 	EnsureMirror(ctx context.Context, remoteURL string) (string, error)
+	RefreshMirror(ctx context.Context, remoteURL string) (string, error)
 	EnsureMirrorContains(ctx context.Context, remoteURL, commitSHA string) error
 }
 
@@ -66,6 +68,14 @@ func (s *mirrorBackedRepositoryStore) ReadFileAtCommit(ctx context.Context, remo
 		return nil, err
 	}
 	return content, nil
+}
+
+func (s *mirrorBackedRepositoryStore) Refresh(ctx context.Context, remoteURL string, _ FetchHints) error {
+	if s == nil || s.mirrors == nil {
+		return fmt.Errorf("repository store is nil")
+	}
+	_, err := s.mirrors.RefreshMirror(ctx, remoteURL)
+	return err
 }
 
 func (s *mirrorBackedRepositoryStore) WithRepository(ctx context.Context, remoteURL, commitSHA string, hints FetchHints, fn func(repoDir string) error) error {

--- a/internal/repositorystore/store_test.go
+++ b/internal/repositorystore/store_test.go
@@ -2,6 +2,7 @@ package repositorystore
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -84,6 +85,33 @@ func TestMirrorBackedRepositoryStoreReadFileAtCommit(t *testing.T) {
 	}
 	if got, want := string(content), "hello\n"; got != want {
 		t.Fatalf("unexpected file content: got %q want %q", got, want)
+	}
+}
+
+func TestMirrorBackedRepositoryStoreReadFileAtCommitReportsMissingFile(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	originDir := filepath.Join(t.TempDir(), "origin.git")
+
+	runGitCommand(t, "", "init", "--bare", originDir)
+	runGitCommand(t, workDir, "init")
+	runGitCommand(t, workDir, "config", "user.email", "test@example.com")
+	runGitCommand(t, workDir, "config", "user.name", "Test")
+	runGitCommand(t, workDir, "branch", "-M", "main")
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runGitCommand(t, workDir, "add", "README.md")
+	runGitCommand(t, workDir, "commit", "-m", "initial")
+	runGitCommand(t, workDir, "remote", "add", "origin", originDir)
+	runGitCommand(t, workDir, "push", "-u", "origin", "main")
+	head := strings.TrimSpace(runGitCommand(t, workDir, "rev-parse", "HEAD"))
+
+	store := NewMirrorBacked(gateway.NewGitMirrorStore(t.TempDir(), 0, nil))
+	_, err := store.ReadFileAtCommit(context.Background(), "file://"+originDir, head, "missing.txt")
+	if !errors.Is(err, ErrFileNotFound) {
+		t.Fatalf("ReadFileAtCommit error = %v, want ErrFileNotFound", err)
 	}
 }
 

--- a/internal/repositorystore/store_test.go
+++ b/internal/repositorystore/store_test.go
@@ -149,6 +149,38 @@ func TestMirrorBackedRepositoryStoreWithRepositoryEnsuresMissingMirrorPath(t *te
 	}
 }
 
+func TestMirrorBackedRepositoryStoreWithRepositoryUsesCachedMirrorBeforeFetch(t *testing.T) {
+	t.Parallel()
+
+	mirrorDir := filepath.Join(t.TempDir(), "mirror.git")
+	if err := os.MkdirAll(mirrorDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mirrorDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	mock := &mockMirrorSource{
+		mirrorPath: mirrorDir,
+		ensureMirrorFunc: func(context.Context, string) (string, error) {
+			return "", errors.New("network unavailable")
+		},
+	}
+	store := NewMirrorBacked(mock)
+
+	err := store.WithRepository(context.Background(), "https://github.com/buildkite/cleanroom.git", "0123456789abcdef0123456789abcdef01234567", FetchHints{}, func(repoDir string) error {
+		if repoDir != mirrorDir {
+			t.Fatalf("unexpected repo dir: got %q want %q", repoDir, mirrorDir)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithRepository returned error: %v", err)
+	}
+	if mock.ensureMirrorCalls != 0 {
+		t.Fatalf("expected cached mirror path to avoid EnsureMirror, got %d call(s)", mock.ensureMirrorCalls)
+	}
+}
+
 func TestMirrorBackedRepositoryStoreRefreshesExistingMirror(t *testing.T) {
 	t.Parallel()
 

--- a/internal/repositorystore/store_test.go
+++ b/internal/repositorystore/store_test.go
@@ -121,7 +121,7 @@ func TestMirrorBackedRepositoryStoreWithRepositoryEnsuresMissingMirrorPath(t *te
 	}
 }
 
-func TestMirrorBackedRepositoryStoreWithRepositoryRefreshesExistingMirror(t *testing.T) {
+func TestMirrorBackedRepositoryStoreRefreshesExistingMirror(t *testing.T) {
 	t.Parallel()
 
 	mirrorDir := filepath.Join(t.TempDir(), "mirror.git")
@@ -134,17 +134,11 @@ func TestMirrorBackedRepositoryStoreWithRepositoryRefreshesExistingMirror(t *tes
 	mock := &mockMirrorSource{mirrorPath: mirrorDir}
 	store := NewMirrorBacked(mock)
 
-	err := store.WithRepository(context.Background(), "https://github.com/buildkite/cleanroom.git", "", FetchHints{}, func(repoDir string) error {
-		if repoDir != mirrorDir {
-			t.Fatalf("unexpected repo dir: got %q want %q", repoDir, mirrorDir)
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("WithRepository returned error: %v", err)
+	if err := store.Refresh(context.Background(), "https://github.com/buildkite/cleanroom.git", FetchHints{}); err != nil {
+		t.Fatalf("Refresh returned error: %v", err)
 	}
-	if mock.ensureMirrorCalls != 1 {
-		t.Fatalf("expected EnsureMirror to be called once, got %d", mock.ensureMirrorCalls)
+	if mock.refreshMirrorCalls != 1 {
+		t.Fatalf("expected RefreshMirror to be called once, got %d", mock.refreshMirrorCalls)
 	}
 }
 
@@ -196,6 +190,7 @@ type mockMirrorSource struct {
 	ensureMirrorContainsSHA string
 	mirrorPathURL           string
 	ensureMirrorCalls       int
+	refreshMirrorCalls      int
 	ensureMirrorFunc        func(context.Context, string) (string, error)
 }
 
@@ -209,6 +204,11 @@ func (m *mockMirrorSource) EnsureMirror(ctx context.Context, remoteURL string) (
 	if m.ensureMirrorFunc != nil {
 		return m.ensureMirrorFunc(ctx, remoteURL)
 	}
+	return m.mirrorPath, nil
+}
+
+func (m *mockMirrorSource) RefreshMirror(_ context.Context, remoteURL string) (string, error) {
+	m.refreshMirrorCalls++
 	return m.mirrorPath, nil
 }
 

--- a/internal/repositorystore/store_test.go
+++ b/internal/repositorystore/store_test.go
@@ -87,6 +87,40 @@ func TestMirrorBackedRepositoryStoreReadFileAtCommit(t *testing.T) {
 	}
 }
 
+func TestMirrorBackedRepositoryStoreWithRepositoryEnsuresMissingMirrorPath(t *testing.T) {
+	t.Parallel()
+
+	mirrorDir := filepath.Join(t.TempDir(), "mirror.git")
+	mock := &mockMirrorSource{
+		mirrorPath: mirrorDir,
+		ensureMirrorFunc: func(_ context.Context, _ string) (string, error) {
+			if err := os.MkdirAll(mirrorDir, 0o755); err != nil {
+				return "", err
+			}
+			if err := os.WriteFile(filepath.Join(mirrorDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+				return "", err
+			}
+			return mirrorDir, nil
+		},
+	}
+	store := NewMirrorBacked(mock)
+
+	var gotRepoDir string
+	err := store.WithRepository(context.Background(), "https://github.com/buildkite/cleanroom.git", "", FetchHints{}, func(repoDir string) error {
+		gotRepoDir = repoDir
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithRepository returned error: %v", err)
+	}
+	if gotRepoDir != mirrorDir {
+		t.Fatalf("unexpected repo dir: got %q want %q", gotRepoDir, mirrorDir)
+	}
+	if mock.ensureMirrorCalls != 1 {
+		t.Fatalf("expected EnsureMirror to be called once, got %d", mock.ensureMirrorCalls)
+	}
+}
+
 func TestEnsureSubmoduleMirror(t *testing.T) {
 	t.Parallel()
 
@@ -134,6 +168,8 @@ type mockMirrorSource struct {
 	ensureMirrorContainsURL string
 	ensureMirrorContainsSHA string
 	mirrorPathURL           string
+	ensureMirrorCalls       int
+	ensureMirrorFunc        func(context.Context, string) (string, error)
 }
 
 func (m *mockMirrorSource) MirrorPath(remoteURL string) (string, error) {
@@ -141,7 +177,11 @@ func (m *mockMirrorSource) MirrorPath(remoteURL string) (string, error) {
 	return m.mirrorPath, nil
 }
 
-func (m *mockMirrorSource) EnsureMirror(_ context.Context, remoteURL string) (string, error) {
+func (m *mockMirrorSource) EnsureMirror(ctx context.Context, remoteURL string) (string, error) {
+	m.ensureMirrorCalls++
+	if m.ensureMirrorFunc != nil {
+		return m.ensureMirrorFunc(ctx, remoteURL)
+	}
 	return m.mirrorPath, nil
 }
 

--- a/internal/repositorystore/store_test.go
+++ b/internal/repositorystore/store_test.go
@@ -121,6 +121,33 @@ func TestMirrorBackedRepositoryStoreWithRepositoryEnsuresMissingMirrorPath(t *te
 	}
 }
 
+func TestMirrorBackedRepositoryStoreWithRepositoryRefreshesExistingMirror(t *testing.T) {
+	t.Parallel()
+
+	mirrorDir := filepath.Join(t.TempDir(), "mirror.git")
+	if err := os.MkdirAll(mirrorDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mirrorDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	mock := &mockMirrorSource{mirrorPath: mirrorDir}
+	store := NewMirrorBacked(mock)
+
+	err := store.WithRepository(context.Background(), "https://github.com/buildkite/cleanroom.git", "", FetchHints{}, func(repoDir string) error {
+		if repoDir != mirrorDir {
+			t.Fatalf("unexpected repo dir: got %q want %q", repoDir, mirrorDir)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithRepository returned error: %v", err)
+	}
+	if mock.ensureMirrorCalls != 1 {
+		t.Fatalf("expected EnsureMirror to be called once, got %d", mock.ensureMirrorCalls)
+	}
+}
+
 func TestEnsureSubmoduleMirror(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Janebot needs to create Cleanroom sandboxes for a specific repository without cloning and compiling that repository's policy itself. Before this change, `CreateSandbox` required callers to provide both a compiled policy and an exact repository commit, which meant repo-aware callers had to duplicate Cleanroom's policy loading and Git resolution behavior.

This lets a `CreateSandboxRequest` include `repository_checkout` without `policy`. The control service now resolves the checkout to a concrete commit through the host repository store, reads `cleanroom.yaml` or `.buildkite/cleanroom.yaml` at that commit, compiles it, and then continues through the normal sandbox creation path. The resolved policy source is returned as `repository:cleanroom.yaml` or `repository:.buildkite/cleanroom.yaml`.

The client API now exposes the repository checkout/change types, `LoadPolicy`, and repository fields on `EnsureSandboxOptions`, so a caller can do:

```go
sandbox, err := client.EnsureSandbox(ctx, threadKey, cleanroom.EnsureSandboxOptions{
    RepositoryCheckout: &cleanroom.RepositoryCheckout{
        RemoteUrl: "https://github.com/buildkite/janebot.git",
        Branch:    "main",
    },
})
```

This also tightens the mirror-backed repository store path used for empty-commit repository access so it ensures the mirror exists before running callbacks.
