### PR TITLE
fix: Reject Git gateway embedded ports

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,8 +1,8 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 15 ready for review
-**Last reviewed:** 2026-05-30
+**Status:** Slice 16 ready for review
+**Last reviewed:** 2026-05-31
 
 ## Summary
 
@@ -15,6 +15,12 @@ remote control-plane auth findings from that set, and Slice 14 closes the
 cached Git pack authorization finding. Slice 15 closes the remaining dynamic
 Git content-cache handler growth finding. The 2026-05-30 DeepSec status now
 shows all 27 findings revalidated as fixed.
+
+DeepSec was rerun against the v0.10.0 release on 2026-05-31. That run tracked
+64 files, found 12 issues, and revalidated all 12 as true positives. The first
+v0.10.0 fixing slice is scoped to the two critical Git gateway port-smuggling
+findings because they share one root cause: route hosts were authorized as
+host:443 while outbound URL construction could preserve an embedded port.
 
 This plan tracks each finding separately while keeping implementation in
 reviewable slices. A slice may close several findings when they share the same
@@ -527,10 +533,56 @@ Result: the dynamic Git handler creation finding revalidated as fixed. DeepSec
 status now reports 27/27 findings revalidated, with 0 true positives and 27
 fixed findings.
 
+Slice 16 is implemented and ready for review. The direct Git route in
+`internal/gateway/git.go` and the cached route in
+`internal/gateway/git_cached.go` now normalize the route host before policy
+checks and outbound URL construction. Explicit ports, userinfo, slashes,
+malformed escapes, and other URL authority syntax are rejected before either
+the direct proxy, content-cache, or fallback paths can construct an outbound
+URL.
+
+Codex review on PR #491 flagged that an escaped route-host slash could be
+decoded by `net/http` before host validation. The slice now validates the
+escaped `/git/<host>/` segment before splitting the decoded path, so encoded
+host separators are rejected before owner, cache, or fallback decisions.
+
+Focused validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Targeted DeepSec revalidation on 2026-05-31:
+
+```text
+cd /Users/lachlan/Develop/cleanroom/.deepsec
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec revalidate --project-id cleanroom-v0.10.0 --force --filter internal/gateway/git.go --concurrency 1 --root /Users/lachlan/.codex/worktrees/28db/cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec revalidate --project-id cleanroom-v0.10.0 --force --filter internal/gateway/git_cached.go --concurrency 1 --root /Users/lachlan/.codex/worktrees/28db/cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec report --project-id cleanroom-v0.10.0
+```
+
+Result: both critical Git gateway port-smuggling findings revalidated as fixed.
+The `internal/gateway/git.go` run also rechecked the existing medium mirror
+buffering finding, which remains a true positive outside this slice. DeepSec
+status now reports 12/12 findings revalidated, with 10 true positives and
+2 fixed findings.
+
 ## Triage
 
 | Finding | Severity | Decision | Remediation slice |
 | --- | --- | --- | --- |
+| Direct Git proxy allows SSRF via embedded port in upstream host | Critical | Fixed by Slice 16 | Slice 16: Git gateway route authority normalization |
+| Git cache route allows policy port bypass via port smuggling in upstream host | Critical | Fixed by Slice 16 | Slice 16: Git gateway route authority normalization |
 | File-handle gateway can host-dial private DNS answers | Critical | Needs fix | Slice 1: darwin-vz host-dial destination guard |
 | Submodule mirroring bypasses network policy and accepts file URLs | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
 | Submodule remotes are mirrored from the host without policy validation | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
@@ -576,6 +628,7 @@ fixed findings.
 13. Require auth for direct non-loopback `cleanroom serve` listeners.
 14. Finish Git pack cache authorization binding.
 15. Bound dynamic Git content-cache handler creation.
+16. Normalize Git gateway route authorities before policy checks or outbound URL construction.
 
 ## Key Learnings From Pressure-Testing
 

