### PR TITLE
fix: Restore gateway scope after execution

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 17 ready for review
+**Status:** Slice 18 ready for review
 **Last reviewed:** 2026-05-31
 
 ## Summary
@@ -21,8 +21,9 @@ DeepSec was rerun against the v0.10.0 release on 2026-05-31. That run tracked
 v0.10.0 fixing slice is scoped to the two critical Git gateway port-smuggling
 findings because they share one root cause: route hosts were authorized as
 host:443 while outbound URL construction could preserve an embedded port.
-Slice 16 closed both critical findings in PR #491. Slice 17 is scoped to the
-HIGH darwin-vz helper resolution finding.
+Slice 16 closed both critical findings in PR #491. Slice 17 closed the HIGH
+darwin-vz helper resolution finding. Slice 18 closes the HIGH
+execution-scoped gateway credential cleanup finding for Firecracker sandboxes.
 
 This plan tracks each finding separately while keeping implementation in
 reviewable slices. A slice may close several findings when they share the same
@@ -615,6 +616,45 @@ npm exec --package=pnpm@9.15.4 -- pnpm deepsec status --project-id cleanroom-v0.
 Result: the helper resolution finding revalidated as fixed. DeepSec status now
 reports 12/12 findings revalidated, with 9 true positives and 3 fixed findings.
 
+Slice 18 is implemented and ready for review. Firecracker execution cleanup now
+clears both the active execution trace and the execution-scoped gateway
+authorization metadata. The gateway registry keeps the registered sandbox scope
+as the fallback authorization and restores it when the matching execution ends,
+while preserving the existing execution-ID guard so an older execution cannot
+clear a newer active scope. The trace-only cleanup path remains available for
+darwin-vz scope-token flows that release the token after each execution.
+
+Focused validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway -run 'TestRegistry.*ExecutionScope'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/firecracker -run 'TestRunInSandbox.*GatewayScope'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/firecracker
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Targeted DeepSec revalidation on 2026-05-31:
+
+```text
+cd /Users/lachlan/Develop/cleanroom/.deepsec
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec revalidate --project-id cleanroom-v0.10.0 --force --filter internal/backend/firecracker/backend.go --concurrency 1 --root /Users/lachlan/.codex/worktrees/28db/cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec status --project-id cleanroom-v0.10.0
+```
+
+Result: the execution-scoped gateway credential cleanup finding revalidated as
+fixed. DeepSec status now reports 12/12 findings revalidated, with 8 true
+positives and 4 fixed findings.
+
 ## Triage
 
 | Finding | Severity | Decision | Remediation slice |
@@ -622,6 +662,7 @@ reports 12/12 findings revalidated, with 9 true positives and 3 fixed findings.
 | Direct Git proxy allows SSRF via embedded port in upstream host | Critical | Fixed by Slice 16 | Slice 16: Git gateway route authority normalization |
 | Git cache route allows policy port bypass via port smuggling in upstream host | Critical | Fixed by Slice 16 | Slice 16: Git gateway route authority normalization |
 | Helper resolution can execute a repo-local binary on the host | High | Fixed by Slice 17 | Slice 17: gate darwin-vz CWD helper discovery |
+| Execution-scoped gateway credential authorization persists after execution | High | Fixed by Slice 18 | Slice 18: restore gateway scope after execution |
 | File-handle gateway can host-dial private DNS answers | Critical | Needs fix | Slice 1: darwin-vz host-dial destination guard |
 | Submodule mirroring bypasses network policy and accepts file URLs | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
 | Submodule remotes are mirrored from the host without policy validation | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
@@ -669,6 +710,7 @@ reports 12/12 findings revalidated, with 9 true positives and 3 fixed findings.
 15. Bound dynamic Git content-cache handler creation.
 16. Normalize Git gateway route authorities before policy checks or outbound URL construction.
 17. Gate darwin-vz current-working-directory helper discovery behind explicit local-development opt-in.
+18. Restore registered gateway authorization when Firecracker execution scopes end.
 
 ## Key Learnings From Pressure-Testing
 

