### PR TITLE
fix: Bound git mirror command output

### DIFF
--- a/docs/plans/deepsec-remediation.md
+++ b/docs/plans/deepsec-remediation.md
@@ -1,7 +1,7 @@
 # DeepSec Remediation Plan
 
 **Spec reference:** `docs/spec.md`; `docs/api.md`; `docs/tls.md`; `docs/plans/multi-principal-control-server.md`; `docs/plans/stage-scoped-egress.md`
-**Status:** Slice 25 ready for review
+**Status:** Slice 26 ready for review
 **Last reviewed:** 2026-05-31
 
 ## Summary
@@ -27,13 +27,15 @@ execution-scoped gateway credential cleanup finding in PR #493. Slice 19 closed
 the HIGH DNS exfiltration finding in PR #494. Slice 20 closed the HIGH OCI
 digest cache authorization finding in PR #495. Slice 21 closed the unknown
 OIDC `kid` JWKS fetch amplification finding in PR #496. Slice 22 closed the
-Git proxy environment port-preservation finding in PR #497. Slice 23 closes the
-retained execution output UTF-8 handling bug. Slice 24 closes the persistent
-darwin-vz file-handle network policy lifetime finding. Slice 25 closes the Git
-mirror upload-pack response buffering finding.
+Git proxy environment port-preservation finding in PR #497. Slice 23 closed the
+retained execution output UTF-8 handling bug in PR #498. Slice 24 closed the
+persistent darwin-vz file-handle network policy lifetime finding in PR #499.
+Slice 25 closed the Git mirror upload-pack response buffering finding in PR
+#500. Slice 26 closes the remaining Git mirror command-output buffering
+finding.
 
-After Slice 25 revalidation, the live `cleanroom-v0.10.0` DeepSec status shows
-1 unresolved true positive: Git mirror command-output buffering.
+After Slice 26 revalidation, the live `cleanroom-v0.10.0` DeepSec status shows
+all 12 findings revalidated as fixed.
 
 This plan tracks each finding separately while keeping implementation in
 reviewable slices. A slice may close several findings when they share the same
@@ -940,6 +942,42 @@ forced `internal/gateway/git.go` run also rechecked the already-fixed critical
 port-smuggling finding in that file. DeepSec status now reports 12/12 findings
 revalidated, with 1 true positive and 11 fixed findings.
 