--- a/internal/gateway/conformance_test.go
+++ b/internal/gateway/conformance_test.go
@@ -159,38 +159,32 @@ func TestCredentialNotLeakedToClient(t *testing.T) {
 
 	const secretToken = "ghp_SUPERSECRET_TOKEN_12345"
 
-	// Upstream server: verifies it receives the token, responds with benign body.
-	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := newGitHandler(&staticCredentialProvider{headers: map[string]string{"https://github.com/org/repo.git": "Bearer " + secretToken}}, nil)
+	h.client = &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		if auth := r.Header.Get("Authorization"); auth != "Bearer "+secretToken {
 			t.Errorf("upstream: expected Authorization header with token, got %q", auth)
 		}
-		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("refs-response"))
-	}))
-	defer upstream.Close()
-
-	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
-	scope := &SandboxScope{
-		SandboxID: "sandbox-leak-test",
-		GuestIP:   "10.1.1.2",
-		Policy: &policy.CompiledPolicy{
-			Version: 1, NetworkDefault: "deny",
-			Allow: []policy.AllowRule{{Host: upstreamHost, Ports: []int{443}}},
-		},
-	}
-
-	creds := &staticCredentialProvider{headers: map[string]string{"https://" + upstreamHost + "/org/repo.git": "Bearer " + secretToken}}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/x-git-upload-pack-advertisement"}},
+			Body:       io.NopCloser(strings.NewReader("refs-response")),
+		}, nil
+	})}
 
 	// Capture log output.
 	var logBuf bytes.Buffer
 	logger := log.NewWithOptions(&logBuf, log.Options{})
+	h.logger = logger
 
-	h := newGitHandler(creds, logger)
-	h.client = upstream.Client()
-
-	req := httptest.NewRequest("GET", "/git/"+upstreamHost+"/org/repo.git/info/refs?service=git-upload-pack", nil)
-	req = withScope(req, scope)
+	req := httptest.NewRequest("GET", "/git/github.com/org/repo.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, &SandboxScope{
+		SandboxID: "sandbox-leak-test",
+		GuestIP:   "10.1.1.2",
+		Policy: &policy.CompiledPolicy{
+			Version: 1, NetworkDefault: "deny",
+			Allow: []policy.AllowRule{{Host: "github.com", Ports: []int{443}}},
+		},
+	})
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 

--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -91,7 +91,7 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	span := trace.SpanFromContext(r.Context())
 