--- a/internal/backend/firecracker/backend.go
+++ b/internal/backend/firecracker/backend.go
@@ -84,9 +84,8 @@ type Adapter struct {
 type gatewayRegistry interface {
 	Register(guestIP, sandboxID string, p *policy.CompiledPolicy, metadata ...gatewayauth.ScopeMetadata) error
 	Release(guestIP string)
-	SetActiveExecutionTrace(sandboxID, executionID string, spanContext trace.SpanContext)
 	SetActiveExecutionScope(sandboxID, executionID string, spanContext trace.SpanContext, metadata gatewayauth.ScopeMetadata)
-	ClearActiveExecutionTrace(sandboxID, executionID string)
+	ClearActiveExecutionScope(sandboxID, executionID string)
 }
 
 type sandboxInstance struct {
@@ -455,7 +454,7 @@ func (a *Adapter) RunInSandbox(ctx context.Context, req backend.ExecutionRequest
 	}
 	if a.GatewayRegistry != nil {
 		a.GatewayRegistry.SetActiveExecutionScope(sandboxID, req.ExecutionID, trace.SpanContextFromContext(ctx), req.GatewayScope)
-		defer a.GatewayRegistry.ClearActiveExecutionTrace(sandboxID, req.ExecutionID)
+		defer a.GatewayRegistry.ClearActiveExecutionScope(sandboxID, req.ExecutionID)
 	}
 
 	cacheOutputCaptures, err := cacheOutputFileCaptures(instance.cacheOutputVolumes, req.CacheOutputFileCaptures)

--- a/internal/backend/firecracker/persistent_test.go
+++ b/internal/backend/firecracker/persistent_test.go
@@ -680,14 +680,26 @@ func (testGatewayRegistry) SetActiveExecutionTrace(string, string, trace.SpanCon
 func (testGatewayRegistry) SetActiveExecutionScope(string, string, trace.SpanContext, gatewayauth.ScopeMetadata) {
 }
 func (testGatewayRegistry) ClearActiveExecutionTrace(string, string) {}
+func (testGatewayRegistry) ClearActiveExecutionScope(string, string) {}
 
 type capturingGatewayRegistry struct {
 	testGatewayRegistry
-	scope gatewayauth.ScopeMetadata
+	scope            gatewayauth.ScopeMetadata
+	setSandboxID     string
+	setExecutionID   string
+	clearSandboxID   string
+	clearExecutionID string
 }
 
-func (r *capturingGatewayRegistry) SetActiveExecutionScope(_ string, _ string, _ trace.SpanContext, metadata gatewayauth.ScopeMetadata) {
+func (r *capturingGatewayRegistry) SetActiveExecutionScope(sandboxID string, executionID string, _ trace.SpanContext, metadata gatewayauth.ScopeMetadata) {
+	r.setSandboxID = sandboxID
+	r.setExecutionID = executionID
 	r.scope = metadata.Clone()
+}
+
+func (r *capturingGatewayRegistry) ClearActiveExecutionScope(sandboxID, executionID string) {
+	r.clearSandboxID = sandboxID
+	r.clearExecutionID = executionID
 }
 
 func TestRunInSandboxUpdatesGatewayScope(t *testing.T) {
@@ -733,6 +745,18 @@ func TestRunInSandboxUpdatesGatewayScope(t *testing.T) {
 	}
 	if got, want := registry.scope.Authorization.GitRepoPrefixes, []string{"github.com/buildkite/cleanroom"}; !slices.Equal(got, want) {
 		t.Fatalf("gateway scope git prefixes mismatch: got %v want %v", got, want)
+	}
+	if got, want := registry.setSandboxID, "cr-test"; got != want {
+		t.Fatalf("set gateway scope sandbox mismatch: got %q want %q", got, want)
+	}
+	if got, want := registry.setExecutionID, "run-gateway-scope"; got != want {
+		t.Fatalf("set gateway scope execution mismatch: got %q want %q", got, want)
+	}
+	if got, want := registry.clearSandboxID, "cr-test"; got != want {
+		t.Fatalf("clear gateway scope sandbox mismatch: got %q want %q", got, want)
+	}
+	if got, want := registry.clearExecutionID, "run-gateway-scope"; got != want {
+		t.Fatalf("clear gateway scope execution mismatch: got %q want %q", got, want)
 	}
 }
 

--- a/internal/gateway/registry.go
+++ b/internal/gateway/registry.go
@@ -12,12 +12,13 @@ import (
 
 // SandboxScope holds the identity and policy for a registered sandbox.
 type SandboxScope struct {
-	SandboxID    string
-	GuestIP      string
-	Policy       *policy.CompiledPolicy
-	GatewayScope gatewayauth.ScopeMetadata
-	ExecutionID  string
-	TraceContext trace.SpanContext
+	SandboxID           string
+	GuestIP             string
+	Policy              *policy.CompiledPolicy
+	GatewayScope        gatewayauth.ScopeMetadata
+	defaultGatewayScope gatewayauth.ScopeMetadata
+	ExecutionID         string
+	TraceContext        trace.SpanContext
 }
 
 // Registry is a thread-safe mapping of guest IPs to sandbox scopes.
@@ -43,11 +44,13 @@ func (r *Registry) Register(guestIP, sandboxID string, p *policy.CompiledPolicy,
 	if _, exists := r.byGuestIP[guestIP]; exists {
 		return fmt.Errorf("guest IP %s already registered (possible IP collision)", guestIP)
 	}
+	defaultGatewayScope := firstScopeMetadata(metadata).Clone()
 	r.byGuestIP[guestIP] = &SandboxScope{
-		SandboxID:    sandboxID,
-		GuestIP:      guestIP,
-		Policy:       p,
-		GatewayScope: firstScopeMetadata(metadata).Clone(),
+		SandboxID:           sandboxID,
+		GuestIP:             guestIP,
+		Policy:              p,
+		GatewayScope:        defaultGatewayScope.Clone(),
+		defaultGatewayScope: defaultGatewayScope.Clone(),
 	}
 	return nil
 }
@@ -79,10 +82,12 @@ func (r *Registry) RegisterScopeToken(scopeToken, sandboxID string, p *policy.Co
 	if _, exists := r.byScopeToken[scopeToken]; exists {
 		return fmt.Errorf("scope token already registered")
 	}
+	defaultGatewayScope := firstScopeMetadata(metadata).Clone()
 	r.byScopeToken[scopeToken] = &SandboxScope{
-		SandboxID:    sandboxID,
-		Policy:       p,
-		GatewayScope: firstScopeMetadata(metadata).Clone(),
+		SandboxID:           sandboxID,
+		Policy:              p,
+		GatewayScope:        defaultGatewayScope.Clone(),
+		defaultGatewayScope: defaultGatewayScope.Clone(),
 	}
 	return nil
 }
@@ -157,12 +162,29 @@ func (r *Registry) ClearActiveExecutionTrace(sandboxID, executionID string) {
 	}
 }
 
+func (r *Registry) ClearActiveExecutionScope(sandboxID, executionID string) {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return
+	}
+	executionID = strings.TrimSpace(executionID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, scope := range r.byGuestIP {
+		clearActiveExecutionScopeForScope(scope, sandboxID, executionID)
+	}
+	for _, scope := range r.byScopeToken {
+		clearActiveExecutionScopeForScope(scope, sandboxID, executionID)
+	}
+}
+
 func cloneSandboxScope(scope *SandboxScope) *SandboxScope {
 	if scope == nil {
 		return nil
 	}
 	clone := *scope
 	clone.GatewayScope = scope.GatewayScope.Clone()
+	clone.defaultGatewayScope = scope.defaultGatewayScope.Clone()
 	return &clone
 }
 
@@ -192,4 +214,16 @@ func clearActiveExecutionTraceForScope(scope *SandboxScope, sandboxID, execution
 	}
 	scope.ExecutionID = ""
 	scope.TraceContext = trace.SpanContext{}
+}
+
+func clearActiveExecutionScopeForScope(scope *SandboxScope, sandboxID, executionID string) {
+	if scope == nil || scope.SandboxID != sandboxID {
+		return
+	}
+	if executionID != "" && strings.TrimSpace(scope.ExecutionID) != executionID {
+		return
+	}
+	scope.ExecutionID = ""
+	scope.TraceContext = trace.SpanContext{}
+	scope.GatewayScope = scope.defaultGatewayScope.Clone()
 }

--- a/internal/gateway/registry_test.go
+++ b/internal/gateway/registry_test.go
@@ -230,6 +230,80 @@ func TestRegistrySetActiveExecutionScopeUpdatesGatewayScope(t *testing.T) {
 	}
 }
 
+func TestRegistryClearActiveExecutionScopeRestoresRegisteredGatewayScope(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+
+	registered := gatewayauth.ScopeMetadata{
+		Owner: gatewayauth.Owner{PrincipalID: "oidc:test:old"},
+		Authorization: gatewayauth.Authorization{
+			GitRepoPrefixes: []string{"github.com/buildkite/original"},
+			OCIRepoPrefixes: []string{"ghcr.io/buildkite/original"},
+		},
+	}
+	if err := r.Register("10.1.1.2", "sandbox-1", testPolicy(), registered); err != nil {
+		t.Fatalf("register scope: %v", err)
+	}
+	if err := r.RegisterScopeToken("token-1", "sandbox-1", testPolicy(), registered); err != nil {
+		t.Fatalf("register scope token: %v", err)
+	}
+
+	r.SetActiveExecutionScope("sandbox-1", "exec-1", testSpanContext(), gatewayauth.ScopeMetadata{
+		Owner: gatewayauth.Owner{PrincipalID: "oidc:test:alice"},
+		Authorization: gatewayauth.Authorization{
+			GitRepoPrefixes: []string{"github.com/buildkite/cleanroom"},
+		},
+	})
+	r.ClearActiveExecutionScope("sandbox-1", "exec-1")
+
+	for name, scope := range map[string]*SandboxScope{
+		"guest IP":    mustLookupScope(t, r, "10.1.1.2"),
+		"scope token": mustLookupScopeToken(t, r, "token-1"),
+	} {
+		if got := scope.ExecutionID; got != "" {
+			t.Fatalf("%s execution id mismatch: got %q want empty", name, got)
+		}
+		if scope.TraceContext.IsValid() {
+			t.Fatalf("%s trace context should be cleared", name)
+		}
+		if got, want := scope.GatewayScope.Owner.PrincipalID, "oidc:test:old"; got != want {
+			t.Fatalf("%s gateway owner mismatch: got %q want %q", name, got, want)
+		}
+		if got, want := scope.GatewayScope.Authorization.GitRepoPrefixes[0], "github.com/buildkite/original"; got != want {
+			t.Fatalf("%s gateway git prefix mismatch: got %q want %q", name, got, want)
+		}
+		if got, want := scope.GatewayScope.Authorization.OCIRepoPrefixes[0], "ghcr.io/buildkite/original"; got != want {
+			t.Fatalf("%s gateway oci prefix mismatch: got %q want %q", name, got, want)
+		}
+	}
+}
+
+func TestRegistryClearActiveExecutionScopeIgnoresMismatchedExecution(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+
+	if err := r.Register("10.1.1.2", "sandbox-1", testPolicy(), gatewayauth.ScopeMetadata{
+		Owner: gatewayauth.Owner{PrincipalID: "oidc:test:old"},
+	}); err != nil {
+		t.Fatalf("register scope: %v", err)
+	}
+	r.SetActiveExecutionScope("sandbox-1", "exec-1", testSpanContext(), gatewayauth.ScopeMetadata{
+		Owner: gatewayauth.Owner{PrincipalID: "oidc:test:alice"},
+	})
+	r.ClearActiveExecutionScope("sandbox-1", "exec-other")
+
+	scope := mustLookupScope(t, r, "10.1.1.2")
+	if got, want := scope.ExecutionID, "exec-1"; got != want {
+		t.Fatalf("execution id mismatch: got %q want %q", got, want)
+	}
+	if !scope.TraceContext.IsValid() {
+		t.Fatal("trace context should still be active")
+	}
+	if got, want := scope.GatewayScope.Owner.PrincipalID, "oidc:test:alice"; got != want {
+		t.Fatalf("gateway owner mismatch: got %q want %q", got, want)
+	}
+}
+
 func TestRegistryDuplicateScopeTokenReturnsError(t *testing.T) {
 	t.Parallel()
 	r := NewRegistry()
@@ -263,6 +337,32 @@ func TestRegistryReleaseScopeToken(t *testing.T) {
 	if _, ok := r.LookupScopeToken("token-1"); ok {
 		t.Fatal("expected token lookup to fail after release")
 	}
+}
+
+func mustLookupScope(t *testing.T, r *Registry, guestIP string) *SandboxScope {
+	t.Helper()
+	scope, ok := r.Lookup(guestIP)
+	if !ok {
+		t.Fatalf("expected lookup for guest IP %q to succeed", guestIP)
+	}
+	return scope
+}
+
+func mustLookupScopeToken(t *testing.T, r *Registry, scopeToken string) *SandboxScope {
+	t.Helper()
+	scope, ok := r.LookupScopeToken(scopeToken)
+	if !ok {
+		t.Fatalf("expected lookup for scope token %q to succeed", scopeToken)
+	}
+	return scope
+}
+
+func testSpanContext() trace.SpanContext {
+	return trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{1},
+		SpanID:     trace.SpanID{2},
+		TraceFlags: trace.FlagsSampled,
+	})
 }
 
 func itoa(i int) string {


### PR DESCRIPTION
Firecracker sandboxes can keep running background processes after a single execution finishes. The gateway registry was updating the sandbox's authorization metadata for the active execution, then cleanup only cleared trace fields. That left the execution's Git and OCI authorization envelope attached to the sandbox until it was replaced or released.

This restores the registered sandbox gateway scope when the matching execution ends. The registry keeps a detached copy of the registered scope, clears both trace and scope metadata through `ClearActiveExecutionScope`, and Firecracker now defers that method after setting execution-scoped metadata. The existing execution-ID guard remains, so an older execution cannot clear a newer active scope.

The darwin-vz scope-token path still uses trace-only cleanup because those scopes are released after each execution. Targeted DeepSec revalidation for `internal/backend/firecracker/backend.go` now marks the finding fixed.
