### PR TITLE
fix: Sanitize retained execution output

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 22 ready for review
+**Status:** Slice 23 ready for review
 **Last reviewed:** 2026-05-31
 
 ## Summary
@@ -25,14 +25,14 @@ Slice 16 closed both critical findings in PR #491. Slice 17 closed the HIGH
 darwin-vz helper resolution finding in PR #492. Slice 18 closed the HIGH
 execution-scoped gateway credential cleanup finding in PR #493. Slice 19 closed
 the HIGH DNS exfiltration finding in PR #494. Slice 20 closed the HIGH OCI
-digest cache authorization finding in PR #495. Slice 21 closes the unknown
-OIDC `kid` JWKS fetch amplification finding. Slice 22 closes the Git proxy
-environment port-preservation finding.
+digest cache authorization finding in PR #495. Slice 21 closed the unknown
+OIDC `kid` JWKS fetch amplification finding in PR #496. Slice 22 closed the
+Git proxy environment port-preservation finding in PR #497. Slice 23 closes the
+retained execution output UTF-8 handling bug.
 
-After Slice 22 revalidation, the live `cleanroom-v0.10.0` DeepSec status shows
-4 unresolved true positives: persistent darwin-vz file-handle policy lifetime,
-two Git mirror resource-exhaustion paths, and retained execution output UTF-8
-handling.
+After Slice 23 revalidation, the live `cleanroom-v0.10.0` DeepSec status shows
+3 unresolved true positives: persistent darwin-vz file-handle policy lifetime
+and two Git mirror resource-exhaustion paths.
 
 This plan tracks each finding separately while keeping implementation in
 reviewable slices. A slice may close several findings when they share the same
@@ -825,6 +825,43 @@ Result: the Git proxy environment port-preservation finding revalidated as
 fixed. DeepSec status now reports 12/12 findings revalidated, with 4 true
 positives and 8 fixed findings.
 
+Slice 23 is implemented and ready for review. Retained execution stdout and
+stderr are now sanitized with `strings.ToValidUTF8` before being stored in
+snapshot strings, and tail truncation advances to a UTF-8 rune boundary before
+cloning the retained bytes. This keeps `InspectExecutionResponse` protobuf
+string fields valid even when a workload emits invalid bytes or a byte limit
+lands in the middle of a multi-byte rune. Raw stream events still carry the
+original bytes.
+
+Focused validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/controlservice -run 'Test(AppendRetainedOutput(ClonesTailSlice|SanitizesInvalidUTF8|TruncatesOnUTF8Boundary)|ExecutionRetention(BoundsOutput|SanitizesInvalidUTF8Output))'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/controlservice
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Targeted DeepSec revalidation on 2026-05-31:
+
+```text
+cd /Users/lachlan/Develop/cleanroom/.deepsec
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec revalidate --project-id cleanroom-v0.10.0 --force --filter internal/controlservice/state_helpers.go --concurrency 1 --root /Users/lachlan/.codex/worktrees/28db/cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec status --project-id cleanroom-v0.10.0
+```
+
+Result: the retained execution output UTF-8 handling bug revalidated as fixed.
+DeepSec status now reports 12/12 findings revalidated, with 3 true positives
+and 9 fixed findings.
+
 ## Triage
 
 | Finding | Severity | Decision | Remediation slice |
@@ -837,6 +874,7 @@ positives and 8 fixed findings.
 | OCI digest cache can bypass repository-level authorization | High | Fixed by Slice 20 | Slice 20: OCI cache scope binding |
 | Unknown JWT key IDs force repeated JWKS fetches | Medium | Fixed by Slice 21 | Slice 21: OIDC JWKS fresh-miss guard |
 | Git proxy rewrites can preserve embedded ports from policy hosts | Medium | Fixed by Slice 22 | Slice 22: policy host authority validation |
+| Retained execution output can become invalid UTF-8 | Bug | Fixed by Slice 23 | Slice 23: retained output UTF-8 sanitization |
 | File-handle gateway can host-dial private DNS answers | Critical | Needs fix | Slice 1: darwin-vz host-dial destination guard |
 | Submodule mirroring bypasses network policy and accepts file URLs | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
 | Submodule remotes are mirrored from the host without policy validation | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
@@ -889,6 +927,7 @@ positives and 8 fixed findings.
 20. Bind OCI digest cache entries to the authorized repo and owner scope.
 21. Return local OIDC JWKS key-not-found errors for fresh unknown `kid` cache misses.
 22. Reject authority-shaped policy hosts before generating Git proxy rewrites.
