### PR TITLE
fix: Reject authority-shaped policy hosts

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 21 ready for review
+**Status:** Slice 22 ready for review
 **Last reviewed:** 2026-05-31
 
 ## Summary
@@ -26,12 +26,13 @@ darwin-vz helper resolution finding in PR #492. Slice 18 closed the HIGH
 execution-scoped gateway credential cleanup finding in PR #493. Slice 19 closed
 the HIGH DNS exfiltration finding in PR #494. Slice 20 closed the HIGH OCI
 digest cache authorization finding in PR #495. Slice 21 closes the unknown
-OIDC `kid` JWKS fetch amplification finding.
+OIDC `kid` JWKS fetch amplification finding. Slice 22 closes the Git proxy
+environment port-preservation finding.
 
-After Slice 21 revalidation, the live `cleanroom-v0.10.0` DeepSec status shows
-5 unresolved true positives: persistent darwin-vz file-handle policy lifetime,
-Git proxy environment port preservation, two Git mirror resource-exhaustion
-paths, and retained execution output UTF-8 handling.
+After Slice 22 revalidation, the live `cleanroom-v0.10.0` DeepSec status shows
+4 unresolved true positives: persistent darwin-vz file-handle policy lifetime,
+two Git mirror resource-exhaustion paths, and retained execution output UTF-8
+handling.
 
 This plan tracks each finding separately while keeping implementation in
 reviewable slices. A slice may close several findings when they share the same
@@ -785,6 +786,43 @@ Result: the unknown OIDC `kid` JWKS fetch amplification finding revalidated as
 fixed. DeepSec status now reports 12/12 findings revalidated, with 5 true
 positives and 7 fixed findings.
 
+Slice 22 is implemented and ready for review. Policy allow-rule hosts now must
+be bare hostnames when loaded from YAML or proto state, so mapping-form rules
+cannot smuggle ports, userinfo, schemes, paths, percent escapes, bracketed
+IPv6 literals, or control characters into host-based policy checks. Git proxy
+environment generation also reuses the normalized Git route-host validator
+before writing `insteadOf` rewrites, so manually constructed compiled policies
+cannot produce a gateway rewrite for an authority-shaped host.
+
+Focused validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway ./internal/policy -run 'Test(GitProxyEnvVarsSkipsMalformedAllowRuleHosts|ProxyEnvVarsStillIncludesGitWhenRubyGemsRouteIsUnavailable|CompileRejectsNetworkAllowHostAuthoritySyntax|FromProtoRejectsNetworkAllowHostAuthoritySyntax|CompileNormalizesNetworkAllowShorthand|FromProtoCanonicalisesAllowRules)'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway ./internal/policy
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Targeted DeepSec revalidation on 2026-05-31:
+
+```text
+cd /Users/lachlan/Develop/cleanroom/.deepsec
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec revalidate --project-id cleanroom-v0.10.0 --force --filter internal/gateway/git_proxy_env.go --concurrency 1 --root /Users/lachlan/.codex/worktrees/28db/cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec status --project-id cleanroom-v0.10.0
+```
+
+Result: the Git proxy environment port-preservation finding revalidated as
+fixed. DeepSec status now reports 12/12 findings revalidated, with 4 true
+positives and 8 fixed findings.
+
 ## Triage
 
 | Finding | Severity | Decision | Remediation slice |
@@ -796,6 +834,7 @@ positives and 7 fixed findings.
 | Denied workloads can still exfiltrate data through DNS queries | High | Fixed by Slice 19 | Slice 19: DNS pre-query policy gate |
 | OCI digest cache can bypass repository-level authorization | High | Fixed by Slice 20 | Slice 20: OCI cache scope binding |
 | Unknown JWT key IDs force repeated JWKS fetches | Medium | Fixed by Slice 21 | Slice 21: OIDC JWKS fresh-miss guard |
+| Git proxy rewrites can preserve embedded ports from policy hosts | Medium | Fixed by Slice 22 | Slice 22: policy host authority validation |
 | File-handle gateway can host-dial private DNS answers | Critical | Needs fix | Slice 1: darwin-vz host-dial destination guard |
 | Submodule mirroring bypasses network policy and accepts file URLs | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
 | Submodule remotes are mirrored from the host without policy validation | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
@@ -847,6 +886,7 @@ positives and 7 fixed findings.
 19. Gate DNS queries against sandbox policy before forwarding to upstream resolvers.
 20. Bind OCI digest cache entries to the authorized repo and owner scope.
 21. Return local OIDC JWKS key-not-found errors for fresh unknown `kid` cache misses.
