### PR TITLE
fix: Stream mirror upload-pack responses

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -906,12 +906,14 @@ responses now stream command stdout directly to the HTTP response writer instead
 of buffering the full packfile in memory before replying. The response writer
 flushes after writes when the server supports it, and upload-pack stderr is
 captured through a bounded error buffer so failure messages cannot grow without
-limit.
+limit. If upload-pack exits non-zero after response bytes have already streamed,
+the gateway records the upstream error but does not append a plaintext gateway
+error into the Git protocol response.
 
 Focused validation run on 2026-05-31:
 
 ```text
-MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway -run 'Test(ServeMirrorUploadPackWritesCommandOutput|LimitedOutputBuffer|GitHandlerServesMirrorToRealGitClient)'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway -run 'Test(ServeMirrorUploadPackWritesCommandOutput|GitHandlerDoesNotAppendErrorAfterMirrorUploadPackStreamStarts|LimitedOutputBuffer|GitHandlerServesMirrorToRealGitClient)'
 MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway
 ```
 

--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 24 ready for review
+**Status:** Slice 25 ready for review
 **Last reviewed:** 2026-05-31
 
 ## Summary
@@ -29,10 +29,11 @@ digest cache authorization finding in PR #495. Slice 21 closed the unknown
 OIDC `kid` JWKS fetch amplification finding in PR #496. Slice 22 closed the
 Git proxy environment port-preservation finding in PR #497. Slice 23 closes the
 retained execution output UTF-8 handling bug. Slice 24 closes the persistent
-darwin-vz file-handle network policy lifetime finding.
+darwin-vz file-handle network policy lifetime finding. Slice 25 closes the Git
+mirror upload-pack response buffering finding.
 
-After Slice 24 revalidation, the live `cleanroom-v0.10.0` DeepSec status shows
-2 unresolved true positives: the two Git mirror resource-exhaustion paths.
+After Slice 25 revalidation, the live `cleanroom-v0.10.0` DeepSec status shows
+1 unresolved true positive: Git mirror command-output buffering.
 
 This plan tracks each finding separately while keeping implementation in
 reviewable slices. A slice may close several findings when they share the same
@@ -900,6 +901,43 @@ Result: the persistent darwin-vz file-handle network policy lifetime finding
 revalidated as fixed. DeepSec status now reports 12/12 findings revalidated,
 with 2 true positives and 10 fixed findings.
 
+Slice 25 is implemented and ready for review. Mirror-backed `git-upload-pack`
+responses now stream command stdout directly to the HTTP response writer instead
+of buffering the full packfile in memory before replying. The response writer
+flushes after writes when the server supports it, and upload-pack stderr is
+captured through a bounded error buffer so failure messages cannot grow without
+limit.
+
+Focused validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway -run 'Test(ServeMirrorUploadPackWritesCommandOutput|LimitedOutputBuffer|GitHandlerServesMirrorToRealGitClient)'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Targeted DeepSec revalidation on 2026-05-31:
+
+```text
+cd /Users/lachlan/Develop/cleanroom/.deepsec
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec revalidate --project-id cleanroom-v0.10.0 --force --filter internal/gateway/git.go --concurrency 1 --root /Users/lachlan/.codex/worktrees/28db/cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec status --project-id cleanroom-v0.10.0
+```
+
+Result: the mirror upload-pack buffering finding revalidated as fixed. The
+forced `internal/gateway/git.go` run also rechecked the already-fixed critical
+port-smuggling finding in that file. DeepSec status now reports 12/12 findings
+revalidated, with 1 true positive and 11 fixed findings.
+
 ## Triage
 
 | Finding | Severity | Decision | Remediation slice |
@@ -914,7 +952,7 @@ with 2 true positives and 10 fixed findings.
 | Git proxy rewrites can preserve embedded ports from policy hosts | Medium | Fixed by Slice 22 | Slice 22: policy host authority validation |
 | Retained execution output can become invalid UTF-8 | Bug | Fixed by Slice 23 | Slice 23: retained output UTF-8 sanitization |
 | Persistent VM network policy remains active after an execution exits | Medium | Fixed by Slice 24 | Slice 24: darwin-vz file-handle policy cleanup |
-| Mirror upload-pack buffers unbounded pack responses in memory | Medium | Needs fix | Slice 25: stream or bound Git upload-pack responses |
+| Mirror upload-pack buffers unbounded pack responses in memory | Medium | Fixed by Slice 25 | Slice 25: stream Git upload-pack responses |
 | Git mirror operations buffer unbounded command output | Medium | Needs fix | Slice 26: bound Git mirror command output |
 | File-handle gateway can host-dial private DNS answers | Critical | Needs fix | Slice 1: darwin-vz host-dial destination guard |
 | Submodule mirroring bypasses network policy and accepts file URLs | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |

