### PR TITLE
docs: Link Buf schema registry

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,9 @@ ownership, and gateway boundaries, see [Control plane](control-plane.md).
 
 Define a minimal, functional control API for creating and managing Cleanroom sandboxes with durable execution streaming and interactive execution bootstrap.
 
+The published protobuf schema is available in the Buf Schema Registry at
+[buf.build/buildkite/cleanroom](https://buf.build/buildkite/cleanroom).
+
 This document is intentionally small-scope:
 - management plane for sandbox lifecycle
 - execution plane for command runs and streaming output

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -35,9 +35,10 @@ Set
 the pipeline should fail when those immutable IDs drift.
 
 The protobuf schema is linted with Buf on every build and published to
-`buf.build/buildkite/cleanroom` after tests pass on `main` and tag builds. The
-publish step uses `buf push --git-metadata`, so Buildkite must expose a BSR
-token as `BUF_TOKEN` on those builds.
+[buf.build/buildkite/cleanroom](https://buf.build/buildkite/cleanroom) after
+tests pass on `main` and tag builds. The publish step uses
+`buf push --git-metadata`, so Buildkite must expose a BSR token as `BUF_TOKEN`
+on those builds.
 
 Cleanroom no longer builds managed `darwin-vz` kernels during its release
 pipeline. The experimental Apple Silicon `darwin-vz` minimal rootfs-profile


### PR DESCRIPTION
Cleanroom now publishes its protobuf schema to the Buf Schema Registry, but API readers did not have a direct path from the docs to the published module.

This adds the BSR link to the API documentation where SDK and integration authors are most likely to look, and turns the existing CI reference into a Markdown link so the publishing destination is easy to open from the CI notes.