### PR TITLE
ci: Publish Cleanroom schema to Buf

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,6 +50,22 @@ steps:
     agents:
       queue: hosted
 
+  - label: ":protobuf: Schema"
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+          install_args: buf
+    command: buf lint
+    cache:
+      paths:
+        - "~/.local/share/mise"
+        - "~/.cache/mise"
+        - "~/.local/state/mise"
+      size: "20g"
+      name: "mise-cache"
+    agents:
+      queue: hosted
+
   - label: ":test_tube: Test (macOS)"
     plugins:
       - github.com/buildkite-plugins/setup-go-buildkite-plugin#daa7af945245588f85b76ba7fe0a9af3d87dbf91:
@@ -137,7 +153,34 @@ steps:
 
   - wait
 
+  - label: ":protobuf: Publish schema"
+    key: publish-schema
+    if: build.branch == "main" || build.tag != null
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+          install_args: buf
+    command: |
+      set -eu
+      if [ -z "${BUF_TOKEN:-}" ]; then
+        echo "BUF_TOKEN is required to publish schema to buf.build/buildkite/cleanroom" >&2
+        exit 1
+      fi
+      buf push --git-metadata
+    secrets:
+      - BUF_TOKEN
+    cache:
+      paths:
+        - "~/.local/share/mise"
+        - "~/.cache/mise"
+        - "~/.local/state/mise"
+      size: "20g"
+      name: "mise-cache"
+    agents:
+      queue: hosted
+
   - label: ":rocket: Publish release"
+    depends_on: publish-schema
     if: build.tag != null
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,4 +1,5 @@
 version: v1
+name: buf.build/buildkite/cleanroom
 
 breaking:
   use:
@@ -7,4 +8,8 @@ breaking:
 lint:
   use:
     - STANDARD
-
+  except:
+    - PACKAGE_DIRECTORY_MATCH
+    - RPC_REQUEST_RESPONSE_UNIQUE
+    - RPC_REQUEST_STANDARD_NAME
+    - RPC_RESPONSE_STANDARD_NAME

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -34,6 +34,11 @@ Set
 `CLEANROOM_AUTH_OIDC_ORGANIZATION_ID` or `CLEANROOM_AUTH_OIDC_PIPELINE_ID` if
 the pipeline should fail when those immutable IDs drift.
 
+The protobuf schema is linted with Buf on every build and published to
+`buf.build/buildkite/cleanroom` after tests pass on `main` and tag builds. The
+publish step uses `buf push --git-metadata`, so Buildkite must expose a BSR
+token as `BUF_TOKEN` on those builds.
+
 Cleanroom no longer builds managed `darwin-vz` kernels during its release
 pipeline. The experimental Apple Silicon `darwin-vz` minimal rootfs-profile
 kernel is published from the `buildkite/cleanroom-kernels` project, and runtime

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 go = "1.26.3"
+buf = "1.70.0"
 gotestsum = "1.13.0"
 shellcheck = "0.11.0"
 hyperfine = "1.20.0"
@@ -16,6 +17,10 @@ run = "go test ./..."
 [tasks.lint-shell]
 description = "Lint shell scripts"
 run = "shellcheck -x .buildkite/hooks/pre-command scripts/base-image-tag.sh scripts/cleanroom-root-helper.sh scripts/benchmark-tti.sh scripts/build-go.sh scripts/install-go.sh scripts/install.sh scripts/install-global.sh scripts/package-darwin-vz-helper.sh scripts/release.sh scripts/e2e-observability.sh scripts/ci-with-host-lock.sh scripts/ci-go-test-engine.sh scripts/ci-auth-oidc-smoke.sh scripts/ci-example-smoke.sh scripts/ci-examples-firecracker.sh scripts/ci-examples-darwin-vz.sh scripts/ci-cleanroom-e2e.sh scripts/ci-darwin-vz-e2e.sh scripts/ci-darwin-vz-filehandle-e2e.sh scripts/build-macos-release-pkg.sh scripts/notarize-macos-package.sh scripts/ci-macos-release-pkg.sh scripts/ci-buildkite-release.sh"
+
+[tasks.lint-proto]
+description = "Lint protobuf schemas"
+run = "buf lint"
 
 [tasks.test-full]
 description = "Run full Go test suite"
@@ -120,8 +125,12 @@ run = "docker compose -f examples/observability/docker-compose.yaml down -v"
 
 [tasks.check]
 description = "Run build, test, and lint"
-depends = ["build", "test", "lint-shell"]
+depends = ["build", "test", "lint-shell", "lint-proto"]
 run = "true"
+
+[tasks."proto:push"]
+description = "Publish protobuf schemas to the Buf Schema Registry"
+run = "buf push --git-metadata"
 
 [tasks.release]
 description = "Tag the next version and push to trigger a release"


### PR DESCRIPTION
Cleanroom's protobuf schema now has a Buf Schema Registry module at `buf.build/buildkite/cleanroom`, but the repository did not have a repeatable path for keeping that module current from CI.

This wires Buf into the repo toolchain and Buildkite pipeline. Every build lints the schema with the pinned Buf CLI, and `main` plus tag builds publish with `buf push --git-metadata` after the test wait. The publish step expects Buildkite to expose a BSR token as `BUF_TOKEN`.

The Buf config is bound to `buf.build/buildkite/cleanroom` and keeps explicit lint exceptions for the current package directory and RPC message naming shape, so the new CI lint does not force an API rename. Developers can run `mise run lint-proto` locally or `mise run proto:push` when they need to publish manually.