### PR TITLE
fix: Scope OCI cache by repository

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 19 ready for review
+**Status:** Slice 20 ready for review
 **Last reviewed:** 2026-05-31
 
 ## Summary
@@ -22,10 +22,15 @@ v0.10.0 fixing slice is scoped to the two critical Git gateway port-smuggling
 findings because they share one root cause: route hosts were authorized as
 host:443 while outbound URL construction could preserve an embedded port.
 Slice 16 closed both critical findings in PR #491. Slice 17 closed the HIGH
-darwin-vz helper resolution finding. Slice 18 closes the HIGH
-execution-scoped gateway credential cleanup finding for Firecracker sandboxes.
-Slice 19 closes the HIGH DNS exfiltration finding by enforcing DNS policy before
-forwarding queries upstream.
+darwin-vz helper resolution finding in PR #492. Slice 18 closed the HIGH
+execution-scoped gateway credential cleanup finding in PR #493. Slice 19 closed
+the HIGH DNS exfiltration finding in PR #494.
+
+After PR #494 merged, the live `cleanroom-v0.10.0` DeepSec export shows 7
+unresolved true positives: OCI digest cache authorization, unknown OIDC `kid`
+JWKS fetch amplification, persistent darwin-vz file-handle policy lifetime, Git
+proxy environment port preservation, two Git mirror resource-exhaustion paths,
+and retained execution output UTF-8 handling.
 
 This plan tracks each finding separately while keeping implementation in
 reviewable slices. A slice may close several findings when they share the same
@@ -706,6 +711,43 @@ Result: the DNS query exfiltration finding revalidated as fixed. DeepSec status
 now reports 12/12 findings revalidated, with 7 true positives and 5 fixed
 findings.
 
+Slice 20 is implemented and ready for review. OCI content-cache handlers are
+now leased by registry prefix plus an authorization cache scope derived from
+the requested OCI repository and authenticated sandbox owner when available.
+Each scoped handler builds its own OCI tag, manifest, and blob indexes and its
+own singleflight downloader. This preserves cache reuse inside the same
+authorized repo scope while preventing digest manifest, blob, and in-flight
+download hits from crossing into another repo or owner envelope.
+
+Focused validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway -run 'Test(CachedRegistryHandler|DockerHubMirrorHandler|OCIHandlerForPrefix|ScopedOCIIndex)'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Targeted DeepSec revalidation on 2026-05-31:
+
+```text
+cd /Users/lachlan/Develop/cleanroom/.deepsec
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec revalidate --project-id cleanroom-v0.10.0 --force --filter internal/gateway/oci_cached.go --concurrency 1 --root /Users/lachlan/.codex/worktrees/28db/cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec status --project-id cleanroom-v0.10.0
+```
+
+Result: the OCI digest cache authorization finding revalidated as fixed.
+DeepSec status now reports 12/12 findings revalidated, with 6 true positives
+and 6 fixed findings.
+
 ## Triage
 
 | Finding | Severity | Decision | Remediation slice |
@@ -715,6 +757,7 @@ findings.
 | Helper resolution can execute a repo-local binary on the host | High | Fixed by Slice 17 | Slice 17: gate darwin-vz CWD helper discovery |
 | Execution-scoped gateway credential authorization persists after execution | High | Fixed by Slice 18 | Slice 18: restore gateway scope after execution |
 | Denied workloads can still exfiltrate data through DNS queries | High | Fixed by Slice 19 | Slice 19: DNS pre-query policy gate |
+| OCI digest cache can bypass repository-level authorization | High | Fixed by Slice 20 | Slice 20: OCI cache scope binding |
 | File-handle gateway can host-dial private DNS answers | Critical | Needs fix | Slice 1: darwin-vz host-dial destination guard |
 | Submodule mirroring bypasses network policy and accepts file URLs | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
 | Submodule remotes are mirrored from the host without policy validation | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
@@ -764,6 +807,7 @@ findings.
 17. Gate darwin-vz current-working-directory helper discovery behind explicit local-development opt-in.
 18. Restore registered gateway authorization when Firecracker execution scopes end.
 19. Gate DNS queries against sandbox policy before forwarding to upstream resolvers.