+Slice 26 is implemented and ready for review. Git mirror `clone`, `remote
+set-url`, `fetch`, and local `cat-file` probes now use the shared bounded
+command-output buffer instead of `CombinedOutput`. Failed Git commands retain a
+small diagnostic prefix, sanitize invalid UTF-8, and append a truncation marker
+instead of allowing a remote Git server to grow gateway memory through
+unbounded progress or error output.
+
+Focused validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway -run 'TestGitMirrorStore(CloneMirrorBoundsCommandOutput|FetchMirrorBoundsSetURLOutput|FetchMirrorBoundsFetchOutput|ClonesAndRefreshesRemote|EnsureMirrorContainsFetchesRequestedCommit|LimitedOutputBuffer)'
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise exec -- go test ./internal/gateway
+```
+
+Result: passed.
+
+Repository validation run on 2026-05-31:
+
+```text
+MISE_TRUSTED_CONFIG_PATHS=/Users/lachlan/.codex/worktrees/28db/cleanroom/mise.toml mise run check
+```
+
+Result: passed.
+
+Targeted DeepSec revalidation on 2026-05-31:
+
+```text
+cd /Users/lachlan/Develop/cleanroom/.deepsec
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec revalidate --project-id cleanroom-v0.10.0 --force --filter internal/gateway/mirror.go --concurrency 1 --root /Users/lachlan/.codex/worktrees/28db/cleanroom
+npm exec --package=pnpm@9.15.4 -- pnpm deepsec status --project-id cleanroom-v0.10.0
+```
+
+Result: the Git mirror command-output buffering finding revalidated as fixed.
+DeepSec status now reports 12/12 findings revalidated, with 0 true positives and
+12 fixed findings.
+
 ## Triage
 
 | Finding | Severity | Decision | Remediation slice |
@@ -955,7 +993,7 @@ revalidated, with 1 true positive and 11 fixed findings.
 | Retained execution output can become invalid UTF-8 | Bug | Fixed by Slice 23 | Slice 23: retained output UTF-8 sanitization |
 | Persistent VM network policy remains active after an execution exits | Medium | Fixed by Slice 24 | Slice 24: darwin-vz file-handle policy cleanup |
 | Mirror upload-pack buffers unbounded pack responses in memory | Medium | Fixed by Slice 25 | Slice 25: stream Git upload-pack responses |
-| Git mirror operations buffer unbounded command output | Medium | Needs fix | Slice 26: bound Git mirror command output |
+| Git mirror operations buffer unbounded command output | Medium | Fixed by Slice 26 | Slice 26: bound Git mirror command output |
 | File-handle gateway can host-dial private DNS answers | Critical | Needs fix | Slice 1: darwin-vz host-dial destination guard |
 | Submodule mirroring bypasses network policy and accepts file URLs | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |
 | Submodule remotes are mirrored from the host without policy validation | Critical | Needs fix | Slice 2: host-side repository mirror policy enforcement |

--- a/internal/gateway/mirror.go
+++ b/internal/gateway/mirror.go
@@ -206,10 +206,10 @@ func (s *gitMirrorStore) cloneMirror(ctx context.Context, remoteURL, mirrorDir s
 		return err
 	}
 	cmd.Env = env
-	output, err := cmd.CombinedOutput()
+	output, err := runGitCommandWithBoundedOutput(cmd)
 	if err != nil {
 		_ = os.RemoveAll(mirrorDir)
-		return fmt.Errorf("git clone --mirror %s: %s: %w", remoteURL, strings.TrimSpace(string(output)), err)
+		return fmt.Errorf("git clone --mirror %s: %s: %w", remoteURL, output, err)
 	}
 	s.markFetched(remoteURL)
 	return nil
@@ -218,8 +218,8 @@ func (s *gitMirrorStore) cloneMirror(ctx context.Context, remoteURL, mirrorDir s
 func (s *gitMirrorStore) fetchMirror(ctx context.Context, remoteURL, mirrorDir string) error {
 	setURL := exec.CommandContext(ctx, "git", "-C", mirrorDir, "remote", "set-url", "origin", remoteURL)
 	setURL.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
-	if output, err := setURL.CombinedOutput(); err != nil {
-		return fmt.Errorf("git remote set-url origin %s: %s: %w", remoteURL, strings.TrimSpace(string(output)), err)
+	if output, err := runGitCommandWithBoundedOutput(setURL); err != nil {
+		return fmt.Errorf("git remote set-url origin %s: %s: %w", remoteURL, output, err)
 	}
 
 	cmd := exec.CommandContext(ctx, "git", "-C", mirrorDir, "fetch", "--prune", "origin")
@@ -228,12 +228,20 @@ func (s *gitMirrorStore) fetchMirror(ctx context.Context, remoteURL, mirrorDir s
 		return err
 	}
 	cmd.Env = env
-	output, err := cmd.CombinedOutput()
+	output, err := runGitCommandWithBoundedOutput(cmd)
 	if err != nil {
-		return fmt.Errorf("git fetch --prune origin: %s: %w", strings.TrimSpace(string(output)), err)
+		return fmt.Errorf("git fetch --prune origin: %s: %w", output, err)
 	}
 	s.markFetched(remoteURL)
 	return nil
+}
+
+func runGitCommandWithBoundedOutput(cmd *exec.Cmd) (string, error) {
+	output := newLimitedOutputBuffer(maxGitCommandErrorOutputBytes)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	err := cmd.Run()
+	return strings.TrimSpace(output.String()), err
 }
 
 func (s *gitMirrorStore) gitEnvWithAuth(ctx context.Context, remoteURL string, baseEnv []string) ([]string, error) {
@@ -316,12 +324,12 @@ func gitConfigCount(env []string) (int, bool) {
 func gitCommitExists(ctx context.Context, repoDir, commitSHA string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "cat-file", "-e", strings.TrimSpace(commitSHA)+"^{commit}")
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
-	output, err := cmd.CombinedOutput()
+	output, err := runGitCommandWithBoundedOutput(cmd)
 	if err == nil {
 		return true, nil
 	}
 	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 128 {
 		return false, nil
 	}
-	return false, fmt.Errorf("git cat-file -e %s^{commit}: %s: %w", strings.TrimSpace(commitSHA), strings.TrimSpace(string(output)), err)
+	return false, fmt.Errorf("git cat-file -e %s^{commit}: %s: %w", strings.TrimSpace(commitSHA), output, err)
 }

--- a/internal/gateway/mirror_test.go
+++ b/internal/gateway/mirror_test.go
@@ -190,6 +190,40 @@ func TestGitMirrorStoreSkipsCredentialsForFileRemote(t *testing.T) {
 	}
 }
 
+func TestGitMirrorStoreCloneMirrorBoundsCommandOutput(t *testing.T) {
+	installLargeOutputGit(t, "clone")
+
+	store := NewGitMirrorStore(t.TempDir(), time.Minute, nil)
+	mirrorDir := filepath.Join(t.TempDir(), "mirror.git")
+	err := store.cloneMirror(context.Background(), "https://github.com/buildkite/cleanroom.git", mirrorDir)
+	assertBoundedGitOutputError(t, err)
+	if _, statErr := os.Stat(mirrorDir); !os.IsNotExist(statErr) {
+		t.Fatalf("failed clone should remove mirror dir, stat err = %v", statErr)
+	}
+}
+
+func TestGitMirrorStoreFetchMirrorBoundsSetURLOutput(t *testing.T) {
+	installLargeOutputGit(t, "set-url")
+
+	store := NewGitMirrorStore(t.TempDir(), time.Minute, nil)
+	err := store.fetchMirror(context.Background(), "https://github.com/buildkite/cleanroom.git", t.TempDir())
+	assertBoundedGitOutputError(t, err)
+	if !strings.Contains(err.Error(), "git remote set-url origin") {
+		t.Fatalf("expected set-url context, got %q", err.Error())
+	}
+}
+
+func TestGitMirrorStoreFetchMirrorBoundsFetchOutput(t *testing.T) {
+	installLargeOutputGit(t, "fetch")
+
+	store := NewGitMirrorStore(t.TempDir(), time.Minute, nil)
+	err := store.fetchMirror(context.Background(), "https://github.com/buildkite/cleanroom.git", t.TempDir())
+	assertBoundedGitOutputError(t, err)
+	if !strings.Contains(err.Error(), "git fetch --prune origin") {
+		t.Fatalf("expected fetch context, got %q", err.Error())
+	}
+}
+
 func findEnvValue(env []string, name string) string {
 	for _, entry := range env {
 		key, value, ok := strings.Cut(entry, "=")
@@ -212,6 +246,59 @@ type failingCredentialProvider struct{}
 
 func (failingCredentialProvider) Resolve(context.Context, string) (string, error) {
 	return "", fmt.Errorf("credentials unavailable")
+}
+
+func installLargeOutputGit(t *testing.T, failMode string) {
+	t.Helper()
+
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	script := `#!/bin/sh
+emit_large_output() {
+	dd if=/dev/zero bs=70000 count=1 2>/dev/null | LC_ALL=C tr '\000' x
+	printf 'unretained-tail\n'
+}
+
+if [ "$FAKE_GIT_FAIL_MODE" = "clone" ] && [ "$1" = "clone" ]; then
+	emit_large_output
+	exit 1
+fi
+
+if [ "$FAKE_GIT_FAIL_MODE" = "set-url" ] && [ "$3" = "remote" ] && [ "$4" = "set-url" ]; then
+	emit_large_output
+	exit 1
+fi
+
+if [ "$FAKE_GIT_FAIL_MODE" = "fetch" ] && [ "$3" = "fetch" ]; then
+	emit_large_output
+	exit 1
+fi
+
+exit 0
+`
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_GIT_FAIL_MODE", failMode)
+}
+
+func assertBoundedGitOutputError(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected git command error")
+	}
+	msg := err.Error()
+	if len(msg) > maxGitCommandErrorOutputBytes+2048 {
+		t.Fatalf("error output was not bounded: len=%d", len(msg))
+	}
+	if !strings.Contains(msg, "[truncated ") {
+		t.Fatalf("expected truncation marker in bounded error output, len=%d", len(msg))
+	}
+	if strings.Contains(msg, "unretained-tail") {
+		t.Fatalf("expected tail marker to be truncated, len=%d", len(msg))
+	}
 }
 
 func TestGitMirrorStorePathIsStableByRemoteURL(t *testing.T) {


### PR DESCRIPTION
Git mirror refreshes still captured full command output in memory when host-side git commands failed. A compromised or noisy allowed Git server could use clone or fetch progress output to grow gateway memory before the command returned.

This changes mirror clone, set-url, fetch, and the local cat-file probe to use the shared bounded command-output buffer. Failure messages still keep a useful prefix, sanitize invalid UTF-8, and include a truncation marker when output is cut off. Normal successful mirror behavior is unchanged.

The v0.10.0 DeepSec revalidation now reports all 12 findings fixed.