-	upstreamHost, repoPath, err := splitGitRequestPath(r.URL.Path)
+	upstreamHost, repoPath, err := splitGitRequestURL(r.URL)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -257,10 +257,66 @@ func splitGitRequestPath(rawPath string) (string, string, error) {
 	if slashIdx <= 0 {
 		return "", "", fmt.Errorf("missing repository path")
 	}
-	return trimmed[:slashIdx], trimmed[slashIdx:], nil
+	upstreamHost, err := normalizeGitRouteHost(trimmed[:slashIdx])
+	if err != nil {
+		return "", "", err
+	}
+	return upstreamHost, trimmed[slashIdx:], nil
+}
+
+func splitGitRequestURL(u *url.URL) (string, string, error) {
+	if u == nil {
+		return "", "", fmt.Errorf("missing upstream host")
+	}
+	if err := validateGitRouteEscapedHost(u.EscapedPath()); err != nil {
+		return "", "", err
+	}
+	return splitGitRequestPath(u.Path)
+}
+
+func validateGitRouteEscapedHost(escapedPath string) error {
+	trimmed := strings.TrimPrefix(escapedPath, "/git/")
+	if trimmed == "" || trimmed == escapedPath {
+		return fmt.Errorf("missing upstream host")
+	}
+	slashIdx := strings.Index(trimmed, "/")
+	if slashIdx <= 0 {
+		return fmt.Errorf("missing repository path")
+	}
+	if strings.Contains(trimmed[:slashIdx], "%") {
+		return fmt.Errorf("invalid upstream host")
+	}
+	return nil
+}
+
+func normalizeGitRouteHost(rawHost string) (string, error) {
+	if rawHost == "" {
+		return "", fmt.Errorf("missing upstream host")
+	}
+	if rawHost != strings.TrimSpace(rawHost) {
+		return "", fmt.Errorf("invalid upstream host")
+	}
+	host := strings.ToLower(rawHost)
+	if strings.ContainsAny(host, "/\\@[]:?&#%") {
+		return "", fmt.Errorf("invalid upstream host")
+	}
+	for _, r := range host {
+		if r <= ' ' || r == 0x7f || r > 0x7e {
+			return "", fmt.Errorf("invalid upstream host")
+		}
+	}
+	parsed, err := url.Parse("https://" + host + "/")
+	if err != nil || parsed.User != nil || parsed.Host != host || parsed.Hostname() != host || parsed.Port() != "" {
+		return "", fmt.Errorf("invalid upstream host")
+	}
+	return host, nil
 }
 
 func canonicalUpstreamRemoteURL(upstreamHost, repoPath string) (string, error) {
+	normalizedHost, err := normalizeGitRouteHost(upstreamHost)
+	if err != nil {
+		return "", err
+	}
 	repositoryPath := repoPath
 	switch {
 	case strings.HasSuffix(repositoryPath, "/info/refs"):
@@ -275,7 +331,7 @@ func canonicalUpstreamRemoteURL(upstreamHost, repoPath string) (string, error) {
 	if strings.TrimSpace(repositoryPath) == "" || repositoryPath == "/" {
 		return "", fmt.Errorf("missing repository path")
 	}
-	return "https://" + upstreamHost + repositoryPath, nil
+	return "https://" + normalizedHost + repositoryPath, nil
 }
 
 func querySuffix(rawQuery string) string {
@@ -286,15 +342,16 @@ func querySuffix(rawQuery string) string {
 }
 
 func upstreamRequestURL(upstreamHost, repoPath, rawQuery string) (string, error) {
-	if strings.TrimSpace(upstreamHost) == "" {
-		return "", fmt.Errorf("missing upstream host")
+	normalizedHost, err := normalizeGitRouteHost(upstreamHost)
+	if err != nil {
+		return "", err
 	}
 	if strings.TrimSpace(repoPath) == "" || !strings.HasPrefix(repoPath, "/") {
 		return "", fmt.Errorf("missing repository path")
 	}
 	return (&url.URL{
 		Scheme:   "https",
-		Host:     upstreamHost,
+		Host:     normalizedHost,
 		Path:     repoPath,
 		RawQuery: rawQuery,
 	}).String(), nil

--- a/internal/gateway/git_cached.go
+++ b/internal/gateway/git_cached.go
@@ -46,7 +46,7 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	upstreamHost, repoPath, err := splitGitRequestPath(r.URL.Path)
+	upstreamHost, repoPath, err := splitGitRequestURL(r.URL)
 	if err != nil {
 		http.Error(w, "bad request: "+err.Error(), http.StatusBadRequest)
 		return
@@ -110,9 +110,10 @@ func (h *cachedGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionAllow, reasonCached)
 
 	// content-cache's git handler expects paths like /{host}/{repo}.git/...
-	// Strip the /git/ prefix so the cache handler sees the host-rooted path.
+	// Rebuild the path from the normalized route host so the cache layer sees
+	// the same authority that policy and owner checks already approved.
 	r = r.Clone(r.Context())
-	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/git")
+	r.URL.Path = "/" + upstreamHost + repoPath
 	r.URL.RawPath = ""
 	cacheHandler.ServeHTTP(w, r)
 }

--- a/internal/gateway/git_cached_test.go
+++ b/internal/gateway/git_cached_test.go
@@ -98,6 +98,72 @@ func TestCachedGitHandlerPolicyDeniesUnallowedHost(t *testing.T) {
 	requireGatewayRequestDecision(t, obs, gatewayActionDeny, reasonHostNotAllowed)
 }
 
+func TestCachedGitHandlerRejectsEmbeddedPortBeforeCacheOrFallback(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubGitHostHandlerProvider{
+		handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			t.Fatal("cache backend should not be called for an invalid route host")
+		}),
+	}
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("fallback should not be called for an invalid route host")
+	})
+	h := newCachedGitHandlerWithDirectFallback(provider, fallback, fallback, nil, false, nil)
+
+	scope := &SandboxScope{
+		SandboxID: "sandbox-cached-test",
+		GuestIP:   "10.1.1.2",
+		Policy: &policy.CompiledPolicy{
+			Version:        1,
+			NetworkDefault: "deny",
+			Allow: []policy.AllowRule{
+				{Host: "127.0.0.1", Ports: []int{443}},
+				{Host: "127.0.0.1:8443", Ports: []int{443}},
+			},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/git/127.0.0.1:8443/org/repo.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, scope)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if provider.host != "" {
+		t.Fatalf("expected cache handler lookup to be skipped, got %q", provider.host)
+	}
+}
+
+func TestCachedGitHandlerRejectsEscapedSlashBeforeCacheOrFallback(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubGitHostHandlerProvider{
+		handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			t.Fatal("cache backend should not be called for an invalid route host")
+		}),
+	}
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("fallback should not be called for an invalid route host")
+	})
+	h := newCachedGitHandlerWithDirectFallback(provider, fallback, fallback, nil, true, nil)
+
+	scope := cachedGitOwnedScope("github.com/org/")
+	req := httptest.NewRequest("GET", "/git/github.com%2forg/../private.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, scope)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if provider.host != "" {
+		t.Fatalf("expected cache handler lookup to be skipped, got %q", provider.host)
+	}
+}
+
 func TestCachedGitHandlerRejectsReceivePack(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gateway/git_test.go
+++ b/internal/gateway/git_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"charm.land/log/v2"
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"github.com/buildkite/cleanroom/internal/policy"
 	"go.opentelemetry.io/otel/attribute"
@@ -143,27 +144,14 @@ func TestGitHandlerMissingRepoPath(t *testing.T) {
 	}
 }
 
