### PR TITLE
fix: Gate DNS queries before forwarding

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -662,18 +662,21 @@ block disallowed queries before contacting upstream resolvers. When this gate
 is enabled, only query names allowed by the active sandbox policy or static
 gateway records are answered; denied names get `REFUSED`, invoke the deny hook,
 and do not create DNS observations. Policy-gated upstream requests also strip
-answer, authority, and additional sections from guest-supplied DNS messages so
-allowed question names cannot carry extra records upstream. They also rebuild
-allowed questions into canonical `IN` address, CNAME, HTTPS, or SVCB lookups so
-header fields, mixed-case QNAME bytes, QCLASS, and unsupported QTYPE values do
-not become covert channels. The gate is enabled for both darwin-vz file-handle
-DNS and Firecracker trusted DNS, and remains disabled when file-handle
-networking runs without a policy runtime.
+answer and authority sections from guest-supplied DNS messages so allowed
+question names cannot carry extra records upstream. For deny-by-default
+policies, they rebuild allowed questions into canonical `IN` address, CNAME,
+HTTPS, or SVCB lookups so header fields, mixed-case QNAME bytes, QCLASS, and
+unsupported QTYPE values do not become covert channels. Allow-default policies
+still permit broader `IN` lookup types, but the forwarder supplies its own DNS
+ID and EDNS capacity before restoring the guest's ID and question casing in the
+response. The gate is enabled for both darwin-vz file-handle DNS and
+Firecracker trusted DNS, and remains disabled when file-handle networking runs
+without a policy runtime.
 
 Focused validation run on 2026-05-31:
 
 ```text
-MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/dnsproxy -run 'TestForwarder(BlocksDisallowedQueryBeforeUpstream|AllowsPolicyQueryWhenBlockingDisallowedQueries|SanitizesAllowedQueryBeforeUpstream|BlocksUnsupportedQueryShapeBeforeUpstream|BlocksAliasWhenOnlyCNAMETargetAllowed|ServesStaticRecordsWithoutUpstreamObservationOrDeny)'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/dnsproxy -run 'TestForwarder(BlocksDisallowedQueryBeforeUpstream|AllowsPolicyQueryWhenBlockingDisallowedQueries|SanitizesAllowedQueryBeforeUpstream|BlocksUnsupportedQueryShapeBeforeUpstream|AllowsAnyINQueryTypeWhenPolicyAllowsAll|BlocksAliasWhenOnlyCNAMETargetAllowed|ServesStaticRecordsWithoutUpstreamObservationOrDeny)'
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/darwinvz -run 'TestStartFileHandleGatewayDoesNotResolveAllowRulesAtStartup|TestNewFileHandleDNSRuntime|TestFileHandleGateway'
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/firecracker -run 'TestSetupHostNetworkWithTrustedDNSFactory|TestTrustedDNS'
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/dnsproxy

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 18 ready for review
+**Status:** Slice 19 ready for review
 **Last reviewed:** 2026-05-31
 
 ## Summary
@@ -24,6 +24,8 @@ host:443 while outbound URL construction could preserve an embedded port.
 Slice 16 closed both critical findings in PR #491. Slice 17 closed the HIGH
 darwin-vz helper resolution finding. Slice 18 closes the HIGH
 execution-scoped gateway credential cleanup finding for Firecracker sandboxes.
+Slice 19 closes the HIGH DNS exfiltration finding by enforcing DNS policy before
+forwarding queries upstream.
 
 This plan tracks each finding separately while keeping implementation in
 reviewable slices. A slice may close several findings when they share the same
@@ -655,6 +657,48 @@ Result: the execution-scoped gateway credential cleanup finding revalidated as
 fixed. DeepSec status now reports 12/12 findings revalidated, with 8 true
 positives and 4 fixed findings.
 
+Slice 19 is implemented and ready for review. The shared DNS forwarder can now
+block disallowed queries before contacting upstream resolvers. When this gate
+is enabled, only query names allowed by the active sandbox policy or static
+gateway records are answered; denied names get `REFUSED`, invoke the deny hook,
+and do not create DNS observations. Policy-gated upstream requests also strip
+answer, authority, and additional sections from guest-supplied DNS messages so
+allowed question names cannot carry extra records upstream. The gate is enabled
+for both darwin-vz file-handle DNS and Firecracker trusted DNS.
+
+Focused validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/dnsproxy -run 'TestForwarder(BlocksDisallowedQueryBeforeUpstream|AllowsPolicyQueryWhenBlockingDisallowedQueries|StripsNonQuestionRecordsWhenBlockingDisallowedQueries|ServesStaticRecordsWithoutUpstreamObservationOrDeny)'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/darwinvz -run 'TestStartFileHandleGatewayDoesNotResolveAllowRulesAtStartup|TestNewFileHandleDNSRuntime|TestFileHandleGateway'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/firecracker -run 'TestSetupHostNetworkWithTrustedDNSFactory|TestTrustedDNS'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/dnsproxy
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/darwinvz
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/firecracker
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Targeted DeepSec revalidation on 2026-05-31:
+
+```text
+cd /Users/lachlan/Develop/cleanroom/.deepsec
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec revalidate --project-id cleanroom-v0.10.0 --force --filter internal/backend/darwinvz/filehandle_gateway.go --concurrency 1 --root /Users/lachlan/.codex/worktrees/28db/cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec status --project-id cleanroom-v0.10.0
+```
+
+Result: the DNS query exfiltration finding revalidated as fixed. DeepSec status
+now reports 12/12 findings revalidated, with 7 true positives and 5 fixed
+findings.
+
 ## Triage
 
 | Finding | Severity | Decision | Remediation slice |
@@ -663,6 +707,7 @@ positives and 4 fixed findings.
 | Git cache route allows policy port bypass via port smuggling in upstream host | Critical | Fixed by Slice 16 | Slice 16: Git gateway route authority normalization |
 | Helper resolution can execute a repo-local binary on the host | High | Fixed by Slice 17 | Slice 17: gate darwin-vz CWD helper discovery |
 | Execution-scoped gateway credential authorization persists after execution | High | Fixed by Slice 18 | Slice 18: restore gateway scope after execution |
+| Denied workloads can still exfiltrate data through DNS queries | High | Fixed by Slice 19 | Slice 19: DNS pre-query policy gate |
 | File-handle gateway can host-dial private DNS answers | Critical | Needs fix | Slice 1: darwin-vz host-dial destination guard |
 | Submodule mirroring bypasses network policy and accepts file URLs | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
 | Submodule remotes are mirrored from the host without policy validation | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
@@ -711,6 +756,7 @@ positives and 4 fixed findings.
 16. Normalize Git gateway route authorities before policy checks or outbound URL construction.
 17. Gate darwin-vz current-working-directory helper discovery behind explicit local-development opt-in.
 18. Restore registered gateway authorization when Firecracker execution scopes end.
+19. Gate DNS queries against sandbox policy before forwarding to upstream resolvers.
 
 ## Key Learnings From Pressure-Testing
 

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -663,13 +663,17 @@ is enabled, only query names allowed by the active sandbox policy or static
 gateway records are answered; denied names get `REFUSED`, invoke the deny hook,
 and do not create DNS observations. Policy-gated upstream requests also strip
 answer, authority, and additional sections from guest-supplied DNS messages so
-allowed question names cannot carry extra records upstream. The gate is enabled
-for both darwin-vz file-handle DNS and Firecracker trusted DNS.
+allowed question names cannot carry extra records upstream. They also rebuild
+allowed questions into canonical `IN` address, CNAME, HTTPS, or SVCB lookups so
+header fields, mixed-case QNAME bytes, QCLASS, and unsupported QTYPE values do
+not become covert channels. The gate is enabled for both darwin-vz file-handle
+DNS and Firecracker trusted DNS, and remains disabled when file-handle
+networking runs without a policy runtime.
 
 Focused validation run on 2026-05-31:
 
 ```text
-MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/dnsproxy -run 'TestForwarder(BlocksDisallowedQueryBeforeUpstream|AllowsPolicyQueryWhenBlockingDisallowedQueries|StripsNonQuestionRecordsWhenBlockingDisallowedQueries|ServesStaticRecordsWithoutUpstreamObservationOrDeny)'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/dnsproxy -run 'TestForwarder(BlocksDisallowedQueryBeforeUpstream|AllowsPolicyQueryWhenBlockingDisallowedQueries|SanitizesAllowedQueryBeforeUpstream|BlocksUnsupportedQueryShapeBeforeUpstream|BlocksAliasWhenOnlyCNAMETargetAllowed|ServesStaticRecordsWithoutUpstreamObservationOrDeny)'
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/darwinvz -run 'TestStartFileHandleGatewayDoesNotResolveAllowRulesAtStartup|TestNewFileHandleDNSRuntime|TestFileHandleGateway'
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/backend/firecracker -run 'TestSetupHostNetworkWithTrustedDNSFactory|TestTrustedDNS'
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/dnsproxy

--- a/internal/backend/darwinvz/filehandle_gateway.go
+++ b/internal/backend/darwinvz/filehandle_gateway.go
@@ -487,7 +487,7 @@ func newFileHandleVirtualNetwork(cfg fileHandleGatewayConfig, dnsUpstreamAddr st
 			Name:      gateway.GuestGatewayHostname,
 			Addresses: staticGatewayAddrs,
 		}},
-		BlockDisallowedQueries: true,
+		BlockDisallowedQueries: dnsRuntime != nil,
 	})
 	dnsUDPServer := &mdns.Server{
 		PacketConn: udpConn,

--- a/internal/backend/darwinvz/filehandle_gateway.go
+++ b/internal/backend/darwinvz/filehandle_gateway.go
@@ -487,6 +487,7 @@ func newFileHandleVirtualNetwork(cfg fileHandleGatewayConfig, dnsUpstreamAddr st
 			Name:      gateway.GuestGatewayHostname,
 			Addresses: staticGatewayAddrs,
 		}},
+		BlockDisallowedQueries: true,
 	})
 	dnsUDPServer := &mdns.Server{
 		PacketConn: udpConn,

--- a/internal/backend/firecracker/trusted_dns.go
+++ b/internal/backend/firecracker/trusted_dns.go
@@ -129,6 +129,7 @@ func newTrustedDNSService(_ context.Context, cfg trustedDNSConfig) (func(), *dns
 			Name:      gateway.GuestGatewayHostname,
 			Addresses: []netip.Addr{cfg.hostIP},
 		}},
+		BlockDisallowedQueries: true,
 	})
 
 	listenAddr := net.JoinHostPort(cfg.hostIP.String(), strconv.Itoa(trustedDNSListenPort))