+22. Reject authority-shaped policy hosts before generating Git proxy rewrites.
 
 ## Key Learnings From Pressure-Testing
 

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -787,17 +787,19 @@ fixed. DeepSec status now reports 12/12 findings revalidated, with 5 true
 positives and 7 fixed findings.
 
 Slice 22 is implemented and ready for review. Policy allow-rule hosts now must
-be bare hostnames when loaded from YAML or proto state, so mapping-form rules
-cannot smuggle ports, userinfo, schemes, paths, percent escapes, bracketed
-IPv6 literals, or control characters into host-based policy checks. Git proxy
-environment generation also reuses the normalized Git route-host validator
-before writing `insteadOf` rewrites, so manually constructed compiled policies
-cannot produce a gateway rewrite for an authority-shaped host.
+be bare hostnames or valid IP literals when loaded from YAML or proto state, so
+mapping-form rules cannot smuggle ports, userinfo, schemes, paths, percent
+escapes, bracketed IPv6 literals, or control characters into host-based policy
+checks. Host validation rejects non-ASCII input before lowercasing so Unicode
+case folding cannot silently rewrite policy hosts. Git proxy environment
+generation also reuses the normalized Git route-host validator before writing
+`insteadOf` rewrites, so manually constructed compiled policies cannot produce
+a gateway rewrite for an authority-shaped host.
 
 Focused validation run on 2026-05-31:
 
 ```text
-MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway ./internal/policy -run 'Test(GitProxyEnvVarsSkipsMalformedAllowRuleHosts|ProxyEnvVarsStillIncludesGitWhenRubyGemsRouteIsUnavailable|CompileRejectsNetworkAllowHostAuthoritySyntax|FromProtoRejectsNetworkAllowHostAuthoritySyntax|CompileNormalizesNetworkAllowShorthand|FromProtoCanonicalisesAllowRules)'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway ./internal/policy -run 'Test(GitProxyEnvVarsSkipsMalformedAllowRuleHosts|ProxyEnvVarsStillIncludesGitWhenRubyGemsRouteIsUnavailable|CompileRejectsNetworkAllowHostAuthoritySyntax|CompilePreservesNetworkAllowIPLiteralHosts|CompileRejectsNetworkAllowNonASCIIBeforeLowercase|FromProtoRejectsNetworkAllowHostAuthoritySyntax|FromProtoPreservesNetworkAllowIPv6LiteralHost|CompileNormalizesNetworkAllowShorthand|FromProtoCanonicalisesAllowRules)'
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway ./internal/policy
 ```
 