-func TestGitHandlerProxiesUpstream(t *testing.T) {
+func TestGitHandlerRejectsEmbeddedPortHost(t *testing.T) {
 	t.Parallel()
 
-	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
-			t.Errorf("expected Bearer test-token, got %q", auth)
-		}
-		if got, want := r.URL.Path, "/org/repo.git/info/refs"; got != want {
-			t.Fatalf("unexpected upstream path: got %q want %q", got, want)
-		}
-		if got, want := r.URL.RawQuery, "service=git-upload-pack"; got != want {
-			t.Fatalf("unexpected upstream query: got %q want %q", got, want)
-		}
-		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("git-refs-data"))
-	}))
-	defer upstream.Close()
-
-	// Extract host:port from upstream URL
-	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
+	h := newGitHandler(nil, nil)
+	h.client = &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("upstream transport should not be called for an invalid route host")
+		return nil, nil
+	})}
 
 	scope := &SandboxScope{
 		SandboxID: "sandbox-test",
@@ -171,16 +159,93 @@ func TestGitHandlerProxiesUpstream(t *testing.T) {
 		Policy: &policy.CompiledPolicy{
 			Version:        1,
 			NetworkDefault: "deny",
-			Allow:          []policy.AllowRule{{Host: upstreamHost, Ports: []int{443}}},
+			Allow: []policy.AllowRule{
+				{Host: "127.0.0.1", Ports: []int{443}},
+				{Host: "127.0.0.1:8443", Ports: []int{443}},
+			},
 		},
 	}
 
-	creds := &staticCredentialProvider{headers: map[string]string{"https://" + upstreamHost + "/org/repo.git": "Bearer test-token"}}
-	h := newGitHandler(creds, nil)
-	h.client = upstream.Client()
-
-	req := httptest.NewRequest("GET", "/git/"+upstreamHost+"/org/repo.git/info/refs?service=git-upload-pack", nil)
+	req := httptest.NewRequest("GET", "/git/127.0.0.1:8443/org/repo.git/info/refs?service=git-upload-pack", nil)
 	req = withScope(req, scope)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestGitHandlerRejectsEscapedSlashInRouteHost(t *testing.T) {
+	t.Parallel()
+
+	h := newGitHandlerWithMirrors(nil, nil, nil, true)
+	h.client = &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("upstream transport should not be called for an invalid route host")
+		return nil, nil
+	})}
+
+	scope := gitTestScope()
+	scope.GatewayScope = gatewayauth.ScopeMetadata{
+		Owner: gatewayauth.Owner{
+			PrincipalID: "oidc:test:alice",
+			Scope:       "repo:org/repo",
+		},
+		Authorization: gatewayauth.Authorization{
+			GitRepoPrefixes: []string{"github.com/org/"},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/git/github.com%2forg/../private.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, scope)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestSplitGitRequestPathRejectsUnsafeHosts(t *testing.T) {
+	t.Parallel()
+
+	for _, rawPath := range []string{
+		"/git/github.com:8443/org/repo.git/info/refs",
+		"/git/user@github.com/org/repo.git/info/refs",
+		"/git/github.com%3a8443/org/repo.git/info/refs",
+		"/git/github.com%zz/org/repo.git/info/refs",
+		"/git/[::1]/org/repo.git/info/refs",
+		"/git/github.com\\evil/org/repo.git/info/refs",
+		"/git/ github.com/org/repo.git/info/refs",
+	} {
+		if host, repoPath, err := splitGitRequestPath(rawPath); err == nil {
+			t.Fatalf("splitGitRequestPath(%q) = host %q repo %q, want error", rawPath, host, repoPath)
+		}
+	}
+}
+
+func TestGitHandlerProxiesUpstream(t *testing.T) {
+	t.Parallel()
+
+	h := newGitHandler(&staticCredentialProvider{headers: map[string]string{
+		"https://github.com/org/repo.git": "Bearer test-token",
+	}}, nil)
+	h.client = &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+			t.Errorf("expected Bearer test-token, got %q", auth)
+		}
+		if got, want := r.URL.String(), "https://github.com/org/repo.git/info/refs?service=git-upload-pack"; got != want {
+			t.Fatalf("unexpected upstream URL: got %q want %q", got, want)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/x-git-upload-pack-advertisement"}},
+			Body:       io.NopCloser(strings.NewReader("git-refs-data")),
+		}, nil
+	})}
+
+	req := httptest.NewRequest("GET", "/git/github.com/org/repo.git/info/refs?service=git-upload-pack", nil)
+	req = withScope(req, gitTestScope())
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -244,7 +309,10 @@ func TestGitHandlerAuditLogIncludesTraceCorrelation(t *testing.T) {
 func TestGitHandlerForwardsEndToEndHeadersAndStripsGatewayHeaders(t *testing.T) {
 	t.Parallel()
 
-	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := newGitHandler(&staticCredentialProvider{headers: map[string]string{
+		"https://github.com/org/repo.git": "Bearer test-token",
+	}}, nil)
+	h.client = &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		if got, want := r.Header.Get("Authorization"), "Bearer test-token"; got != want {
 			t.Fatalf("unexpected Authorization header: got %q want %q", got, want)
 		}
@@ -279,29 +347,15 @@ func TestGitHandlerForwardsEndToEndHeadersAndStripsGatewayHeaders(t *testing.T) 
 		if got, want := string(body), "request-payload"; got != want {
 			t.Fatalf("unexpected proxied body: got %q want %q", got, want)
 		}
-		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("packfile"))
-	}))
-	defer upstream.Close()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/x-git-upload-pack-result"}},
+			Body:       io.NopCloser(strings.NewReader("packfile")),
+		}, nil
+	})}
 