--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -413,19 +413,16 @@ func serveMirrorUploadPack(r *http.Request, w http.ResponseWriter, mirrorDir str
 	cmd.Env = append(os.Environ(), gitProtocolEnv(r)...)
 	cmd.Stdin = bytes.NewReader(body)
 
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("git upload-pack --stateless-rpc: %s: %w", strings.TrimSpace(stderr.String()), err)
-	}
+	stderr := newLimitedOutputBuffer(maxGitCommandErrorOutputBytes)
+	cmd.Stdout = flushResponseWriter{w: w}
+	cmd.Stderr = stderr
 
 	w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
 	w.Header().Set("Cache-Control", "no-cache")
-	_, err = w.Write(stdout.Bytes())
-	return err
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git upload-pack --stateless-rpc: %s: %w", strings.TrimSpace(stderr.String()), err)
+	}
+	return nil
 }
 
 func gitProtocolEnv(r *http.Request) []string {
@@ -458,6 +455,18 @@ func readUploadPackBodyWithLimit(r *http.Request, limit int64) ([]byte, error) {
 		return nil, fmt.Errorf("%w: limit %d bytes", errUploadPackRequestTooLarge, limit)
 	}
 	return body, nil
+}
+
+type flushResponseWriter struct {
+	w http.ResponseWriter
+}
+
+func (fw flushResponseWriter) Write(p []byte) (int, error) {
+	n, err := fw.w.Write(p)
+	if flusher, ok := fw.w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	return n, err
 }
 
 func uploadPackConfigArgs() []string {

--- a/internal/gateway/git.go
+++ b/internal/gateway/git.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"charm.land/log/v2"
@@ -46,6 +47,7 @@ const (
 var (
 	maxUploadPackRequestBytes    int64 = 32 << 20
 	errUploadPackRequestTooLarge       = errors.New("git-upload-pack request body too large")
+	errGitMirrorResponseStarted        = errors.New("git mirror response already started")
 )
 
 type gitHandler struct {
@@ -178,6 +180,9 @@ func (h *gitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			)
 			span.SetStatus(codes.Error, err.Error())
 			h.auditLog(r.Context(), scope.SandboxID, upstreamHost, repoPath, gatewayActionDeny, reasonUpstreamError)
+			if errors.Is(err, errGitMirrorResponseStarted) {
+				return
+			}
 			writeReasonError(w, http.StatusBadGateway, reasonUpstreamError, err.Error())
 			return
 		}
@@ -414,13 +419,18 @@ func serveMirrorUploadPack(r *http.Request, w http.ResponseWriter, mirrorDir str
 	cmd.Stdin = bytes.NewReader(body)
 
 	stderr := newLimitedOutputBuffer(maxGitCommandErrorOutputBytes)
-	cmd.Stdout = flushResponseWriter{w: w}
+	stdout := &flushResponseWriter{w: w}
+	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
 	w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
 	w.Header().Set("Cache-Control", "no-cache")
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("git upload-pack --stateless-rpc: %s: %w", strings.TrimSpace(stderr.String()), err)
+		runErr := fmt.Errorf("git upload-pack --stateless-rpc: %s: %w", strings.TrimSpace(stderr.String()), err)
+		if stdout.Wrote() {
+			return fmt.Errorf("%w: %v", errGitMirrorResponseStarted, runErr)
+		}
+		return runErr
 	}
 	return nil
 }
@@ -458,15 +468,23 @@ func readUploadPackBodyWithLimit(r *http.Request, limit int64) ([]byte, error) {
 }
 
 type flushResponseWriter struct {
-	w http.ResponseWriter
+	w     http.ResponseWriter
+	wrote atomic.Bool
 }
 
-func (fw flushResponseWriter) Write(p []byte) (int, error) {
+func (fw *flushResponseWriter) Write(p []byte) (int, error) {
 	n, err := fw.w.Write(p)
+	if n > 0 {
+		fw.wrote.Store(true)
+	}
 	if flusher, ok := fw.w.(http.Flusher); ok {
 		flusher.Flush()
 	}
 	return n, err
+}
+
+func (fw *flushResponseWriter) Wrote() bool {
+	return fw != nil && fw.wrote.Load()
 }
 
 func uploadPackConfigArgs() []string {

--- a/internal/gateway/git_test.go
+++ b/internal/gateway/git_test.go
@@ -504,6 +504,27 @@ func TestGitHandlerServesMirrorToRealGitClient(t *testing.T) {
 	}
 }
 
+func TestServeMirrorUploadPackWritesCommandOutput(t *testing.T) {
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	if err := os.WriteFile(gitPath, []byte("#!/bin/sh\ncat >/dev/null\nprintf 'pack-result'\n"), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	req := httptest.NewRequest(http.MethodPost, "/git/github.com/org/repo.git/git-upload-pack", strings.NewReader("request-payload"))
+	resp := httptest.NewRecorder()
+	if err := serveMirrorUploadPack(req, resp, t.TempDir()); err != nil {
+		t.Fatalf("serveMirrorUploadPack returned error: %v", err)
+	}
+	if got, want := resp.Header().Get("Content-Type"), "application/x-git-upload-pack-result"; got != want {
+		t.Fatalf("unexpected content type: got %q want %q", got, want)
+	}
+	if got, want := resp.Body.String(), "pack-result"; got != want {
+		t.Fatalf("unexpected response body: got %q want %q", got, want)
+	}
+}
+
 type staticMirrorStore struct {
 	mirrorDir    string
 	gotRemoteURL string

--- a/internal/gateway/git_test.go
+++ b/internal/gateway/git_test.go
@@ -525,6 +525,33 @@ func TestServeMirrorUploadPackWritesCommandOutput(t *testing.T) {
 	}
 }
 
+func TestGitHandlerDoesNotAppendErrorAfterMirrorUploadPackStreamStarts(t *testing.T) {
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	if err := os.WriteFile(gitPath, []byte("#!/bin/sh\ncat >/dev/null\nprintf 'partial-pack'\nprintf 'broken mirror\\n' >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	handler := newGitHandler(nil, nil)
+	handler.mirrors = &staticMirrorStore{mirrorDir: t.TempDir()}
+
+	req := httptest.NewRequest(http.MethodPost, "/git/github.com/org/repo.git/git-upload-pack", strings.NewReader("request-payload"))
+	req = withScope(req, gitTestScope())
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+
+	if got, want := resp.Code, http.StatusOK; got != want {
+		t.Fatalf("unexpected response code after partial stream: got %d want %d", got, want)
+	}
+	if got, want := resp.Body.String(), "partial-pack"; got != want {
+		t.Fatalf("unexpected response body: got %q want %q", got, want)
+	}
+	if strings.Contains(resp.Body.String(), reasonUpstreamError) || strings.Contains(resp.Body.String(), "broken mirror") {
+		t.Fatalf("gateway error was appended to streamed pack response: %q", resp.Body.String())
+	}
+}
+
 type staticMirrorStore struct {
 	mirrorDir    string
 	gotRemoteURL string

--- a/internal/gateway/limited_output.go
+++ b/internal/gateway/limited_output.go
@@ -1,0 +1,51 @@
+package gateway
+
+import (
+	"fmt"
+	"strings"
+)
+
+const maxGitCommandErrorOutputBytes = 64 << 10
+
+type limitedOutputBuffer struct {
+	limit     int
+	buf       []byte
+	truncated int64
+}
+
+func newLimitedOutputBuffer(limit int) *limitedOutputBuffer {
+	if limit < 0 {
+		limit = 0
+	}
+	return &limitedOutputBuffer{limit: limit}
+}
+
+func (b *limitedOutputBuffer) Write(p []byte) (int, error) {
+	originalLen := len(p)
+	if b == nil {
+		return originalLen, nil
+	}
+	if remaining := b.limit - len(b.buf); remaining > 0 {
+		if remaining > len(p) {
+			remaining = len(p)
+		}
+		b.buf = append(b.buf, p[:remaining]...)
+		p = p[remaining:]
+	}
+	b.truncated += int64(len(p))
+	return originalLen, nil
+}
+
+func (b *limitedOutputBuffer) String() string {
+	if b == nil {
+		return ""
+	}
+	out := strings.ToValidUTF8(string(b.buf), "\uFFFD")
+	if b.truncated > 0 {
+		if strings.TrimSpace(out) != "" {
+			out += "\n"
+		}
+		out += fmt.Sprintf("[truncated %d bytes]", b.truncated)
+	}
+	return out
+}

--- a/internal/gateway/limited_output_test.go
+++ b/internal/gateway/limited_output_test.go
@@ -1,0 +1,35 @@
+package gateway
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLimitedOutputBufferTruncates(t *testing.T) {
+	t.Parallel()
+
+	buf := newLimitedOutputBuffer(8)
+	if n, err := buf.Write([]byte("hello world")); err != nil || n != len("hello world") {
+		t.Fatalf("Write returned n=%d err=%v", n, err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "hello wo") {
+		t.Fatalf("expected retained prefix in %q", got)
+	}
+	if !strings.Contains(got, "[truncated 3 bytes]") {
+		t.Fatalf("expected truncation marker in %q", got)
+	}
+}
+
+func TestLimitedOutputBufferSanitizesInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
+	buf := newLimitedOutputBuffer(8)
+	if _, err := buf.Write([]byte{'o', 0xff, 'k'}); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if got, want := buf.String(), "o\uFFFDk"; got != want {
+		t.Fatalf("unexpected output: got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
Mirror-backed git-upload-pack responses were buffered completely in memory before the gateway replied. A large allowed repository could make the host hold the full packfile in a bytes.Buffer, which is unnecessary and can pressure gateway memory.

This streams upload-pack stdout directly to the HTTP response writer and flushes response writes when supported. Command stderr now uses a bounded error buffer so failure messages stay useful without growing indefinitely.

DeepSec revalidated the upload-pack buffering finding as fixed. The v0.10.0 project now has 1 true positive left and 11 fixed findings.