### PR TITLE
fix: Gate darwin-vz helper cwd lookup

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 16 ready for review
+**Status:** Slice 17 ready for review
 **Last reviewed:** 2026-05-31
 
 ## Summary
@@ -21,6 +21,8 @@ DeepSec was rerun against the v0.10.0 release on 2026-05-31. That run tracked
 v0.10.0 fixing slice is scoped to the two critical Git gateway port-smuggling
 findings because they share one root cause: route hosts were authorized as
 host:443 while outbound URL construction could preserve an embedded port.
+Slice 16 closed both critical findings in PR #491. Slice 17 is scoped to the
+HIGH darwin-vz helper resolution finding.
 
 This plan tracks each finding separately while keeping implementation in
 reviewable slices. A slice may close several findings when they share the same
@@ -577,12 +579,49 @@ buffering finding, which remains a true positive outside this slice. DeepSec
 status now reports 12/12 findings revalidated, with 10 true positives and
 2 fixed findings.
 
+Slice 17 is implemented and ready for review. The darwin-vz helper resolver
+now keeps explicit `CLEANROOM_DARWIN_VZ_HELPER`, installed sibling helper, and
+PATH discovery, but no longer searches the current working directory or
+ancestor `dist/` directories unless `CLEANROOM_DARWIN_VZ_HELPER_ALLOW_CWD=1`
+is explicitly set for local development. This keeps normal installed helper
+resolution working while removing the default repo-local helper execution path
+from untrusted working directories.
+
+Focused validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/darwinvz -run 'TestResolveHelperBinaryPath|TestHelperWorkdirLookupAllowed|TestResolvePrebuiltBinaryPathFromWorkdirUsesAncestorDist'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/darwinvz
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Targeted DeepSec revalidation on 2026-05-31:
+
+```text
+cd /Users/lachlan/Develop/cleanroom/.deepsec
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec revalidate --project-id cleanroom-v0.10.0 --force --filter internal/backend/darwinvz/helper_client.go --concurrency 1 --root /Users/lachlan/.codex/worktrees/28db/cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec status --project-id cleanroom-v0.10.0
+```
+
+Result: the helper resolution finding revalidated as fixed. DeepSec status now
+reports 12/12 findings revalidated, with 9 true positives and 3 fixed findings.
+
 ## Triage
 
 | Finding | Severity | Decision | Remediation slice |
 | --- | --- | --- | --- |
 | Direct Git proxy allows SSRF via embedded port in upstream host | Critical | Fixed by Slice 16 | Slice 16: Git gateway route authority normalization |
 | Git cache route allows policy port bypass via port smuggling in upstream host | Critical | Fixed by Slice 16 | Slice 16: Git gateway route authority normalization |
+| Helper resolution can execute a repo-local binary on the host | High | Fixed by Slice 17 | Slice 17: gate darwin-vz CWD helper discovery |
 | File-handle gateway can host-dial private DNS answers | Critical | Needs fix | Slice 1: darwin-vz host-dial destination guard |
 | Submodule mirroring bypasses network policy and accepts file URLs | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
 | Submodule remotes are mirrored from the host without policy validation | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
@@ -629,6 +668,7 @@ status now reports 12/12 findings revalidated, with 10 true positives and
 14. Finish Git pack cache authorization binding.
 15. Bound dynamic Git content-cache handler creation.
 16. Normalize Git gateway route authorities before policy checks or outbound URL construction.
+17. Gate darwin-vz current-working-directory helper discovery behind explicit local-development opt-in.
 
 ## Key Learnings From Pressure-Testing
 

--- a/internal/backend/darwinvz/helper_path.go
+++ b/internal/backend/darwinvz/helper_path.go
@@ -10,16 +10,25 @@ import (
 )
 
 const (
-	helperBinaryName = "cleanroom-darwin-vz"
-	helperEnvVar     = "CLEANROOM_DARWIN_VZ_HELPER"
+	helperBinaryName         = "cleanroom-darwin-vz"
+	helperEnvVar             = "CLEANROOM_DARWIN_VZ_HELPER"
+	helperAllowWorkdirEnvVar = "CLEANROOM_DARWIN_VZ_HELPER_ALLOW_CWD"
 )
 
 func resolveHelperBinaryPath() (string, error) {
-	return resolveHelperBinaryPathWith(os.Getenv(helperEnvVar), exec.LookPath, os.Executable, os.Getwd, os.Stat)
+	return resolveHelperBinaryPathWith(
+		os.Getenv(helperEnvVar),
+		helperWorkdirLookupAllowed(os.Getenv(helperAllowWorkdirEnvVar)),
+		exec.LookPath,
+		os.Executable,
+		os.Getwd,
+		os.Stat,
+	)
 }
 
 func resolveHelperBinaryPathWith(
 	envOverride string,
+	allowWorkdirLookup bool,
 	lookPath func(string) (string, error),
 	executable func() (string, error),
 	getwd func() (string, error),
@@ -44,7 +53,7 @@ func resolveHelperBinaryPathWith(
 		}
 	}
 