-	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
-	scope := &SandboxScope{
-		SandboxID: "sandbox-test",
-		GuestIP:   "10.1.1.2",
-		Policy: &policy.CompiledPolicy{
-			Version:        1,
-			NetworkDefault: "deny",
-			Allow:          []policy.AllowRule{{Host: upstreamHost, Ports: []int{443}}},
-		},
-	}
-
-	creds := &staticCredentialProvider{headers: map[string]string{"https://" + upstreamHost + "/org/repo.git": "Bearer test-token"}}
-	h := newGitHandler(creds, nil)
-	h.client = upstream.Client()
-
-	req := httptest.NewRequest("POST", "/git/"+upstreamHost+"/org/repo.git/git-upload-pack", strings.NewReader("request-payload"))
-	req = withScope(req, scope)
+	req := httptest.NewRequest("POST", "/git/github.com/org/repo.git/git-upload-pack", strings.NewReader("request-payload"))
+	req = withScope(req, gitTestScope())
 	req.Header.Set("Authorization", "Basic should-not-leak")
 	req.Header.Set("User-Agent", "git/2.49.0")
 	req.Header.Set("Git-Protocol", "version=2")


### PR DESCRIPTION
DeepSec's v0.10.0 scan found that the Git gateway accepted route hosts such as `127.0.0.1:8443`, authorized them as if they were `host:443`, and then let direct or cached Git paths build an outbound URL that preserved the embedded port.

This normalizes the `/git/<host>/...` route host before policy, owner, cache, and upstream URL handling. Hosts with explicit ports, userinfo, slashes, percent escapes, or other URL-authority syntax now fail before direct proxying, content-cache, or fallback handlers can run. Cached Git also rebuilds the content-cache path from the normalized host.

The normal `github.com` flow is still covered, while direct and cached embedded-port requests now return `400` without touching upstream/cache/fallback code. I ran `go test ./internal/gateway`, `mise run check`, and targeted DeepSec revalidation for `internal/gateway/git.go` and `internal/gateway/git_cached.go`; both critical findings revalidated as fixed.