--- a/internal/dnsproxy/forwarder.go
+++ b/internal/dnsproxy/forwarder.go
@@ -102,7 +102,7 @@ func (f *Forwarder) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 			_ = writeRefused(w, req)
 			return
 		}
-		upstreamReq = sanitizedQueryForUpstream(questions)
+		upstreamReq = sanitizedQueryForUpstream(questions, req.Id)
 	}
 	resp, _, err := f.client.Exchange(upstreamReq, f.upstreamAddr)
 	if err != nil || resp == nil {
@@ -111,6 +111,7 @@ func (f *Forwarder) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	}
 	if f.blockDisallowedQueries {
 		resp.Id = req.Id
+		resp.Question = append([]dns.Question(nil), req.Question...)
 	}
 
 	if err := w.WriteMsg(resp); err != nil {
@@ -131,12 +132,13 @@ func (f *Forwarder) questionsAllowedByPolicy(remoteAddr net.Addr, req *dns.Msg) 
 	if !ok {
 		return nil, false
 	}
+	allowAll := f.runtime.SandboxAllowsAllQueries(sandboxID)
 
 	allAllowed := true
 	questions := make([]dns.Question, 0, len(req.Question))
 	for _, question := range req.Question {
 		name := normalizeName(question.Name)
-		if name == "" || question.Qclass != dns.ClassINET || !allowedDNSQuestionType(question.Qtype) || !f.runtime.HostAllowedByPolicy(sandboxID, name) {
+		if name == "" || question.Qclass != dns.ClassINET || (!allowAll && !allowedDNSQuestionType(question.Qtype)) || !f.runtime.HostAllowedByPolicy(sandboxID, name) {
 			allAllowed = false
 			if f.onDeny != nil && name != "" {
 				f.onDeny(sandboxID, name)
@@ -164,12 +166,27 @@ func allowedDNSQuestionType(qtype uint16) bool {
 	}
 }
 
-func sanitizedQueryForUpstream(questions []dns.Question) *dns.Msg {
+func sanitizedQueryForUpstream(questions []dns.Question, originalID uint16) *dns.Msg {
 	msg := new(dns.Msg)
+	msg.Id = upstreamDNSID(originalID)
 	msg.MsgHdr.Opcode = dns.OpcodeQuery
 	msg.MsgHdr.RecursionDesired = true
 	msg.Question = append([]dns.Question(nil), questions...)
+	msg.SetEdns0(1232, false)
 	return msg
+}
+
+func upstreamDNSID(originalID uint16) uint16 {
+	for i := 0; i < 4; i++ {
+		id := dns.Id()
+		if id != 0 && id != originalID {
+			return id
+		}
+	}
+	if originalID != 1 {
+		return 1
+	}
+	return 2
 }
 
 func (f *Forwarder) observeScopedResponse(remoteAddr net.Addr, resp *dns.Msg) {

--- a/internal/dnsproxy/forwarder.go
+++ b/internal/dnsproxy/forwarder.go
@@ -33,27 +33,29 @@ type StaticRecord struct {
 
 // ForwarderConfig configures a DNS forwarding handler.
 type ForwarderConfig struct {
-	Runtime       *Runtime
-	UpstreamAddr  string
-	ScopeResolver ScopeResolver
-	Client        DNSClient
-	Now           func() time.Time
-	OnObserve     ObserveHook
-	OnDeny        DenyHook
-	StaticRecords []StaticRecord
+	Runtime                *Runtime
+	UpstreamAddr           string
+	ScopeResolver          ScopeResolver
+	Client                 DNSClient
+	Now                    func() time.Time
+	OnObserve              ObserveHook
+	OnDeny                 DenyHook
+	StaticRecords          []StaticRecord
+	BlockDisallowedQueries bool
 }
 
 // Forwarder forwards DNS requests to an upstream resolver and records the
 // answers in the runtime when the caller is mapped to a sandbox scope.
 type Forwarder struct {
-	runtime       *Runtime
-	upstreamAddr  string
-	scopeResolver ScopeResolver
-	client        DNSClient
-	now           func() time.Time
-	onObserve     ObserveHook
-	onDeny        DenyHook
-	staticRecords map[string][]netip.Addr
+	runtime                *Runtime
+	upstreamAddr           string
+	scopeResolver          ScopeResolver
+	client                 DNSClient
+	now                    func() time.Time
+	onObserve              ObserveHook
+	onDeny                 DenyHook
+	staticRecords          map[string][]netip.Addr
+	blockDisallowedQueries bool
 }
 
 // NewForwarder creates a DNS forwarding handler backed by miekg/dns.
@@ -67,14 +69,15 @@ func NewForwarder(cfg ForwarderConfig) *Forwarder {
 		now = func() time.Time { return time.Now().UTC() }
 	}
 	return &Forwarder{
-		runtime:       cfg.Runtime,
-		upstreamAddr:  cfg.UpstreamAddr,
-		scopeResolver: cfg.ScopeResolver,
-		client:        client,
-		now:           now,
-		onObserve:     cfg.OnObserve,
-		onDeny:        cfg.OnDeny,
-		staticRecords: normalizeStaticRecords(cfg.StaticRecords),
+		runtime:                cfg.Runtime,
+		upstreamAddr:           cfg.UpstreamAddr,
+		scopeResolver:          cfg.ScopeResolver,
+		client:                 client,
+		now:                    now,
+		onObserve:              cfg.OnObserve,
+		onDeny:                 cfg.OnDeny,
+		staticRecords:          normalizeStaticRecords(cfg.StaticRecords),
+		blockDisallowedQueries: cfg.BlockDisallowedQueries,
 	}
 }
 
@@ -92,8 +95,18 @@ func (f *Forwarder) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		_ = writeServerFailure(w, req)
 		return
 	}
+	if f.blockDisallowedQueries && !f.queryAllowedByPolicy(w.RemoteAddr(), req) {
+		_ = writeRefused(w, req)
+		return
+	}
 
-	resp, _, err := f.client.Exchange(req.Copy(), f.upstreamAddr)
+	upstreamReq := req.Copy()
+	if f.blockDisallowedQueries {
+		upstreamReq.Answer = nil
+		upstreamReq.Ns = nil
+		upstreamReq.Extra = nil
+	}
+	resp, _, err := f.client.Exchange(upstreamReq, f.upstreamAddr)
 	if err != nil || resp == nil {
 		_ = writeServerFailure(w, req)
 		return
@@ -103,6 +116,33 @@ func (f *Forwarder) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		return
 	}
 	f.observeScopedResponse(w.RemoteAddr(), resp)
+}
+
+func (f *Forwarder) queryAllowedByPolicy(remoteAddr net.Addr, req *dns.Msg) bool {
+	if f.runtime == nil || f.scopeResolver == nil || req == nil || len(req.Question) == 0 {
+		return false
+	}
+	sourceIP, ok := addrFromNetAddr(remoteAddr)
+	if !ok {
+		return false
+	}
+	sandboxID, ok := f.scopeResolver(sourceIP)
+	if !ok {
+		return false
+	}
+
+	allowed := true
+	for _, question := range req.Question {
+		name := normalizeName(question.Name)
+		if name != "" && f.runtime.HostAllowedByPolicy(sandboxID, name) {
+			continue
+		}
+		allowed = false
+		if f.onDeny != nil && name != "" {
+			f.onDeny(sandboxID, name)
+		}
+	}
+	return allowed
 }
 
 func (f *Forwarder) observeScopedResponse(remoteAddr net.Addr, resp *dns.Msg) {
@@ -171,6 +211,17 @@ func writeServerFailure(w dns.ResponseWriter, req *dns.Msg) error {
 		msg.SetRcode(req, dns.RcodeServerFailure)
 	} else {
 		msg.MsgHdr.Rcode = dns.RcodeServerFailure
+		msg.Response = true
+	}
+	return w.WriteMsg(msg)
+}
+
+func writeRefused(w dns.ResponseWriter, req *dns.Msg) error {
+	msg := new(dns.Msg)
+	if req != nil {
+		msg.SetRcode(req, dns.RcodeRefused)
+	} else {
+		msg.MsgHdr.Rcode = dns.RcodeRefused
 		msg.Response = true
 	}
 	return w.WriteMsg(msg)

--- a/internal/dnsproxy/forwarder.go
+++ b/internal/dnsproxy/forwarder.go
@@ -95,21 +95,22 @@ func (f *Forwarder) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		_ = writeServerFailure(w, req)
 		return
 	}
-	if f.blockDisallowedQueries && !f.queryAllowedByPolicy(w.RemoteAddr(), req) {
-		_ = writeRefused(w, req)
-		return
-	}
-
 	upstreamReq := req.Copy()
 	if f.blockDisallowedQueries {
-		upstreamReq.Answer = nil
-		upstreamReq.Ns = nil
-		upstreamReq.Extra = nil
+		questions, ok := f.questionsAllowedByPolicy(w.RemoteAddr(), req)
+		if !ok {
+			_ = writeRefused(w, req)
+			return
+		}
+		upstreamReq = sanitizedQueryForUpstream(questions)
 	}
 	resp, _, err := f.client.Exchange(upstreamReq, f.upstreamAddr)
 	if err != nil || resp == nil {
 		_ = writeServerFailure(w, req)
 		return
+	}
+	if f.blockDisallowedQueries {
+		resp.Id = req.Id
 	}
 
 	if err := w.WriteMsg(resp); err != nil {
@@ -118,31 +119,57 @@ func (f *Forwarder) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 	f.observeScopedResponse(w.RemoteAddr(), resp)
 }
 
-func (f *Forwarder) queryAllowedByPolicy(remoteAddr net.Addr, req *dns.Msg) bool {
+func (f *Forwarder) questionsAllowedByPolicy(remoteAddr net.Addr, req *dns.Msg) ([]dns.Question, bool) {
 	if f.runtime == nil || f.scopeResolver == nil || req == nil || len(req.Question) == 0 {
-		return false
+		return nil, false
 	}
 	sourceIP, ok := addrFromNetAddr(remoteAddr)
 	if !ok {
-		return false
+		return nil, false
 	}
 	sandboxID, ok := f.scopeResolver(sourceIP)
 	if !ok {
-		return false
+		return nil, false
 	}
 
-	allowed := true
+	allAllowed := true
+	questions := make([]dns.Question, 0, len(req.Question))
 	for _, question := range req.Question {
 		name := normalizeName(question.Name)
-		if name != "" && f.runtime.HostAllowedByPolicy(sandboxID, name) {
+		if name == "" || question.Qclass != dns.ClassINET || !allowedDNSQuestionType(question.Qtype) || !f.runtime.HostAllowedByPolicy(sandboxID, name) {
+			allAllowed = false
+			if f.onDeny != nil && name != "" {
+				f.onDeny(sandboxID, name)
+			}
 			continue
 		}
-		allowed = false
-		if f.onDeny != nil && name != "" {
-			f.onDeny(sandboxID, name)
-		}
+		questions = append(questions, dns.Question{
+			Name:   dns.Fqdn(name),
+			Qtype:  question.Qtype,
+			Qclass: dns.ClassINET,
+		})
 	}
-	return allowed
+	if !allAllowed || len(questions) == 0 {
+		return nil, false
+	}
+	return questions, true
+}
+
+func allowedDNSQuestionType(qtype uint16) bool {
+	switch qtype {
+	case dns.TypeA, dns.TypeAAAA, dns.TypeCNAME, dns.TypeHTTPS, dns.TypeSVCB:
+		return true
+	default:
+		return false
+	}
+}
+
+func sanitizedQueryForUpstream(questions []dns.Question) *dns.Msg {
+	msg := new(dns.Msg)
+	msg.MsgHdr.Opcode = dns.OpcodeQuery
+	msg.MsgHdr.RecursionDesired = true
+	msg.Question = append([]dns.Question(nil), questions...)
+	return msg
 }
 
 func (f *Forwarder) observeScopedResponse(remoteAddr net.Addr, resp *dns.Msg) {

--- a/internal/dnsproxy/runtime.go
+++ b/internal/dnsproxy/runtime.go
@@ -452,6 +452,17 @@ func (r *Runtime) HostAllowedByPolicy(sandboxID, host string) bool {
 	return state.policy.HostAllowed(host)
 }
 
+func (r *Runtime) SandboxAllowsAllQueries(sandboxID string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	state, ok := r.sandboxes[strings.TrimSpace(sandboxID)]
+	if !ok {
+		return false
+	}
+	return state.allowsAllConnections()
+}
+
 func (r *Runtime) queryAllowedByPolicy(sandboxID string, sourceIP netip.Addr, resp *dns.Msg, queryName string, now time.Time) bool {
 	sourceIP = normalizeAddr(sourceIP)
 	queryName = normalizeName(queryName)

--- a/internal/dnsproxy/runtime_test.go
+++ b/internal/dnsproxy/runtime_test.go
@@ -945,7 +945,7 @@ func TestForwarderAllowsPolicyQueryWhenBlockingDisallowedQueries(t *testing.T) {
 	}
 }
 
-func TestForwarderStripsNonQuestionRecordsWhenBlockingDisallowedQueries(t *testing.T) {
+func TestForwarderSanitizesAllowedQueryBeforeUpstream(t *testing.T) {
 	t.Parallel()
 
 	runtime := NewRuntime(RuntimeConfig{})
@@ -957,6 +957,11 @@ func TestForwarderStripsNonQuestionRecordsWhenBlockingDisallowedQueries(t *testi
 
 	sourceIP := netip.MustParseAddr("10.0.0.2")
 	var gotAnswer, gotAuthority, gotExtra int
+	var gotID uint16
+	var gotName string
+	var gotQtype, gotQclass uint16
+	var gotOpcode int
+	var gotRecursionDesired bool
 	forwarder := NewForwarder(ForwarderConfig{
 		Runtime:                runtime,
 		UpstreamAddr:           "127.0.0.1:5300",
@@ -968,6 +973,14 @@ func TestForwarderStripsNonQuestionRecordsWhenBlockingDisallowedQueries(t *testi
 			return "", false
 		},
 		Client: exchangeFunc(func(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+			gotID = msg.Id
+			gotOpcode = msg.Opcode
+			gotRecursionDesired = msg.RecursionDesired
+			if len(msg.Question) == 1 {
+				gotName = msg.Question[0].Name
+				gotQtype = msg.Question[0].Qtype
+				gotQclass = msg.Question[0].Qclass
+			}
 			gotAnswer = len(msg.Answer)
 			gotAuthority = len(msg.Ns)
 			gotExtra = len(msg.Extra)
@@ -980,7 +993,8 @@ func TestForwarderStripsNonQuestionRecordsWhenBlockingDisallowedQueries(t *testi
 		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
 	}
 	request := new(dns.Msg)
-	request.SetQuestion("api.example.com.", dns.TypeA)
+	request.Id = 1234
+	request.SetQuestion("ApI.ExAmPlE.CoM.", dns.TypeA)
 	request.Answer = []dns.RR{&dns.TXT{
 		Hdr: dns.RR_Header{Name: "leak-answer.example.com.", Rrtype: dns.TypeTXT, Class: dns.ClassINET},
 		Txt: []string{"secret"},
@@ -996,8 +1010,115 @@ func TestForwarderStripsNonQuestionRecordsWhenBlockingDisallowedQueries(t *testi
 
 	forwarder.ServeDNS(writer, request)
 
+	if gotID != 0 {
+		t.Fatalf("expected upstream query id to be rebuilt, got %d", gotID)
+	}
+	if gotOpcode != dns.OpcodeQuery || !gotRecursionDesired {
+		t.Fatalf("unexpected upstream query flags: opcode=%d recursion_desired=%v", gotOpcode, gotRecursionDesired)
+	}
+	if gotName != "api.example.com." || gotQtype != dns.TypeA || gotQclass != dns.ClassINET {
+		t.Fatalf("unexpected sanitized question: name=%q qtype=%d qclass=%d", gotName, gotQtype, gotQclass)
+	}
 	if gotAnswer != 0 || gotAuthority != 0 || gotExtra != 0 {
 		t.Fatalf("expected upstream query sections to be stripped, got answer=%d authority=%d extra=%d", gotAnswer, gotAuthority, gotExtra)
+	}
+	if writer.message == nil || writer.message.Id != request.Id {
+		t.Fatalf("expected response id to be restored to %d, got %#v", request.Id, writer.message)
+	}
+}
+
+func TestForwarderBlocksUnsupportedQueryShapeBeforeUpstream(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "api.example.com", Ports: []int{443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	upstreamCalls := 0
+	forwarder := NewForwarder(ForwarderConfig{
+		Runtime:                runtime,
+		UpstreamAddr:           "127.0.0.1:5300",
+		BlockDisallowedQueries: true,
+		ScopeResolver: func(addr netip.Addr) (string, bool) {
+			if addr == sourceIP {
+				return "sandbox-1", true
+			}
+			return "", false
+		},
+		Client: exchangeFunc(func(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+			upstreamCalls++
+			return testResponse(msg.Question[0].Name), 0, nil
+		}),
+	})
+
+	writer := &testResponseWriter{
+		remoteAddr: &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 53000},
+		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
+	}
+	request := new(dns.Msg)
+	request.SetQuestion("api.example.com.", dns.TypeTXT)
+
+	forwarder.ServeDNS(writer, request)
+
+	if upstreamCalls != 0 {
+		t.Fatalf("expected unsupported query type to skip upstream exchange, got %d calls", upstreamCalls)
+	}
+	if writer.message == nil || writer.message.Rcode != dns.RcodeRefused {
+		t.Fatalf("expected refused response, got %#v", writer.message)
+	}
+}
+
+func TestForwarderBlocksAliasWhenOnlyCNAMETargetAllowed(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "cdn.example.com", Ports: []int{443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	upstreamCalls := 0
+	forwarder := NewForwarder(ForwarderConfig{
+		Runtime:                runtime,
+		UpstreamAddr:           "127.0.0.1:5300",
+		BlockDisallowedQueries: true,
+		ScopeResolver: func(addr netip.Addr) (string, bool) {
+			if addr == sourceIP {
+				return "sandbox-1", true
+			}
+			return "", false
+		},
+		Client: exchangeFunc(func(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+			upstreamCalls++
+			return testResponse(msg.Question[0].Name,
+				&dns.CNAME{
+					Hdr:    dns.RR_Header{Name: msg.Question[0].Name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 30},
+					Target: "cdn.example.com.",
+				},
+			), 0, nil
+		}),
+	})
+
+	writer := &testResponseWriter{
+		remoteAddr: &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 53000},
+		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
+	}
+	request := new(dns.Msg)
+	request.SetQuestion("service.example.com.", dns.TypeA)
+
+	forwarder.ServeDNS(writer, request)
+
+	if upstreamCalls != 0 {
+		t.Fatalf("expected non-allowlisted alias query to skip upstream exchange, got %d calls", upstreamCalls)
+	}
+	if writer.message == nil || writer.message.Rcode != dns.RcodeRefused {
+		t.Fatalf("expected refused response, got %#v", writer.message)
 	}
 }
 

--- a/internal/dnsproxy/runtime_test.go
+++ b/internal/dnsproxy/runtime_test.go
@@ -962,6 +962,8 @@ func TestForwarderSanitizesAllowedQueryBeforeUpstream(t *testing.T) {
 	var gotQtype, gotQclass uint16
 	var gotOpcode int
 	var gotRecursionDesired bool
+	var gotEDNSUDPSize uint16
+	var gotEDNSOptions int
 	forwarder := NewForwarder(ForwarderConfig{
 		Runtime:                runtime,
 		UpstreamAddr:           "127.0.0.1:5300",
@@ -984,6 +986,10 @@ func TestForwarderSanitizesAllowedQueryBeforeUpstream(t *testing.T) {
 			gotAnswer = len(msg.Answer)
 			gotAuthority = len(msg.Ns)
 			gotExtra = len(msg.Extra)
+			if opt := msg.IsEdns0(); opt != nil {
+				gotEDNSUDPSize = opt.UDPSize()
+				gotEDNSOptions = len(opt.Option)
+			}
 			return testResponse(msg.Question[0].Name), 0, nil
 		}),
 	})
@@ -993,8 +999,8 @@ func TestForwarderSanitizesAllowedQueryBeforeUpstream(t *testing.T) {
 		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
 	}
 	request := new(dns.Msg)
-	request.Id = 1234
 	request.SetQuestion("ApI.ExAmPlE.CoM.", dns.TypeA)
+	request.Id = 1234
 	request.Answer = []dns.RR{&dns.TXT{
 		Hdr: dns.RR_Header{Name: "leak-answer.example.com.", Rrtype: dns.TypeTXT, Class: dns.ClassINET},
 		Txt: []string{"secret"},
@@ -1010,8 +1016,8 @@ func TestForwarderSanitizesAllowedQueryBeforeUpstream(t *testing.T) {
 
 	forwarder.ServeDNS(writer, request)
 
-	if gotID != 0 {
-		t.Fatalf("expected upstream query id to be rebuilt, got %d", gotID)
+	if gotID == 0 || gotID == request.Id {
+		t.Fatalf("expected upstream query id to be host-generated, got %d with original %d", gotID, request.Id)
 	}
 	if gotOpcode != dns.OpcodeQuery || !gotRecursionDesired {
 		t.Fatalf("unexpected upstream query flags: opcode=%d recursion_desired=%v", gotOpcode, gotRecursionDesired)
@@ -1019,11 +1025,14 @@ func TestForwarderSanitizesAllowedQueryBeforeUpstream(t *testing.T) {
 	if gotName != "api.example.com." || gotQtype != dns.TypeA || gotQclass != dns.ClassINET {
 		t.Fatalf("unexpected sanitized question: name=%q qtype=%d qclass=%d", gotName, gotQtype, gotQclass)
 	}
-	if gotAnswer != 0 || gotAuthority != 0 || gotExtra != 0 {
+	if gotAnswer != 0 || gotAuthority != 0 || gotExtra != 1 || gotEDNSUDPSize != 1232 || gotEDNSOptions != 0 {
 		t.Fatalf("expected upstream query sections to be stripped, got answer=%d authority=%d extra=%d", gotAnswer, gotAuthority, gotExtra)
 	}
 	if writer.message == nil || writer.message.Id != request.Id {
 		t.Fatalf("expected response id to be restored to %d, got %#v", request.Id, writer.message)
+	}
+	if len(writer.message.Question) != 1 || writer.message.Question[0].Name != "ApI.ExAmPlE.CoM." {
+		t.Fatalf("expected response question to preserve original casing, got %+v", writer.message.Question)
 	}
 }
 
@@ -1069,6 +1078,52 @@ func TestForwarderBlocksUnsupportedQueryShapeBeforeUpstream(t *testing.T) {
 	}
 	if writer.message == nil || writer.message.Rcode != dns.RcodeRefused {
 		t.Fatalf("expected refused response, got %#v", writer.message)
+	}
+}
+
+func TestForwarderAllowsAnyINQueryTypeWhenPolicyAllowsAll(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if err := runtime.RegisterSandbox("sandbox-1", &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "allow",
+	}); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	var gotQtype uint16
+	forwarder := NewForwarder(ForwarderConfig{
+		Runtime:                runtime,
+		UpstreamAddr:           "127.0.0.1:5300",
+		BlockDisallowedQueries: true,
+		ScopeResolver: func(addr netip.Addr) (string, bool) {
+			if addr == sourceIP {
+				return "sandbox-1", true
+			}
+			return "", false
+		},
+		Client: exchangeFunc(func(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+			gotQtype = msg.Question[0].Qtype
+			return testResponse(msg.Question[0].Name), 0, nil
+		}),
+	})
+
+	writer := &testResponseWriter{
+		remoteAddr: &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 53000},
+		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
+	}
+	request := new(dns.Msg)
+	request.SetQuestion("txt.example.com.", dns.TypeTXT)
+
+	forwarder.ServeDNS(writer, request)
+
+	if gotQtype != dns.TypeTXT {
+		t.Fatalf("expected TXT query to reach upstream under allow-all policy, got qtype %d", gotQtype)
+	}
+	if writer.message == nil || writer.message.Rcode != dns.RcodeSuccess {
+		t.Fatalf("expected successful response, got %#v", writer.message)
 	}
 }
 

--- a/internal/dnsproxy/runtime_test.go
+++ b/internal/dnsproxy/runtime_test.go
@@ -827,6 +827,180 @@ func TestForwarderRecordsScopedUpstreamAnswers(t *testing.T) {
 	}
 }
 
+func TestForwarderBlocksDisallowedQueryBeforeUpstream(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "api.example.com", Ports: []int{443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	now := time.Date(2026, time.April, 12, 9, 0, 0, 0, time.UTC)
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	upstreamCalls := 0
+	var denied []string
+	forwarder := NewForwarder(ForwarderConfig{
+		Runtime:                runtime,
+		UpstreamAddr:           "127.0.0.1:5300",
+		Now:                    func() time.Time { return now },
+		BlockDisallowedQueries: true,
+		ScopeResolver: func(addr netip.Addr) (string, bool) {
+			if addr == sourceIP {
+				return "sandbox-1", true
+			}
+			return "", false
+		},
+		Client: exchangeFunc(func(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+			upstreamCalls++
+			return testResponse(msg.Question[0].Name), 0, nil
+		}),
+		OnDeny: func(_, queryName string) {
+			denied = append(denied, queryName)
+		},
+	})
+
+	writer := &testResponseWriter{
+		remoteAddr: &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 53000},
+		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
+	}
+	request := new(dns.Msg)
+	request.SetQuestion("leak.example.com.", dns.TypeA)
+
+	forwarder.ServeDNS(writer, request)
+
+	if upstreamCalls != 0 {
+		t.Fatalf("expected disallowed query to skip upstream exchange, got %d calls", upstreamCalls)
+	}
+	if writer.message == nil {
+		t.Fatal("expected forwarder to write a refusal")
+	}
+	if got, want := writer.message.Rcode, dns.RcodeRefused; got != want {
+		t.Fatalf("unexpected response code: got %d want %d", got, want)
+	}
+	if len(denied) != 1 || denied[0] != "leak.example.com" {
+		t.Fatalf("expected deny hook for leak.example.com, got %v", denied)
+	}
+	if observations := runtime.Observations("sandbox-1", now); len(observations) != 0 {
+		t.Fatalf("did not expect refused query to populate observations: %+v", observations)
+	}
+}
+
+func TestForwarderAllowsPolicyQueryWhenBlockingDisallowedQueries(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "api.example.com", Ports: []int{443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	now := time.Date(2026, time.April, 12, 9, 5, 0, 0, time.UTC)
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	upstreamCalls := 0
+	forwarder := NewForwarder(ForwarderConfig{
+		Runtime:                runtime,
+		UpstreamAddr:           "127.0.0.1:5300",
+		Now:                    func() time.Time { return now },
+		BlockDisallowedQueries: true,
+		ScopeResolver: func(addr netip.Addr) (string, bool) {
+			if addr == sourceIP {
+				return "sandbox-1", true
+			}
+			return "", false
+		},
+		Client: exchangeFunc(func(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+			upstreamCalls++
+			return testResponse(msg.Question[0].Name,
+				&dns.A{
+					Hdr: dns.RR_Header{Name: msg.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+					A:   net.ParseIP("203.0.113.44"),
+				},
+			), 0, nil
+		}),
+	})
+
+	writer := &testResponseWriter{
+		remoteAddr: &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 53000},
+		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
+	}
+	request := new(dns.Msg)
+	request.SetQuestion("api.example.com.", dns.TypeA)
+
+	forwarder.ServeDNS(writer, request)
+
+	if upstreamCalls != 1 {
+		t.Fatalf("expected allowed query to reach upstream once, got %d calls", upstreamCalls)
+	}
+	if writer.message == nil {
+		t.Fatal("expected forwarder to write a response")
+	}
+	if got, want := writer.message.Rcode, dns.RcodeSuccess; got != want {
+		t.Fatalf("unexpected response code: got %d want %d", got, want)
+	}
+	if observations := runtime.Observations("sandbox-1", now); len(observations) != 1 {
+		t.Fatalf("expected allowed query observation, got %+v", observations)
+	}
+}
+
+func TestForwarderStripsNonQuestionRecordsWhenBlockingDisallowedQueries(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewRuntime(RuntimeConfig{})
+	if err := runtime.RegisterSandbox("sandbox-1", testCompiledPolicy(
+		policy.AllowRule{Host: "api.example.com", Ports: []int{443}},
+	)); err != nil {
+		t.Fatalf("register sandbox: %v", err)
+	}
+
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	var gotAnswer, gotAuthority, gotExtra int
+	forwarder := NewForwarder(ForwarderConfig{
+		Runtime:                runtime,
+		UpstreamAddr:           "127.0.0.1:5300",
+		BlockDisallowedQueries: true,
+		ScopeResolver: func(addr netip.Addr) (string, bool) {
+			if addr == sourceIP {
+				return "sandbox-1", true
+			}
+			return "", false
+		},
+		Client: exchangeFunc(func(msg *dns.Msg, _ string) (*dns.Msg, time.Duration, error) {
+			gotAnswer = len(msg.Answer)
+			gotAuthority = len(msg.Ns)
+			gotExtra = len(msg.Extra)
+			return testResponse(msg.Question[0].Name), 0, nil
+		}),
+	})
+
+	writer := &testResponseWriter{
+		remoteAddr: &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 53000},
+		localAddr:  &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1053},
+	}
+	request := new(dns.Msg)
+	request.SetQuestion("api.example.com.", dns.TypeA)
+	request.Answer = []dns.RR{&dns.TXT{
+		Hdr: dns.RR_Header{Name: "leak-answer.example.com.", Rrtype: dns.TypeTXT, Class: dns.ClassINET},
+		Txt: []string{"secret"},
+	}}
+	request.Ns = []dns.RR{&dns.NS{
+		Hdr: dns.RR_Header{Name: "leak-authority.example.com.", Rrtype: dns.TypeNS, Class: dns.ClassINET},
+		Ns:  "ns.example.com.",
+	}}
+	request.Extra = []dns.RR{&dns.TXT{
+		Hdr: dns.RR_Header{Name: "leak-extra.example.com.", Rrtype: dns.TypeTXT, Class: dns.ClassINET},
+		Txt: []string{"secret"},
+	}}
+
+	forwarder.ServeDNS(writer, request)
+
+	if gotAnswer != 0 || gotAuthority != 0 || gotExtra != 0 {
+		t.Fatalf("expected upstream query sections to be stripped, got answer=%d authority=%d extra=%d", gotAnswer, gotAuthority, gotExtra)
+	}
+}
+
 func TestForwarderDoesNotRecordScopedAnswersWhenWriteFails(t *testing.T) {
 	t.Parallel()
 
@@ -1239,6 +1413,7 @@ func TestForwarderServesStaticRecordsWithoutUpstreamObservationOrDeny(t *testing
 			Name:      "gateway.cleanroom.internal",
 			Addresses: []netip.Addr{staticIP},
 		}},
+		BlockDisallowedQueries: true,
 	})
 
 	writer := &testResponseWriter{


### PR DESCRIPTION
Deny-by-default sandboxes could still send arbitrary DNS questions to the configured upstream resolver before the gateway checked policy. That meant a workload could encode data in query labels even when later TCP or UDP egress would be blocked.

This adds a pre-forward DNS policy gate to the shared forwarder and enables it for darwin-vz file-handle DNS and Firecracker trusted DNS. With the gate on, static gateway records are still answered locally, allowlisted names such as `api.example.com` still forward upstream, and denied names such as `leak.example.com` get `REFUSED` without contacting upstream or recording observations.

For allowed queries, the forwarder now strips guest-supplied answer, authority, and additional sections before upstream exchange so an allowed question name cannot carry extra records out of the sandbox. Targeted DeepSec revalidation for `internal/backend/darwinvz/filehandle_gateway.go` now marks the DNS exfiltration finding fixed.