-	if getwd != nil {
+	if allowWorkdirLookup && getwd != nil {
 		if cwd, err := getwd(); err == nil {
 			if path, err := resolvePrebuiltBinaryPathFromWorkdir(cwd, helperBinaryName, stat); err == nil {
 				return path, nil
@@ -57,11 +66,21 @@ func resolveHelperBinaryPathWith(
 	}
 
 	return "", fmt.Errorf(
-		"%s helper binary was not found (set %s, build prebuilt binaries with `mise run build`, or install %s in PATH)",
+		"%s helper binary was not found (set %s, set %s=1 after building prebuilt binaries with `mise run build`, or install %s in PATH)",
 		helperBinaryName,
 		helperEnvVar,
+		helperAllowWorkdirEnvVar,
 		helperBinaryName,
 	)
+}
+
+func helperWorkdirLookupAllowed(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func resolvePrebuiltBinaryPathFromWorkdir(startDir, binaryName string, stat func(string) (os.FileInfo, error)) (string, error) {

--- a/internal/backend/darwinvz/helper_path_test.go
+++ b/internal/backend/darwinvz/helper_path_test.go
@@ -19,6 +19,7 @@ func TestResolveHelperBinaryPathPrefersEnvOverride(t *testing.T) {
 
 	got, err := resolveHelperBinaryPathWith(
 		override,
+		false,
 		func(string) (string, error) { return "", errors.New("not found") },
 		func() (string, error) { return "", errors.New("no executable") },
 		func() (string, error) { return "", errors.New("no working directory") },
@@ -47,6 +48,7 @@ func TestResolveHelperBinaryPathUsesSiblingBeforePath(t *testing.T) {
 
 	got, err := resolveHelperBinaryPathWith(
 		"",
+		false,
 		func(string) (string, error) { return "/usr/local/bin/cleanroom-darwin-vz", nil },
 		func() (string, error) { return self, nil },
 		func() (string, error) { return "", errors.New("no working directory") },
@@ -83,6 +85,7 @@ func TestResolveHelperBinaryPathPrefersSiblingAppBundleOverLooseBinary(t *testin
 
 	got, err := resolveHelperBinaryPathWith(
 		"",
+		false,
 		func(string) (string, error) { return "/usr/local/bin/cleanroom-darwin-vz", nil },
 		func() (string, error) { return self, nil },
 		func() (string, error) { return "", errors.New("no working directory") },
@@ -111,6 +114,7 @@ func TestResolveHelperBinaryPathUsesAppBundleOverride(t *testing.T) {
 
 	got, err := resolveHelperBinaryPathWith(
 		appBundle,
+		false,
 		func(string) (string, error) { return "", errors.New("not found") },
 		func() (string, error) { return "", errors.New("no executable") },
 		func() (string, error) { return "", errors.New("no working directory") },
@@ -143,6 +147,7 @@ func TestResolveHelperBinaryPathUsesAncestorDistBeforePATH(t *testing.T) {
 
 	got, err := resolveHelperBinaryPathWith(
 		"",
+		true,
 		func(string) (string, error) { return "/usr/local/bin/cleanroom-darwin-vz", nil },
 		func() (string, error) { return "", errors.New("no executable") },
 		func() (string, error) { return cwd, nil },
@@ -153,6 +158,39 @@ func TestResolveHelperBinaryPathUsesAncestorDistBeforePATH(t *testing.T) {
 	}
 	if got != prebuilt {
 		t.Fatalf("unexpected helper path: got %q want %q", got, prebuilt)
+	}
+}
+
+func TestResolveHelperBinaryPathSkipsAncestorDistUnlessAllowed(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	repoRoot := tmp + "/repo"
+	cwd := repoRoot + "/nested/workdir"
+	prebuilt := repoRoot + "/dist/cleanroom-darwin-vz"
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+	if err := os.MkdirAll(repoRoot+"/dist", 0o755); err != nil {
+		t.Fatalf("mkdir dist: %v", err)
+	}
+	if err := os.WriteFile(prebuilt, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write prebuilt helper: %v", err)
+	}
+
+	got, err := resolveHelperBinaryPathWith(
+		"",
+		false,
+		func(string) (string, error) { return "/usr/local/bin/cleanroom-darwin-vz", nil },
+		func() (string, error) { return "", errors.New("no executable") },
+		func() (string, error) { return cwd, nil },
+		os.Stat,
+	)
+	if err != nil {
+		t.Fatalf("resolveHelperBinaryPathWith returned error: %v", err)
+	}
+	if got != "/usr/local/bin/cleanroom-darwin-vz" {
+		t.Fatalf("unexpected helper path: got %q", got)
 	}
 }
 
@@ -176,6 +214,7 @@ func TestResolveHelperBinaryPathUsesAncestorDistAppBundleBeforePATH(t *testing.T
 
 	got, err := resolveHelperBinaryPathWith(
 		"",
+		true,
 		func(string) (string, error) { return "/usr/local/bin/cleanroom-darwin-vz", nil },
 		func() (string, error) { return "", errors.New("no executable") },
 		func() (string, error) { return cwd, nil },
@@ -213,6 +252,7 @@ func TestResolveHelperBinaryPathPrefersAncestorDistAppBundleOverLooseBinary(t *t
 
 	got, err := resolveHelperBinaryPathWith(
 		"",
+		true,
 		func(string) (string, error) { return "/usr/local/bin/cleanroom-darwin-vz", nil },
 		func() (string, error) { return "", errors.New("no executable") },
 		func() (string, error) { return cwd, nil },
@@ -257,6 +297,7 @@ func TestResolveHelperBinaryPathPrefersSiblingBeforeAncestorDist(t *testing.T) {
 
 	got, err := resolveHelperBinaryPathWith(
 		"",
+		true,
 		func(string) (string, error) { return "/usr/local/bin/cleanroom-darwin-vz", nil },
 		func() (string, error) { return self, nil },
 		func() (string, error) { return cwd, nil },
@@ -275,6 +316,7 @@ func TestResolveHelperBinaryPathFallsBackToPATH(t *testing.T) {
 
 	got, err := resolveHelperBinaryPathWith(
 		"",
+		false,
 		func(string) (string, error) { return "/usr/local/bin/cleanroom-darwin-vz", nil },
 		func() (string, error) { return "", errors.New("no executable") },
 		func() (string, error) { return "", errors.New("no working directory") },
@@ -293,6 +335,7 @@ func TestResolveHelperBinaryPathReturnsActionableError(t *testing.T) {
 
 	_, err := resolveHelperBinaryPathWith(
 		"",
+		false,
 		func(string) (string, error) { return "", errors.New("not found") },
 		func() (string, error) { return "", errors.New("no executable") },
 		func() (string, error) { return "", errors.New("no working directory") },
@@ -301,8 +344,25 @@ func TestResolveHelperBinaryPathReturnsActionableError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if got := err.Error(); got == "" || !strings.Contains(got, "cleanroom-darwin-vz") || !strings.Contains(got, "CLEANROOM_DARWIN_VZ_HELPER") || !strings.Contains(got, "mise run build") {
-		t.Fatalf("unexpected error: %v", err)
+	for _, want := range []string{"cleanroom-darwin-vz", "CLEANROOM_DARWIN_VZ_HELPER", "CLEANROOM_DARWIN_VZ_HELPER_ALLOW_CWD", "mise run build"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got: %v", want, err)
+		}
+	}
+}
+
+func TestHelperWorkdirLookupAllowedParsesExplicitOptIn(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"1", "true", "TRUE", "yes", "on", " On "} {
+		if !helperWorkdirLookupAllowed(value) {
+			t.Fatalf("expected %q to enable workdir helper lookup", value)
+		}
+	}
+	for _, value := range []string{"", "0", "false", "no", "off", "random"} {
+		if helperWorkdirLookupAllowed(value) {
+			t.Fatalf("expected %q to disable workdir helper lookup", value)
+		}
 	}
 }
 


### PR DESCRIPTION
DeepSec flagged that darwin-vz helper discovery could walk upward from the current working directory and execute a repo-local `dist/cleanroom-darwin-vz` host binary. In source or development installs without a sibling helper, running Cleanroom inside an untrusted repository could hand that repository host-code execution before VM launch failed.

This keeps the explicit `CLEANROOM_DARWIN_VZ_HELPER`, installed sibling helper, and PATH lookup paths, but makes current-working-directory `dist/` discovery require `CLEANROOM_DARWIN_VZ_HELPER_ALLOW_CWD=1`. Local development with a freshly built repo helper remains available as an explicit opt-in, while the default resolver no longer trusts arbitrary working directories.

Focused helper-path tests cover the default skip and explicit opt-in behavior. `mise run check` passes locally, and targeted DeepSec revalidation for `internal/backend/darwinvz/helper_client.go` marks the finding fixed.