+20. Bind OCI digest cache entries to the authorized repo and owner scope.
 
 ## Key Learnings From Pressure-Testing
 

--- a/internal/gateway/contentcache.go
+++ b/internal/gateway/contentcache.go
@@ -109,21 +109,6 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	ociHTTPClient := newOCIContentCacheHTTPClient(cfg.Credentials)
 	rubyGemsHTTPClient := newRubyGemsContentCacheHTTPClient(cfg.Credentials)
 
-	manifestIdx, err := metadb.NewEnvelopeIndex(db, "oci", "manifest", 24*time.Hour)
-	if err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("create oci manifest index: %w", err)
-	}
-	blobIdx, err := metadb.NewEnvelopeIndex(db, "oci", "blob", 24*time.Hour)
-	if err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("create oci blob index: %w", err)
-	}
-	imageIdx, err := metadb.NewEnvelopeIndex(db, "oci", "image", 24*time.Hour)
-	if err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("create oci image index: %w", err)
-	}
 	sumDBIdx, err := metadb.NewEnvelopeIndex(db, "sumdb", "cache", 0)
 	if err != nil {
 		_ = db.Close()
@@ -160,7 +145,6 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 	}
 
 	sumDBIndex := ccgoproxy.NewSumdbIndex(sumDBIdx)
-	ociIndex := ccoci.NewIndex(imageIdx, manifestIdx, blobIdx)
 	rubyGemsIndex := ccrubygems.NewIndex(
 		rubyGemsVersionsIdx,
 		rubyGemsInfoIdx,
@@ -291,8 +275,12 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 		}
 		return entry, nil
 	}
