### PR TITLE
docs: Add Cleanroom getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ mise run install:global
 
 ## Docs
 
+- [Getting started](docs/getting-started.md) - first local run, repository policy, shared server setup, and Buildkite OIDC
+- [Control plane](docs/control-plane.md) - client/server architecture, auth, ownership, host gateway, and credential boundaries
 - [Policy](docs/policy.md) - `cleanroom.yaml`, resources, networking, Docker, dependencies, and services
 - [Workspaces](docs/workspaces.md) - repo-aware execution, local edits, copy-in, copy-out, and sync
 - [Networking](docs/networking.md) - deny-by-default egress, DNS, the host gateway, and service exposure

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,8 @@
 # Cleanroom Minimal API (ConnectRPC)
 
+For an operator-oriented explanation of the client/server control plane,
+ownership, and gateway boundaries, see [Control plane](control-plane.md).
+
 ## 1) Goal
 
 Define a minimal, functional control API for creating and managing Cleanroom sandboxes with durable execution streaming and interactive execution bootstrap.

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -1,0 +1,156 @@
+# Control plane
+
+Cleanroom uses one control plane for local and remote operation. Local commands
+are not a separate execution path; they are CLI calls to a local server endpoint.
+
+## Components
+
+| Component | Role |
+|---|---|
+| CLI and API clients | Resolve the control endpoint, load repository policy, package requested local changes when asked, and call the Cleanroom API |
+| `cleanroom serve` | Authoritative server for sandbox lifecycle, execution state, policy validation, auth, observability, and backend dispatch |
+| Backend adapter | Implements VM creation, file operations, execution, suspend/resume, and backend capability checks for `firecracker` or `darwin-vz` |
+| Guest agent | Runs inside each microVM and performs command execution, file transfer, and interactive session work requested by the server |
+| Host gateway | Mediates allowed guest access to Git, OCI registries, Go modules, RubyGems, immutable fetches, and host-side upstream credentials |
+| Repository policy | Backend-neutral workload contract committed with the repository |
+| Runtime config | Host or server-specific configuration for endpoints, auth, credentials, caches, lifecycle, and observability |
+
+The default local endpoint is a Unix socket. HTTP loopback is useful for local
+development. Shared servers should use HTTPS with `auth.required: true`.
+
+## Request lifecycle
+
+For a typical `cleanroom exec`:
+
+1. The CLI resolves the server endpoint from `--host`, `CLEANROOM_HOST`,
+   runtime config, or the default socket.
+2. The CLI loads and compiles repository policy from `cleanroom.yaml` or
+   `.buildkite/cleanroom.yaml`.
+3. The CLI resolves repository metadata, including the remote URL and exact
+   commit, and packages local changes only when flags such as `--copy-in` or
+   `--sync` request that.
+4. The server authenticates and authorizes the caller when auth is enabled.
+5. The server validates and persists the compiled policy for the sandbox
+   lifetime.
+6. The selected backend materializes the image, creates the microVM, starts the
+   guest agent, and checks that required policy capabilities can be enforced.
+7. Repository checkout and requested changeset application happen in the guest
+   workspace.
+8. Dependency and service blocks run at sandbox creation time when configured.
+9. The server creates the requested execution and streams output back through
+   the control API.
+10. The sandbox remains available for later commands until it is removed or the
+    caller chooses a one-shot path that cleans it up.
+
+The compiled policy is immutable for the sandbox lifetime. A later policy file
+change affects newly created sandboxes, not already running ones.
+
+## Auth and ownership
+
+Local Unix-socket use is intended for trusted local callers. Remote control
+plane access uses HTTPS bearer authentication.
+
+With OIDC enabled, the server:
+
+1. Verifies the token issuer, audience, signature, lifetime, and required
+   claims.
+2. Maps trusted claims to a Cleanroom principal.
+3. Evaluates grants for the requested action and request attributes, such as
+   repository remote URL, backend, resource floors, and network default.
+4. Records the principal as the owner of created sandboxes, executions, and
+   snapshots.
+
+Authenticated resource access is exact-owner scoped. A caller can only manage
+resources owned by the same derived principal unless policy grants broaden that
+explicitly.
+
+## Host gateway and credentials
+
+The host gateway is part of the server runtime, not the guest. It receives
+traffic from sandboxes, identifies the sandbox, checks the active compiled
+policy, then decides whether to fetch upstream or deny the request.
+
+Supported gateway routes include:
+
+| Route | Purpose |
+|---|---|
+| `/git/` | Cache-backed Git smart-HTTP and mirror-backed Git proxying |
+| `/registry/` | OCI registry pull-through route |
+| `/v2/` | Docker Hub-compatible mirror for guest `dockerd` |
+| `/goproxy/` | Go module proxy and checksum database mirror |
+| `/rubygems/` | Bundler/RubyGems mirror |
+| `/fetch/` | Immutable artifact downloads such as Go SDK tarballs |
+
+Gateway credentials live in runtime config or trusted server environment, never
+in `cleanroom.yaml` and never in the guest environment.
+
+GitHub App credentials are one credential provider for upstream Git requests:
+
+```yaml
+gateway:
+  credentials:
+    github_app:
+      app_id: "3817917"
+      installation_id: "134770928"
+      private_key_file: /etc/cleanroom/github-app.pem
+      repo_prefixes:
+        - buildkite/
+```
+
+When a sandbox runs `git clone https://github.com/buildkite/private-repo.git`,
+the guest command remains unchanged. Cleanroom rewrites matching Git traffic to
+`gateway.cleanroom.internal`, the gateway validates that `github.com:443` is
+allowed by the active policy, and the host-side gateway obtains the upstream
+credential if the repository matches `repo_prefixes`.
+
+GitHub App credentials answer "how can the host authenticate upstream?" They do
+not answer "is this sandbox allowed to reach GitHub?" The allow decision still
+comes from repository policy.
+
+## Configuration boundaries
+
+Keep repository policy portable:
+
+```yaml
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/debian@sha256:28c3f638fabe1ed780f87b82cfb0c6dda2549c86b9e4edbe519e8250243411c5
+  resources:
+    memory: 8GiB
+  network:
+    default: deny
+    allow:
+      - github.com:443
+      - proxy.golang.org:443
+      - sum.golang.org:443
+```
+
+Keep host concerns in runtime config:
+
+```yaml
+control_host: unix:///run/user/501/cleanroom/cleanroom.sock
+default_backend: darwin-vz
+auth:
+  required: true
+gateway:
+  credentials:
+    github_app:
+      app_id: "3817917"
+      installation_id: "134770928"
+      private_key_file: /etc/cleanroom/github-app.pem
+      repo_prefixes:
+        - buildkite/
+```
+
+This split lets the same repository policy run on local macOS, local Linux, and
+a shared CI server while each host keeps its own backend, credentials, and
+operational settings.
+
+## Related docs
+
+- [Getting started](getting-started.md) for the first local and CI flows
+- [Policy](policy.md) for `cleanroom.yaml`
+- [Remote access](remote-access.md) for HTTPS and OIDC auth
+- [Host gateway](gateway.md) for route and credential details
+- [API](api.md) for the ConnectRPC service surface

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -61,8 +61,9 @@ With OIDC enabled, the server:
    snapshots.
 
 Authenticated resource access is exact-owner scoped. A caller can only manage