+23. Sanitize retained execution output before exposing protobuf strings.
 
 ## Key Learnings From Pressure-Testing
 

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -826,17 +826,19 @@ fixed. DeepSec status now reports 12/12 findings revalidated, with 4 true
 positives and 8 fixed findings.
 
 Slice 23 is implemented and ready for review. Retained execution stdout and
-stderr are now sanitized with `strings.ToValidUTF8` before being stored in
-snapshot strings, and tail truncation advances to a UTF-8 rune boundary before
-cloning the retained bytes. This keeps `InspectExecutionResponse` protobuf
-string fields valid even when a workload emits invalid bytes or a byte limit
-lands in the middle of a multi-byte rune. Raw stream events still carry the
-original bytes.
+stderr now carry a tiny per-stream pending UTF-8 tail between chunks, store only
+valid UTF-8 in snapshot strings, and flush any incomplete final sequence as a
+replacement character when execution finishes. Tail truncation advances to a
+UTF-8 rune boundary before cloning the retained bytes. This keeps
+`InspectExecutionResponse` protobuf string fields valid even when a workload
+emits invalid bytes, a valid multi-byte rune is split across output chunks, or a
+byte limit lands in the middle of a multi-byte rune. Raw stream events still
+carry the original bytes.
 
 Focused validation run on 2026-05-31:
 
 ```text
-MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/controlservice -run 'Test(AppendRetainedOutput(ClonesTailSlice|SanitizesInvalidUTF8|TruncatesOnUTF8Boundary)|ExecutionRetention(BoundsOutput|SanitizesInvalidUTF8Output))'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/controlservice -run 'Test(AppendRetainedOutput(ClonesTailSlice|SanitizesInvalidUTF8|TruncatesOnUTF8Boundary)|AppendRetainedOutputBytesPreservesSplitUTF8|FlushRetainedOutputPendingSanitizesIncompleteUTF8|ExecutionRetention(BoundsOutput|SanitizesInvalidUTF8Output))'
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/controlservice
 ```
 