--- a/internal/gateway/git_proxy_env.go
+++ b/internal/gateway/git_proxy_env.go
@@ -58,8 +58,8 @@ func GitProxyEnvVars(compiled *policy.CompiledPolicy, gatewayPort int, scopeToke
 	entries := make([]configEntry, 0, len(compiled.Allow)+1)
 	seenHosts := make(map[string]struct{}, len(compiled.Allow))
 	for _, rule := range compiled.Allow {
-		host := strings.TrimSpace(rule.Host)
-		if host == "" {
+		host, err := normalizeGitRouteHost(strings.TrimSpace(rule.Host))
+		if err != nil {
 			continue
 		}
 		for _, port := range rule.Ports {

--- a/internal/gateway/git_proxy_env_test.go
+++ b/internal/gateway/git_proxy_env_test.go
@@ -57,6 +57,33 @@ func TestProxyEnvVarsStillIncludesGitWhenRubyGemsRouteIsUnavailable(t *testing.T
 	}
 }
 
+func TestGitProxyEnvVarsSkipsMalformedAllowRuleHosts(t *testing.T) {
+	t.Parallel()
+
+	compiled := &policy.CompiledPolicy{
+		Version:        1,
+		NetworkDefault: "deny",
+		Allow: []policy.AllowRule{
+			{Host: "internal.example:8443", Ports: []int{443}},
+			{Host: "github.com", Ports: []int{443}},
+		},
+	}
+
+	env := GitProxyEnvVars(compiled, 8170, "")
+	if len(env) != 3 {
+		t.Fatalf("expected only one git rewrite for the valid host, got %d: %v", len(env), env)
+	}
+	if env[0] != "GIT_CONFIG_COUNT=1" {
+		t.Fatalf("expected one git config entry, got %q", env[0])
+	}
+	if want := "GIT_CONFIG_KEY_0=url.http://gateway.cleanroom.internal:8170/git/github.com/.insteadOf"; env[1] != want {
+		t.Fatalf("expected valid host rewrite key %q, got %q", want, env[1])
+	}
+	if want := "GIT_CONFIG_VALUE_0=https://github.com/"; env[2] != want {
+		t.Fatalf("expected valid host rewrite value %q, got %q", want, env[2])
+	}
+}
+
 func TestGoProxyEnvVarsRequiresLiveRoute(t *testing.T) {
 	t.Parallel()
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -264,9 +264,9 @@ type AllowRule struct {
 func normalizeRawAllowRules(raw rawAllowRules) ([]AllowRule, error) {
 	allow := make([]AllowRule, 0, len(raw))
 	for _, rule := range raw {
-		host := strings.TrimSpace(strings.ToLower(rule.Host))
-		if host == "" {
-			return nil, errors.New("allow rule host cannot be empty")
+		host, err := normalizeAllowRuleHost(rule.Host)
+		if err != nil {
+			return nil, err
 		}
 		if len(rule.Ports) == 0 {
 			return nil, fmt.Errorf("allow rule for host %q must include at least one port", host)
@@ -292,6 +292,22 @@ func normalizeRawAllowRules(raw rawAllowRules) ([]AllowRule, error) {
 		return allow[i].Host < allow[j].Host
 	})
 	return allow, nil
+}
+
+func normalizeAllowRuleHost(rawHost string) (string, error) {
+	host := strings.TrimSpace(strings.ToLower(rawHost))
+	if host == "" {
+		return "", errors.New("allow rule host cannot be empty")
+	}
+	if strings.ContainsAny(host, "/\\@[]:?&#%") {
+		return "", fmt.Errorf("allow rule host %q must be a bare hostname without scheme, path, userinfo, or port", host)
+	}
+	for _, r := range host {
+		if r <= ' ' || r == 0x7f || r > 0x7e {
+			return "", fmt.Errorf("allow rule host %q must be a bare hostname without control or non-ASCII characters", host)
+		}
+	}
+	return host, nil
 }
 
 func normalizeRawStageNetwork(raw *rawStageNetworkConfig) (*NetworkPolicy, error) {
@@ -1090,9 +1106,9 @@ func networkStagesToProto(stages *NetworkStagePolicies) *cleanroomv1.PolicyNetwo
 func normalizeProtoAllowRules(rules []*cleanroomv1.PolicyAllowRule) ([]AllowRule, error) {
 	allow := make([]AllowRule, 0, len(rules))
 	for _, rule := range rules {
-		host := strings.TrimSpace(strings.ToLower(rule.GetHost()))
-		if host == "" {
-			return nil, errors.New("allow rule host cannot be empty")
+		host, err := normalizeAllowRuleHost(rule.GetHost())
+		if err != nil {
+			return nil, err
 		}
 		ports := make([]int, 0, len(rule.GetPorts()))
 		seen := map[int]struct{}{}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -295,17 +295,21 @@ func normalizeRawAllowRules(raw rawAllowRules) ([]AllowRule, error) {
 }
 
 func normalizeAllowRuleHost(rawHost string) (string, error) {
-	host := strings.TrimSpace(strings.ToLower(rawHost))
-	if host == "" {
+	trimmed := strings.TrimSpace(rawHost)
+	if trimmed == "" {
 		return "", errors.New("allow rule host cannot be empty")
+	}
+	for _, r := range trimmed {
+		if r <= ' ' || r == 0x7f || r > 0x7e {
+			return "", fmt.Errorf("allow rule host %q must be a bare hostname without control or non-ASCII characters", trimmed)
+		}
+	}
+	host := strings.ToLower(trimmed)
+	if net.ParseIP(host) != nil {
+		return host, nil
 	}
 	if strings.ContainsAny(host, "/\\@[]:?&#%") {
 		return "", fmt.Errorf("allow rule host %q must be a bare hostname without scheme, path, userinfo, or port", host)
-	}
-	for _, r := range host {
-		if r <= ' ' || r == 0x7f || r > 0x7e {
-			return "", fmt.Errorf("allow rule host %q must be a bare hostname without control or non-ASCII characters", host)
-		}
 	}
 	return host, nil
 }

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -211,6 +211,40 @@ sandbox:
 	}
 }
 
+func TestCompileRejectsNetworkAllowHostAuthoritySyntax(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		host string
+	}{
+		{name: "embedded port", host: "internal.example:8443"},
+		{name: "url scheme", host: "https://internal.example"},
+		{name: "userinfo", host: "user@internal.example"},
+		{name: "path", host: "internal.example/repo"},
+		{name: "escaped slash", host: "internal.example%2frepo"},
+		{name: "ipv6 literal", host: "[2001:db8::1]"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := baseRawPolicy()
+			raw.Sandbox.Network.Allow = rawAllowRules{
+				{Host: tc.host, Ports: []int{443}},
+			}
+
+			_, err := Compile(raw)
+			if err == nil {
+				t.Fatal("expected Compile to reject allow host authority syntax")
+			}
+			if !strings.Contains(err.Error(), "must be a bare hostname") {
+				t.Fatalf("unexpected error: got %v want bare hostname error", err)
+			}
+		})
+	}
+}
+
 func TestCompileNormalizesNetworkAllowScalar(t *testing.T) {
 	t.Parallel()
 
@@ -1626,6 +1660,25 @@ func TestFromProtoCanonicalisesAllowRules(t *testing.T) {
 	}
 	if got, want := compiled.Allow[0].Ports, []int{80, 443}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
 		t.Fatalf("expected deduplicated/sorted ports %v, got %v", want, got)
+	}
+}
+
+func TestFromProtoRejectsNetworkAllowHostAuthoritySyntax(t *testing.T) {
+	t.Parallel()
+
+	_, err := FromProto(&cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       validImageRef,
+		NetworkDefault: "deny",
+		Allow: []*cleanroomv1.PolicyAllowRule{
+			{Host: "internal.example:8443", Ports: []int32{443}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected FromProto to reject allow host authority syntax")
+	}
+	if !strings.Contains(err.Error(), "must be a bare hostname") {
+		t.Fatalf("unexpected error: got %v want bare hostname error", err)
 	}
 }
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -245,6 +245,44 @@ func TestCompileRejectsNetworkAllowHostAuthoritySyntax(t *testing.T) {
 	}
 }
 
+func TestCompilePreservesNetworkAllowIPLiteralHosts(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Network.Allow = rawAllowRules{
+		{Host: "2606:4700:4700::1111", Ports: []int{443}},
+		{Host: "192.0.2.10", Ports: []int{443}},
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("Compile returned error: %v", err)
+	}
+	if !compiled.Allows("2606:4700:4700::1111", 443) {
+		t.Fatal("expected IPv6 literal allow rule to compile")
+	}
+	if !compiled.Allows("192.0.2.10", 443) {
+		t.Fatal("expected IPv4 literal allow rule to compile")
+	}
+}
+
+func TestCompileRejectsNetworkAllowNonASCIIBeforeLowercase(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Network.Allow = rawAllowRules{
+		{Host: "\u212a.example", Ports: []int{443}},
+	}
+
+	_, err := Compile(raw)
+	if err == nil {
+		t.Fatal("expected Compile to reject non-ASCII allow host")
+	}
+	if !strings.Contains(err.Error(), "without control or non-ASCII characters") {
+		t.Fatalf("unexpected error: got %v want non-ASCII error", err)
+	}
+}
+
 func TestCompileNormalizesNetworkAllowScalar(t *testing.T) {
 	t.Parallel()
 
@@ -1679,6 +1717,25 @@ func TestFromProtoRejectsNetworkAllowHostAuthoritySyntax(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "must be a bare hostname") {
 		t.Fatalf("unexpected error: got %v want bare hostname error", err)
+	}
+}
+
+func TestFromProtoPreservesNetworkAllowIPv6LiteralHost(t *testing.T) {
+	t.Parallel()
+
+	compiled, err := FromProto(&cleanroomv1.Policy{
+		Version:        1,
+		ImageRef:       validImageRef,
+		NetworkDefault: "deny",
+		Allow: []*cleanroomv1.PolicyAllowRule{
+			{Host: "2606:4700:4700::1111", Ports: []int32{443}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("FromProto returned error: %v", err)
+	}
+	if !compiled.Allows("2606:4700:4700::1111", 443) {
+		t.Fatal("expected IPv6 literal allow rule to compile")
 	}
 }
 


### PR DESCRIPTION
Mapping-form network policy hosts were normalized with trim/lowercase only, so a host like `internal.example:8443` paired with port `443` could survive into Git proxy rewrite generation. That made the policy read like a 443-only allow rule while still carrying authority syntax that Git and URL handling could preserve.

This change makes YAML and proto allow-rule hosts bare hostnames only: no scheme, path, userinfo, brackets, percent escapes, control characters, or embedded port. Git proxy env generation also runs hosts through the normalized Git route-host validator before writing `insteadOf` rewrites, so manually built policies do not produce malformed gateway routes.

For example, `host: internal.example:8443` with `ports: [443]` now fails policy compilation instead of generating a rewrite for `https://internal.example:8443/`.

Covers Slice 22 in `docs/plans/deepsec-remediation.md`.