-resources owned by the same derived principal unless policy grants broaden that
-explicitly.
+resources owned by the same derived principal. Grants can allow or deny actions
+on resources owned by that principal, but they cannot grant access to resources
+owned by a different derived principal.
 
 ## Host gateway and credentials
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,209 @@
+# Getting started
+
+Use this guide when bringing a repository or Buildkite pipeline onto
+Cleanroom. It starts with a local run, then shows where the shared control
+plane, OIDC authentication, and GitHub App credentials fit.
+
+## Mental model
+
+Cleanroom has two configuration layers:
+
+| Layer | Lives in | Owns |
+|---|---|---|
+| Repository policy | `cleanroom.yaml` or `.buildkite/cleanroom.yaml` | Sandbox image, resource floors, repository checkout defaults, deny-by-default network policy, Docker requirement, dependency and service setup |
+| Runtime config | `~/.config/cleanroom/config.yaml` or the server's config path | Backend selection, control endpoint, TLS, auth, gateway credentials, cache peers, observability, lifecycle timers |
+
+The `cleanroom` CLI is always a client. Local commands talk to the local
+`cleanroom serve` daemon over a Unix socket by default. Shared servers expose
+the same control API over HTTPS with authentication.
+
+GitHub App support belongs to the host gateway runtime config. It lets the
+server authenticate upstream Git requests for matching repositories without
+placing credentials in the guest. It does not replace repository network
+policy: a private GitHub checkout still needs policy entries such as
+`github.com:443`, plus whatever package or API hosts the workload uses.
+
+## 1. Install and check the host
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/buildkite/cleanroom/main/scripts/install.sh | bash
+cleanroom doctor
+cleanroom daemon status
+```
+
+The installer puts `cleanroom` in `/usr/local/bin`, installs the VM helper
+where needed, creates runtime config, and starts the daemon. `cleanroom doctor`
+checks the selected backend, helper binaries, image tooling, and policy support
+for the current host.
+
+## 2. Prove a sandbox can run
+
+Start with a repo-agnostic sandbox. This checks the daemon, backend, image
+materialization, and guest execution before repository policy enters the
+picture.
+
+```bash
+sandbox_id="$(cleanroom sandbox create --image ghcr.io/buildkite/cleanroom-base/alpine:latest)"
+cleanroom exec --in "$sandbox_id" -- uname -a
+cleanroom sandbox rm "$sandbox_id"
+```
+
+Use these diagnostics when a first run fails:
+
+```bash
+cleanroom status --last
+cleanroom sandbox inspect --last
+cleanroom execution inspect --last
+cleanroom daemon logs
+```
+
+## 3. Run the Buildkite Agent example
+
+The Buildkite Agent example keeps policy in this repository but checks out and
+runs `buildkite/agent` inside the sandbox.
+
+```bash
+cd examples/buildkite-agent
+cleanroom policy validate
+
+cleanroom exec \
+  --repo-url https://github.com/buildkite/agent.git \
+  -- mise x -- go run . --version
+```
+
+The first run clones the repository, installs the declared `mise` toolchain,
+downloads Go modules, and publishes reusable dependency-stage outputs. Later
+runs against the same exact commit and policy can reuse those warmed outputs.
+
+The example is public and does not require GitHub App credentials. Its network
+allow-list is still representative: it allows GitHub for checkout and the exact
+toolchain/module hosts needed during dependency bootstrap.
+
+## 4. Add Cleanroom policy to your repository
+
+In a real repository, commit `cleanroom.yaml` so CI and local developers use
+the same policy. Start with the smallest set of hosts required for checkout and
+the command you want to run.
+
+```yaml
+version: 1
+sandbox:
+  image:
+    ref: ghcr.io/buildkite/cleanroom-base/debian@sha256:28c3f638fabe1ed780f87b82cfb0c6dda2549c86b9e4edbe519e8250243411c5
+  resources:
+    memory: 8GiB
+    disk: 16GiB
+  network:
+    default: deny
+    allow:
+      - github.com:443
+      - proxy.golang.org:443
+      - sum.golang.org:443
+```
+
+Validate before relying on it:
+
+```bash
+cleanroom policy validate
+cleanroom exec -- go test ./...
+```
+
+Use a digest-pinned image in committed policy. To resolve or update an image
+reference:
+
+```bash
+cleanroom image resolve ghcr.io/buildkite/cleanroom-base/debian:latest
+cleanroom image bump-ref ghcr.io/buildkite/cleanroom-base/debian:latest
+```
+
+Top-level `cleanroom exec` and `cleanroom console` are repo-aware when run from
+a Git checkout. They resolve the current remote and exact `HEAD`, then check out
+that commit at `/workspace` in the guest. Dirty local files are not included
+unless requested:
+
+```bash
+cleanroom exec --copy-in -- go test ./...
+cleanroom exec --copy-out -- gofmt -w ./...
+cleanroom exec --sync -- make generate
+```
+
+## 5. Configure a shared server
+
+For a shared control plane, run the server on HTTPS and require bearer auth:
+
+```bash
+cleanroom serve --listen https://0.0.0.0:7777 \
+  --tls-cert /etc/cleanroom/tls/server.pem \
+  --tls-key /etc/cleanroom/tls/server.key
+```
+
+Server runtime config owns the auth policy and host-side upstream credentials:
+
+```yaml
+auth:
+  required: true
+  oidc:
+    issuers:
+      - name: buildkite
+        issuer: https://agent.buildkite.com
+        audiences:
+          - https://cleanroom.example.com
+        jwks_url: https://agent.buildkite.com/.well-known/jwks
+  policy_file: /etc/cleanroom/auth-policy.yaml
+
+gateway:
+  credentials:
+    github_app:
+      app_id: "3817917"
+      installation_id: "134770928"
+      private_key_file: /etc/cleanroom/github-app.pem
+      repo_prefixes:
+        - buildkite/
+```
+
+Keep the GitHub App private key readable only by the daemon user. GitHub App
+credentials authenticate the host gateway's upstream Git fetches for matching
+repositories. The sandbox still sees normal Git URLs and still needs policy
+allow entries for the upstream destinations.
+
+See [Remote access](remote-access.md) for the full OIDC policy shape and
+[Host gateway](gateway.md#credentials) for credential provider details.
+
+## 6. Call the shared server from Buildkite
+
+Request a short-lived Buildkite OIDC token for the Cleanroom server audience,
+then pass it to the CLI:
+
+```bash
+buildkite-agent oidc request-token \
+  --audience "https://cleanroom.example.com" \
+  --subject-claim pipeline_id \
+  --claim organization_id \
+  > /tmp/cleanroom.jwt
+
+cleanroom exec \
+  --host https://cleanroom.example.com:7777 \
+  --auth-token-file /tmp/cleanroom.jwt \
+  --repo-url "$BUILDKITE_REPO" \
+  -- go test ./...
+```
+
+Use `cleanroom auth check` before pointing a pipeline at a shared server. The
+auth policy should bind immutable Buildkite IDs, then grant only the sandbox
+and execution actions needed by that pipeline.
+
+## 7. Decide where each setting belongs
+
+| Need | Put it in |
+|---|---|
+| Allow `github.com:443` for checkout | Repository policy |
+| Allow `proxy.golang.org:443` for dependency download | Repository policy |
+| Require Docker inside the guest | Repository policy |
+| Configure GitHub App credentials | Server runtime config |
+| Choose `firecracker` or `darwin-vz` | Runtime config or an explicit `--backend` request flag |
+| Require Buildkite OIDC before sandbox creation | Server runtime config |
+| Set OTLP tracing or JSON logs | Server runtime config |
+| Copy local uncommitted changes | Request flag such as `--copy-in` or `--sync` |
+
+Repository policy should stay backend-neutral. Host-specific paths, TLS files,
+credentials, cache peers, and daemon options belong in runtime config.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -185,6 +185,7 @@ cleanroom exec \
   --host https://cleanroom.example.com:7777 \
   --auth-token-file /tmp/cleanroom.jwt \
   --repo-url "$BUILDKITE_REPO" \
+  --repo-commit "$BUILDKITE_COMMIT" \
   -- go test ./...
 ```
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -1,5 +1,8 @@
 # Remote access
 