--- a/internal/controlservice/service.go
+++ b/internal/controlservice/service.go
@@ -150,7 +150,9 @@ type executionState struct {
 	FinishedAt        *time.Time
 	Message           string
 	Stdout            string
+	StdoutPendingUTF8 []byte
 	Stderr            string
+	StderrPendingUTF8 []byte
 	LaunchedVM        bool
 	PlanPath          string
 	RunDir            string
@@ -4186,7 +4188,7 @@ func (s *Service) appendExecutionStdoutLocked(ex *executionState, status cleanro
 	if ex == nil || len(chunk) == 0 {
 		return
 	}
-	ex.Stdout = appendRetainedOutput(ex.Stdout, string(chunk), s.retention().maxRetainedExecutionOutputBytes)
+	ex.Stdout, ex.StdoutPendingUTF8 = appendRetainedOutputBytes(ex.Stdout, ex.StdoutPendingUTF8, chunk, s.retention().maxRetainedExecutionOutputBytes)
 	s.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
 		SandboxId:   ex.SandboxID,
 		ExecutionId: ex.ID,
@@ -4200,7 +4202,7 @@ func (s *Service) appendExecutionStderrLocked(ex *executionState, status cleanro
 	if ex == nil || len(chunk) == 0 {
 		return
 	}
-	ex.Stderr = appendRetainedOutput(ex.Stderr, string(chunk), s.retention().maxRetainedExecutionOutputBytes)
+	ex.Stderr, ex.StderrPendingUTF8 = appendRetainedOutputBytes(ex.Stderr, ex.StderrPendingUTF8, chunk, s.retention().maxRetainedExecutionOutputBytes)
 	s.recordExecutionEventLocked(ex, &cleanroomv1.ExecutionStreamEvent{
 		SandboxId:   ex.SandboxID,
 		ExecutionId: ex.ID,
@@ -4812,6 +4814,7 @@ func (s *Service) finalizeExecutionInternalLocked(ex *executionState, status cle
 	if ex == nil {
 		return
 	}
+	s.flushExecutionOutputUTF8Locked(ex)
 	if finished.IsZero() {
 		finished = s.clock().Now()
 	}
@@ -4838,4 +4841,13 @@ func (s *Service) finalizeExecutionInternalLocked(ex *executionState, status cle
 	if prune {
 		s.pruneStateLocked(finished)
 	}
+}
+
+func (s *Service) flushExecutionOutputUTF8Locked(ex *executionState) {
+	if ex == nil {
+		return
+	}
+	limit := s.retention().maxRetainedExecutionOutputBytes
+	ex.Stdout, ex.StdoutPendingUTF8 = flushRetainedOutputPending(ex.Stdout, ex.StdoutPendingUTF8, limit)
+	ex.Stderr, ex.StderrPendingUTF8 = flushRetainedOutputPending(ex.Stderr, ex.StderrPendingUTF8, limit)
 }

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 	"unsafe"
 
 	"github.com/buildkite/cleanroom/internal/backend"
@@ -40,6 +41,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"google.golang.org/protobuf/proto"
 )
 
 type stubAdapter struct {
@@ -10309,6 +10311,26 @@ func TestAppendRetainedOutputClonesTailSlice(t *testing.T) {
 	}
 }
 
+func TestAppendRetainedOutputSanitizesInvalidUTF8(t *testing.T) {
+	got := appendRetainedOutput("", string([]byte{'o', 0xff, 'k'}), 32)
+	if !utf8.ValidString(got) {
+		t.Fatalf("expected retained output to be valid UTF-8, got %q", got)
+	}
+	if want := "o\uFFFDk"; got != want {
+		t.Fatalf("unexpected retained output: got %q want %q", got, want)
+	}
+}
+
+func TestAppendRetainedOutputTruncatesOnUTF8Boundary(t *testing.T) {
+	got := appendRetainedOutput("ab\u20AC", "cd", 5)
+	if !utf8.ValidString(got) {
+		t.Fatalf("expected retained output to be valid UTF-8, got %q", got)
+	}
+	if want := "\u20ACcd"; got != want {
+		t.Fatalf("unexpected retained output: got %q want %q", got, want)
+	}
+}
+
 func TestStatePruningBoundsRetainedTerminalState(t *testing.T) {
 	svc := newTestService(&stubAdapter{})
 	retention := testRetentionPolicy()
@@ -10687,6 +10709,65 @@ func TestExecutionRetentionBoundsOutput(t *testing.T) {
 	}
 	if got, want := snapshot.Stderr, "cdefghij"; got != want {
 		t.Fatalf("unexpected retained stderr: got %q want %q", got, want)
+	}
+}
+
+func TestExecutionRetentionSanitizesInvalidUTF8Output(t *testing.T) {
+	adapter := &stubAdapter{
+		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
+			if stream.OnStdout != nil {
+				stream.OnStdout([]byte{'o', 0xff, 'k'})
+			}
+			if stream.OnStderr != nil {
+				stream.OnStderr([]byte{'e', 'r', 0xe2, 0x82})
+			}
+			return &backend.ExecutionResult{
+				ExecutionID: req.ExecutionID,
+				ExitCode:    0,
+				Message:     "ok",
+			}, nil
+		},
+	}
+	svc := newTestService(adapter)
+	retention := testRetentionPolicy()
+	retention.maxRetainedExecutionOutputBytes = 32
+	svc.runtime.retention = retention
+
+	createSandboxResp, err := svc.CreateSandbox(context.Background(), &cleanroomv1.CreateSandboxRequest{Policy: testPolicy()})
+	if err != nil {
+		t.Fatalf("CreateSandbox returned error: %v", err)
+	}
+	sandboxID := createSandboxResp.GetSandbox().GetSandboxId()
+	createExecutionResp, err := svc.CreateExecution(context.Background(), &cleanroomv1.CreateExecutionRequest{
+		SandboxId: sandboxID,
+		Command:   []string{"emit", "invalid-utf8"},
+	})
+	if err != nil {
+		t.Fatalf("CreateExecution returned error: %v", err)
+	}
+	executionID := createExecutionResp.GetExecution().GetExecutionId()
+	if _, err := svc.WaitExecution(context.Background(), sandboxID, executionID); err != nil {
+		t.Fatalf("WaitExecution returned error: %v", err)
+	}
+
+	inspect, err := svc.InspectExecution(context.Background(), &cleanroomv1.InspectExecutionRequest{
+		SandboxId:   sandboxID,
+		ExecutionId: executionID,
+	})
+	if err != nil {
+		t.Fatalf("InspectExecution returned error: %v", err)
+	}
+	if !utf8.ValidString(inspect.GetStdout()) || !utf8.ValidString(inspect.GetStderr()) {
+		t.Fatalf("expected retained output to be valid UTF-8, stdout=%q stderr=%q", inspect.GetStdout(), inspect.GetStderr())
+	}
+	if got, want := inspect.GetStdout(), "o\uFFFDk"; got != want {
+		t.Fatalf("unexpected retained stdout: got %q want %q", got, want)
+	}
+	if got, want := inspect.GetStderr(), "er\uFFFD"; got != want {
+		t.Fatalf("unexpected retained stderr: got %q want %q", got, want)
+	}
+	if _, err := proto.Marshal(inspect); err != nil {
+		t.Fatalf("marshal InspectExecutionResponse: %v", err)
 	}
 }
 

--- a/internal/controlservice/service_test.go
+++ b/internal/controlservice/service_test.go
@@ -10331,6 +10331,41 @@ func TestAppendRetainedOutputTruncatesOnUTF8Boundary(t *testing.T) {
 	}
 }
 
+func TestAppendRetainedOutputBytesPreservesSplitUTF8(t *testing.T) {
+	var pending []byte
+	got, pending := appendRetainedOutputBytes("", pending, []byte{0xe2}, 32)
+	if got != "" {
+		t.Fatalf("expected incomplete rune to stay pending, got %q", got)
+	}
+	if want := []byte{0xe2}; !bytes.Equal(pending, want) {
+		t.Fatalf("unexpected pending bytes: got %v want %v", pending, want)
+	}
+
+	got, pending = appendRetainedOutputBytes(got, pending, []byte{0x82, 0xac}, 32)
+	if len(pending) != 0 {
+		t.Fatalf("expected pending bytes to be consumed, got %v", pending)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("expected retained output to be valid UTF-8, got %q", got)
+	}
+	if want := "\u20AC"; got != want {
+		t.Fatalf("unexpected retained output: got %q want %q", got, want)
+	}
+}
+
+func TestFlushRetainedOutputPendingSanitizesIncompleteUTF8(t *testing.T) {
+	got, pending := flushRetainedOutputPending("er", []byte{0xe2, 0x82}, 32)
+	if len(pending) != 0 {
+		t.Fatalf("expected pending bytes to be cleared, got %v", pending)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("expected retained output to be valid UTF-8, got %q", got)
+	}
+	if want := "er\uFFFD"; got != want {
+		t.Fatalf("unexpected retained output: got %q want %q", got, want)
+	}
+}
+
 func TestStatePruningBoundsRetainedTerminalState(t *testing.T) {
 	svc := newTestService(&stubAdapter{})
 	retention := testRetentionPolicy()
@@ -10717,6 +10752,8 @@ func TestExecutionRetentionSanitizesInvalidUTF8Output(t *testing.T) {
 		runStreamFn: func(_ context.Context, req backend.ExecutionRequest, stream backend.OutputStream) (*backend.ExecutionResult, error) {
 			if stream.OnStdout != nil {
 				stream.OnStdout([]byte{'o', 0xff, 'k'})
+				stream.OnStdout([]byte{' ', 0xe2})
+				stream.OnStdout([]byte{0x82, 0xac})
 			}
 			if stream.OnStderr != nil {
 				stream.OnStderr([]byte{'e', 'r', 0xe2, 0x82})
@@ -10760,7 +10797,7 @@ func TestExecutionRetentionSanitizesInvalidUTF8Output(t *testing.T) {
 	if !utf8.ValidString(inspect.GetStdout()) || !utf8.ValidString(inspect.GetStderr()) {
 		t.Fatalf("expected retained output to be valid UTF-8, stdout=%q stderr=%q", inspect.GetStdout(), inspect.GetStderr())
 	}
-	if got, want := inspect.GetStdout(), "o\uFFFDk"; got != want {
+	if got, want := inspect.GetStdout(), "o\uFFFDk \u20AC"; got != want {
 		t.Fatalf("unexpected retained stdout: got %q want %q", got, want)
 	}
 	if got, want := inspect.GetStderr(), "er\uFFFD"; got != want {

--- a/internal/controlservice/state_helpers.go
+++ b/internal/controlservice/state_helpers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/buildkite/cleanroom/internal/backend"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
@@ -245,19 +246,30 @@ func appendRetainedOutput(existing, chunk string, limit int) string {
 		return ""
 	}
 	if chunk == "" {
-		if len(existing) <= limit {
-			return existing
-		}
-		return strings.Clone(existing[len(existing)-limit:])
+		return retainedUTF8Tail(existing, limit)
 	}
+	chunk = strings.ToValidUTF8(chunk, "\uFFFD")
 	if len(chunk) >= limit {
-		return strings.Clone(chunk[len(chunk)-limit:])
+		return retainedUTF8Tail(chunk, limit)
 	}
 	keepExisting := limit - len(chunk)
-	if keepExisting < len(existing) {
-		existing = strings.Clone(existing[len(existing)-keepExisting:])
+	existing = retainedUTF8Tail(existing, keepExisting)
+	return retainedUTF8Tail(existing+chunk, limit)
+}
+
+func retainedUTF8Tail(value string, limit int) string {
+	if limit <= 0 || value == "" {
+		return ""
 	}
-	return existing + chunk
+	value = strings.ToValidUTF8(value, "\uFFFD")
+	if len(value) <= limit {
+		return strings.Clone(value)
+	}
+	start := len(value) - limit
+	for start < len(value) && !utf8.RuneStart(value[start]) {
+		start++
+	}
+	return strings.Clone(value[start:])
 }
 
 func appendBounded[T any](history []T, item T, limit int) []T {

--- a/internal/controlservice/state_helpers.go
+++ b/internal/controlservice/state_helpers.go
@@ -248,13 +248,63 @@ func appendRetainedOutput(existing, chunk string, limit int) string {
 	if chunk == "" {
 		return retainedUTF8Tail(existing, limit)
 	}
-	chunk = strings.ToValidUTF8(chunk, "\uFFFD")
 	if len(chunk) >= limit {
 		return retainedUTF8Tail(chunk, limit)
 	}
 	keepExisting := limit - len(chunk)
 	existing = retainedUTF8Tail(existing, keepExisting)
 	return retainedUTF8Tail(existing+chunk, limit)
+}
+
+func appendRetainedOutputBytes(existing string, pending, chunk []byte, limit int) (string, []byte) {
+	if limit <= 0 {
+		return "", nil
+	}
+	if len(chunk) == 0 {
+		return retainedUTF8Tail(existing, limit), cloneBytes(pending)
+	}
+
+	combined := make([]byte, 0, len(pending)+len(chunk))
+	combined = append(combined, pending...)
+	combined = append(combined, chunk...)
+	prefix, nextPending := splitTrailingIncompleteUTF8(combined)
+	if len(prefix) > 0 {
+		existing = appendRetainedOutput(existing, string(prefix), limit)
+	} else {
+		existing = retainedUTF8Tail(existing, limit)
+	}
+	return existing, cloneBytes(nextPending)
+}
+
+func flushRetainedOutputPending(existing string, pending []byte, limit int) (string, []byte) {
+	if len(pending) == 0 {
+		return retainedUTF8Tail(existing, limit), nil
+	}
+	return appendRetainedOutput(existing, string(pending), limit), nil
+}
+
+func splitTrailingIncompleteUTF8(value []byte) ([]byte, []byte) {
+	if len(value) == 0 || utf8.Valid(value) {
+		return value, nil
+	}
+	max := len(value)
+	if max > utf8.UTFMax {
+		max = utf8.UTFMax
+	}
+	for size := 1; size <= max; size++ {
+		start := len(value) - size
+		if value[start] < utf8.RuneSelf {
+			break
+		}
+		if !utf8.RuneStart(value[start]) {
+			continue
+		}
+		if !utf8.FullRune(value[start:]) {
+			return value[:start], value[start:]
+		}
+		break
+	}
+	return value, nil
 }
 
 func retainedUTF8Tail(value string, limit int) string {
@@ -270,6 +320,13 @@ func retainedUTF8Tail(value string, limit int) string {
 		start++
 	}
 	return strings.Clone(value[start:])
+}
+
+func cloneBytes(value []byte) []byte {
+	if len(value) == 0 {
+		return nil
+	}
+	return append([]byte(nil), value...)
 }
 
 func appendBounded[T any](history []T, item T, limit int) []T {


### PR DESCRIPTION
Retained execution stdout and stderr are exposed through protobuf string fields. Before this change the retention helper kept raw output as Go strings and sliced by byte offset, so invalid bytes or truncation in the middle of a multi-byte rune could leave `InspectExecution` with invalid UTF-8.

This change sanitizes retained output with `strings.ToValidUTF8` and only truncates at UTF-8 rune boundaries before cloning the retained tail. Raw stream events still carry the original output bytes; this only affects the retained snapshot strings used by inspection.

For example, output bytes like `o 0xff k` are retained as `o�k`, and a byte limit that lands inside a multi-byte rune advances to the next valid rune start instead of storing a partial sequence.

Covers Slice 23 in `docs/plans/deepsec-remediation.md`.