-	cache.buildOCIHandler = func(prefix string) (ociHandlerEntry, error) {
+	cache.buildOCIHandler = func(prefix, cacheScope string) (ociHandlerEntry, error) {
 		route, err := cache.resolveOCIRoute(prefix)
+		if err != nil {
+			return ociHandlerEntry{}, err
+		}
+		ociIndex, err := newScopedOCIIndex(db, scopedMetadataPrefix("oci:"+cacheScope))
 		if err != nil {
 			return ociHandlerEntry{}, err
 		}
@@ -313,7 +301,7 @@ func NewContentCache(cfg ContentCacheConfig) (*ContentCache, error) {
 			ociIndex,
 			cafs,
 			ccoci.WithRouter(router),
-			ccoci.WithDownloader(dl),
+			ccoci.WithDownloader(download.New()),
 			ccoci.WithTagTTL(tagTTL),
 			ccoci.WithLogger(logger),
 		)
@@ -424,6 +412,22 @@ func newScopedGitIndex(db metadb.EnvelopeStore, scopePrefix string) (*ccgit.Inde
 		return nil, fmt.Errorf("create scoped git pack index: %w", err)
 	}
 	return ccgit.NewIndex(packIdx), nil
+}
+
+func newScopedOCIIndex(db metadb.EnvelopeStore, scopePrefix string) (*ccoci.Index, error) {
+	imageIdx, err := newScopedEnvelopeIndex(db, "oci", "image", scopePrefix, 24*time.Hour)
+	if err != nil {
+		return nil, fmt.Errorf("create scoped oci image index: %w", err)
+	}
+	manifestIdx, err := newScopedEnvelopeIndex(db, "oci", "manifest", scopePrefix, 24*time.Hour)
+	if err != nil {
+		return nil, fmt.Errorf("create scoped oci manifest index: %w", err)
+	}
+	blobIdx, err := newScopedEnvelopeIndex(db, "oci", "blob", scopePrefix, 24*time.Hour)
+	if err != nil {
+		return nil, fmt.Errorf("create scoped oci blob index: %w", err)
+	}
+	return ccoci.NewIndex(imageIdx, manifestIdx, blobIdx), nil
 }
 
 func newScopedEnvelopeIndex(db metadb.EnvelopeStore, protocol, kind, policyPrefix string, ttl time.Duration) (*metadb.EnvelopeIndex, error) {

--- a/internal/gateway/contentcache_types.go
+++ b/internal/gateway/contentcache_types.go
@@ -25,7 +25,7 @@ const (
 
 type gitHandlerFactory func(host, cacheScope string) (gitHandlerEntry, error)
 
-type ociHandlerFactory func(prefix string) (ociHandlerEntry, error)
+type ociHandlerFactory func(prefix, cacheScope string) (ociHandlerEntry, error)
 
 type ociRouteResolver func(prefix string) (ociRoute, error)
 
@@ -657,13 +657,6 @@ func (c *ContentCache) OCIUpstreamForPrefix(prefix string) (string, int, string,
 		return "", 0, "", 0, errors.New("empty registry prefix")
 	}
 
-	c.ociMu.Lock()
-	if entry, ok := c.ociHandlers[prefix]; ok {
-		c.ociMu.Unlock()
-		return entry.policyHost, entry.policyPort, entry.upstreamHost, entry.upstreamPort, nil
-	}
-	c.ociMu.Unlock()
-
 	route, err := c.resolveOCIRoute(prefix)
 	if err != nil {
 		return "", 0, "", 0, err
@@ -672,8 +665,8 @@ func (c *ContentCache) OCIUpstreamForPrefix(prefix string) (string, int, string,
 }
 
 // OCIHandlerForPrefix returns an OCI cache handler for the requested registry
-// prefix, creating and caching it on first use.
-func (c *ContentCache) OCIHandlerForPrefix(prefix string) (http.Handler, func(), error) {
+// prefix and authorization cache scope, creating and caching it on first use.
+func (c *ContentCache) OCIHandlerForPrefix(prefix, cacheScope string) (http.Handler, func(), error) {
 	if c == nil || c.buildOCIHandler == nil {
 		return nil, nil, errors.New("oci cache not configured")
 	}
@@ -682,17 +675,22 @@ func (c *ContentCache) OCIHandlerForPrefix(prefix string) (http.Handler, func(),
 	if prefix == "" {
 		return nil, nil, errors.New("empty registry prefix")
 	}
+	cacheScope = strings.TrimSpace(cacheScope)
+	if cacheScope == "" {
+		return nil, nil, errors.New("empty oci cache scope")
+	}
+	cacheKey := prefix + "\x00" + cacheScope
 
 	c.ociMu.Lock()
-	if entry, ok := c.ociHandlers[prefix]; ok {
+	if entry, ok := c.ociHandlers[cacheKey]; ok {
 		entry.active++
-		c.touchOCIHandlerLocked(prefix)
+		c.touchOCIHandlerLocked(cacheKey)
 		release := c.releaseOCIHandler(entry)
 		c.ociMu.Unlock()
 		return entry.handler, release, nil
 	}
 
-	entryValue, err := c.buildOCIHandler(prefix)
+	entryValue, err := c.buildOCIHandler(prefix, cacheScope)
 	if err != nil {
 		c.ociMu.Unlock()
 		return nil, nil, err
@@ -702,8 +700,8 @@ func (c *ContentCache) OCIHandlerForPrefix(prefix string) (http.Handler, func(),
 	}
 	entry := &entryValue
 	entry.active = 1
-	c.ociHandlers[prefix] = entry
-	c.touchOCIHandlerLocked(prefix)
+	c.ociHandlers[cacheKey] = entry
+	c.touchOCIHandlerLocked(cacheKey)
 	evicted := c.evictOCIHandlerLocked()
 	release := c.releaseOCIHandler(entry)
 	c.ociMu.Unlock()

--- a/internal/gateway/contentcache_types_test.go
+++ b/internal/gateway/contentcache_types_test.go
@@ -14,7 +14,9 @@ import (
 	"time"
 
 	"github.com/buildkite/cleanroom/internal/policy"
+	contentcache "github.com/buildkite/content-cache"
 	ccgit "github.com/buildkite/content-cache/protocol/git"
+	ccoci "github.com/buildkite/content-cache/protocol/oci"
 	"github.com/buildkite/content-cache/store/metadb"
 )
 
@@ -647,32 +649,33 @@ func TestOCIHandlerForPrefixEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	cache := &ContentCache{
 		ociHandlers:    make(map[string]*ociHandlerEntry),
 		maxOCIHandlers: 2,
-		buildOCIHandler: func(prefix string) (ociHandlerEntry, error) {
+		buildOCIHandler: func(prefix, cacheScope string) (ociHandlerEntry, error) {
+			cacheKey := prefix + "\x00" + cacheScope
 			return ociHandlerEntry{
 				handler: &comparableHandler{},
 				closer: closeFunc(func() {
-					closed = append(closed, prefix)
+					closed = append(closed, cacheKey)
 				}),
 			}, nil
 		},
 	}
 
-	handlerA, releaseA, err := cache.OCIHandlerForPrefix("registry-a.test")
+	handlerA, releaseA, err := cache.OCIHandlerForPrefix("registry-a.test", "scope-a")
 	if err != nil {
 		t.Fatalf("handler A: %v", err)
 	}
-	_, releaseB, err := cache.OCIHandlerForPrefix("registry-b.test")
+	_, releaseB, err := cache.OCIHandlerForPrefix("registry-b.test", "scope-b")
 	if err != nil {
 		t.Fatalf("handler B: %v", err)
 	}
-	reusedA, releaseReusedA, err := cache.OCIHandlerForPrefix("registry-a.test")
+	reusedA, releaseReusedA, err := cache.OCIHandlerForPrefix("registry-a.test", "scope-a")
 	if err != nil {
 		t.Fatalf("reused handler A: %v", err)
 	}
 	if reusedA != handlerA {
 		t.Fatal("expected registry-a handler to be reused before eviction")
 	}
-	_, releaseC, err := cache.OCIHandlerForPrefix("registry-c.test")
+	_, releaseC, err := cache.OCIHandlerForPrefix("registry-c.test", "scope-c")
 	if err != nil {
 		t.Fatalf("handler C: %v", err)
 	}
@@ -680,23 +683,85 @@ func TestOCIHandlerForPrefixEvictsLeastRecentlyUsedHandler(t *testing.T) {
 	if got, want := len(cache.ociHandlers), 2; got != want {
 		t.Fatalf("expected %d cached handlers, got %d", want, got)
 	}
-	if _, ok := cache.ociHandlers["registry-a.test"]; !ok {
+	if _, ok := cache.ociHandlers["registry-a.test\x00scope-a"]; !ok {
 		t.Fatal("expected registry-a to remain cached after recent reuse")
 	}
-	if _, ok := cache.ociHandlers["registry-c.test"]; !ok {
+	if _, ok := cache.ociHandlers["registry-c.test\x00scope-c"]; !ok {
 		t.Fatal("expected registry-c to be cached")
 	}
-	if _, ok := cache.ociHandlers["registry-b.test"]; ok {
+	if _, ok := cache.ociHandlers["registry-b.test\x00scope-b"]; ok {
 		t.Fatal("expected registry-b to be evicted")
 	}
 	if len(closed) != 0 {
 		t.Fatalf("expected active registry-b handler to stay open until release, got %v", closed)
 	}
 	releaseB()
-	if !slices.Equal(closed, []string{"registry-b.test"}) {
+	if !slices.Equal(closed, []string{"registry-b.test\x00scope-b"}) {
 		t.Fatalf("expected registry-b closer to run, got %v", closed)
 	}
 	releaseA()
 	releaseReusedA()
 	releaseC()
+}
+
+func TestOCIHandlerForPrefixSeparatesCacheScopes(t *testing.T) {
+	t.Parallel()
+
+	cache := &ContentCache{
+		ociHandlers: make(map[string]*ociHandlerEntry),
+		buildOCIHandler: func(_, _ string) (ociHandlerEntry, error) {
+			return ociHandlerEntry{handler: &comparableHandler{}}, nil
+		},
+	}
+
+	handlerA, releaseA, err := cache.OCIHandlerForPrefix("registry.test", "scope-a")
+	if err != nil {
+		t.Fatalf("handler A: %v", err)
+	}
+	handlerB, releaseB, err := cache.OCIHandlerForPrefix("registry.test", "scope-b")
+	if err != nil {
+		t.Fatalf("handler B: %v", err)
+	}
+	defer releaseA()
+	defer releaseB()
+
+	if handlerA == handlerB {
+		t.Fatal("expected different cache scopes for the same registry prefix to use different handlers")
+	}
+}
+
+func TestScopedOCIIndexKeepsManifestAndBlobDigestsSeparate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := metadb.NewBoltDB()
+	if err := db.Open(t.TempDir() + "/meta.db"); err != nil {
+		t.Fatalf("open metadb: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	indexA, err := newScopedOCIIndex(db, scopedMetadataPrefix("oci-scope-a"))
+	if err != nil {
+		t.Fatalf("index A: %v", err)
+	}
+	indexB, err := newScopedOCIIndex(db, scopedMetadataPrefix("oci-scope-b"))
+	if err != nil {
+		t.Fatalf("index B: %v", err)
+	}
+
+	digest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	hash := contentcache.HashBytes([]byte("scope-a"))
+	if err := indexA.PutManifest(ctx, digest, "application/vnd.oci.image.manifest.v1+json", hash, 123); err != nil {
+		t.Fatalf("put manifest: %v", err)
+	}
+	if err := indexA.PutBlob(ctx, digest, hash, 456); err != nil {
+		t.Fatalf("put blob: %v", err)
+	}
+
+	if _, err := indexB.GetManifest(ctx, digest); !errors.Is(err, ccoci.ErrNotFound) {
+		t.Fatalf("expected manifest to be hidden from other scope, got %v", err)
+	}
+	if _, err := indexB.GetBlob(ctx, digest); !errors.Is(err, ccoci.ErrNotFound) {
+		t.Fatalf("expected blob to be hidden from other scope, got %v", err)
+	}
 }

--- a/internal/gateway/dockerhub_cached.go
+++ b/internal/gateway/dockerhub_cached.go
@@ -93,7 +93,8 @@ func (h *dockerHubMirrorHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	cacheHandler, releaseHandler, err := h.cache.OCIHandlerForPrefix(dockerHubMirrorPrefix)
+	cacheScope := ociCacheScope(scope, dockerHubMirrorPrefix, rest)
+	cacheHandler, releaseHandler, err := h.cache.OCIHandlerForPrefix(dockerHubMirrorPrefix, cacheScope)
 	if err != nil {
 		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUnknownRegistryPrefix)
 		span.RecordError(err)

--- a/internal/gateway/oci_cached.go
+++ b/internal/gateway/oci_cached.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"charm.land/log/v2"
+	"github.com/buildkite/cleanroom/internal/gatewayauth"
 	"github.com/buildkite/cleanroom/internal/observability"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -15,7 +16,7 @@ import (
 
 type registryPrefixHandlerProvider interface {
 	OCIUpstreamForPrefix(prefix string) (string, int, string, int, error)
-	OCIHandlerForPrefix(prefix string) (http.Handler, func(), error)
+	OCIHandlerForPrefix(prefix, cacheScope string) (http.Handler, func(), error)
 }
 
 // cachedRegistryHandler wraps a content-cache OCI handler with cleanroom's
@@ -125,7 +126,8 @@ func (h *cachedRegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	setGatewayRequestDecision(r.Context(), gatewayActionAllow, reasonCached)
 	h.auditLog(r.Context(), scope.SandboxID, upstreamHost, gatewayActionAllow, reasonCached)
 
-	cacheHandler, releaseHandler, err := h.cache.OCIHandlerForPrefix(normalizedPrefix)
+	cacheScope := ociCacheScope(scope, normalizedPrefix, rest)
+	cacheHandler, releaseHandler, err := h.cache.OCIHandlerForPrefix(normalizedPrefix, cacheScope)
 	if err != nil {
 		setGatewayRequestDecision(r.Context(), gatewayActionDeny, reasonUnknownRegistryPrefix)
 		span.RecordError(err)
@@ -153,6 +155,18 @@ func rewriteOCICachePath(prefix, rest string) string {
 	}
 	rest = strings.TrimPrefix(rest, "v2/")
 	return "/v2/" + prefix + "/" + rest
+}
+
+func ociCacheScope(scope *SandboxScope, prefix, rest string) string {
+	repoKey, ok, err := gatewayauth.OCIRepoKeyFromPath(prefix, rest)
+	if err != nil || !ok {
+		repoKey = gatewayauth.NormalizeOCIRepoPrefix(prefix)
+	}
+	ownerKey := "owner:none"
+	if scope != nil && scope.GatewayScope.HasOwner() {
+		ownerKey = "owner:" + strings.TrimSpace(scope.GatewayScope.Owner.PrincipalID) + "\x00scope:" + strings.TrimSpace(scope.GatewayScope.Owner.Scope)
+	}
+	return ownerKey + "\x00oci:" + repoKey
 }
 
 func (h *cachedRegistryHandler) auditLog(ctx context.Context, sandboxID, target, action, reason string) {

--- a/internal/gateway/oci_cached_test.go
+++ b/internal/gateway/oci_cached_test.go
@@ -18,6 +18,7 @@ type stubRegistryPrefixHandlerProvider struct {
 	upstreamPort int
 	err          error
 	prefix       string
+	cacheScope   string
 	handlerCalls int
 	lookupCalls  int
 }
@@ -31,8 +32,9 @@ func (s *stubRegistryPrefixHandlerProvider) OCIUpstreamForPrefix(prefix string) 
 	return s.policyHost, s.policyPort, s.upstreamHost, s.upstreamPort, nil
 }
 
-func (s *stubRegistryPrefixHandlerProvider) OCIHandlerForPrefix(prefix string) (http.Handler, func(), error) {
+func (s *stubRegistryPrefixHandlerProvider) OCIHandlerForPrefix(prefix, cacheScope string) (http.Handler, func(), error) {
 	s.prefix = prefix
+	s.cacheScope = cacheScope
 	s.handlerCalls++
 	if s.err != nil {
 		return nil, nil, s.err
@@ -275,6 +277,35 @@ func TestCachedRegistryHandlerAllowsRepoInGatewayEnvelope(t *testing.T) {
 	}
 	if capturedPath == "" {
 		t.Fatal("expected cache handler to be called")
+	}
+}
+
+func TestCachedRegistryHandlerScopesCacheToAuthorizedRepoAndOwner(t *testing.T) {
+	t.Parallel()
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	provider := &stubRegistryPrefixHandlerProvider{
+		handler:      backend,
+		policyHost:   "ghcr.io",
+		policyPort:   443,
+		upstreamHost: "ghcr.io",
+		upstreamPort: 443,
+	}
+	h := newCachedRegistryHandler(provider, nil, true)
+
+	req := httptest.NewRequest("GET", "/registry/ghcr.io/buildkite/cleanroom-base/alpine/blobs/sha256:abc123", nil)
+	req = withScope(req, registryOwnedScope([]string{"ghcr.io/buildkite/cleanroom-base/alpine"}, "ghcr.io"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	want := "owner:oidc:test:alice\x00scope:repo:buildkite/cleanroom\x00oci:ghcr.io/buildkite/cleanroom-base/alpine"
+	if provider.cacheScope != want {
+		t.Fatalf("unexpected cache scope: got %q want %q", provider.cacheScope, want)
 	}
 }
 


### PR DESCRIPTION
OCI digest cache hits were global across registry repositories. A sandbox authorized for one OCI repo could request a known manifest or blob digest under that repo path and receive content that had been cached from a different private repo, because content-cache indexed manifests and blobs only by digest.

This changes Cleanroom's OCI cache wrapper to lease handlers by registry prefix plus a cache scope derived from the requested OCI repository and authenticated sandbox owner when available. Each scoped handler now gets separate tag, manifest, and blob indexes and its own singleflight downloader, so cache hits and in-flight fills stay inside the authorized repo envelope.

The normal Docker Hub mirror and `/registry/<host>/...` paths keep the same external request shape; the change only narrows how host-side cache metadata is shared. DeepSec revalidated the OCI digest cache authorization finding as fixed.