+For an end-to-end view of how local and shared Cleanroom servers fit into the
+control plane, start with [Control plane](control-plane.md).
+
 The Cleanroom server supports HTTP and HTTPS listener modes for remote access.
 
 ## HTTP

--- a/examples/buildkite-agent/README.md
+++ b/examples/buildkite-agent/README.md
@@ -50,9 +50,16 @@ agent token and `buildkite-agent start` flags.
 
 ## Network Allow List
 
-The `cleanroom.yaml` policy allows egress to the minimum set of hosts
-needed for the explicit `mise exec -- go mod download` dependency bootstrap and
-Go module resolution:
+The `cleanroom.yaml` policy allows egress to the minimum set of hosts needed
+for repository checkout, the explicit `mise exec -- go mod download`
+dependency bootstrap, and Go module resolution.
+
+This section is still current with GitHub App support. GitHub App credentials
+are host-side gateway credentials; they authenticate upstream Git requests for
+matching repositories. They do not replace the sandbox network allow-list. A
+private GitHub checkout still needs `github.com:443` in policy, while the
+server runtime config decides whether the gateway authenticates with a GitHub
+App, a token, or no credential.
 
 | Host | Why |
 |---|---|
@@ -86,3 +93,5 @@ Go module resolution:
 - `ruby.compile=false` avoids source-building Ruby during the dependency stage while still allowing `mise install` to satisfy the repo's current tool declarations
 - Use `mise x -- go ...` for execution commands so the installed Go toolchain is placed on `PATH`
 - `go test -p 1` avoids OOM kills on constrained guest memory
+- For the broader flow from local install to shared Buildkite usage, see
+  [Getting started](../../docs/getting-started.md).


### PR DESCRIPTION
Cleanroom already had detailed policy, API, remote access, and gateway docs, but a new operator trying to understand the control plane had to assemble the first-run path from several places. The Buildkite Agent example also made it unclear whether its network allow-list was still relevant now that GitHub App support exists.

This adds a getting-started guide that walks from local install checks through a first sandbox run, repository policy, shared HTTPS/OIDC server setup, Buildkite token usage, and the split between repository policy and runtime config.

It also adds a control-plane overview that explains the CLI/server/backend/gateway responsibilities, request lifecycle, exact-owner auth behavior, and host-side GitHub App credential boundary.

The Buildkite Agent example now calls out the concrete GitHub App behavior: host-side credentials authenticate upstream Git fetches from the gateway, while the sandbox still needs policy entries such as `github.com:443`.