### PR TITLE
feat: Add system warmup command

### DIFF
--- a/internal/backend/darwinvz/backend_darwin.go
+++ b/internal/backend/darwinvz/backend_darwin.go
@@ -464,6 +464,96 @@ func (a *Adapter) Capabilities() map[string]bool {
 	}
 }
 
+func (a *Adapter) Warmup(ctx context.Context, req backend.WarmupRequest) (*backend.WarmupResult, error) {
+	cfg := req.FirecrackerConfig
+	result := &backend.WarmupResult{
+		Backend:            a.Name(),
+		MinimumRootFSBytes: cfg.MinimumRootFSBytes,
+	}
+
+	kernel, err := bootassets.ResolveKernelPathForHostWithVersion(ctx, a.Name(), cfg.KernelImagePath, a.Version)
+	if err != nil {
+		return nil, fmt.Errorf("warm kernel: %w", err)
+	}
+	result.KernelPath = kernel.Path
+	result.KernelStatus = warmupKernelStatus(kernel)
+
+	rootFSPath, imageRef, imageDigest, rootFSStatus, err := a.warmupRootFS(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	rootFSPath, err = filepath.Abs(rootFSPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve rootfs path: %w", err)
+	}
+	if _, err := os.Stat(rootFSPath); err != nil {
+		return nil, fmt.Errorf("rootfs %s: %w", rootFSPath, err)
+	}
+
+	driver, err := rootFSVolumeDriver(cfg)
+	if err != nil {
+		return nil, err
+	}
+	baseVolume, err := driver.EnsureBaseVolume(ctx, volumestore.EnsureBaseVolumeRequest{
+		BaseID:       strings.TrimSuffix(filepath.Base(rootFSPath), filepath.Ext(rootFSPath)),
+		SourcePath:   rootFSPath,
+		MinimumBytes: cfg.MinimumRootFSBytes,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("prepare base volume: %w", err)
+	}
+	baseRootFSRef := strings.TrimSpace(baseVolume.Ref)
+	if baseRootFSRef == "" {
+		return nil, errors.New("prepare base volume returned empty ref")
+	}
+
+	result.RootFSPath = rootFSPath
+	result.RootFSStatus = rootFSStatus
+	result.BaseRootFSRef = baseRootFSRef
+	result.BaseRootFSStatus = backend.WarmupStatusReady
+	result.ImageRef = imageRef
+	result.ImageDigest = imageDigest
+	return result, nil
+}
+
+func warmupKernelStatus(result bootassets.ResolveResult) string {
+	if !result.Managed {
+		return backend.WarmupStatusConfigured
+	}
+	if result.CacheHit {
+		return backend.WarmupStatusCached
+	}
+	return backend.WarmupStatusFetched
+}
+
+func (a *Adapter) warmupRootFS(ctx context.Context, req backend.WarmupRequest) (path, imageRef, imageDigest, status string, err error) {
+	cfg := req.FirecrackerConfig
+	configuredPath := strings.TrimSpace(cfg.RootFSPath)
+	if configuredPath != "" {
+		if _, statErr := os.Stat(configuredPath); statErr == nil {
+			return configuredPath, "", "", backend.WarmupStatusConfigured, nil
+		}
+	}
+
+	ref := strings.TrimSpace(req.ImageRef)
+	if ref == "" {
+		return "", "", "", "", errors.New("warm rootfs: rootfs is not configured and image_ref is empty")
+	}
+	ensurePrepared := a.ensurePreparedRootFSFn
+	if ensurePrepared == nil {
+		ensurePrepared = a.ensurePreparedRuntimeRootFSFromImage
+	}
+	prepared, err := ensurePrepared(ctx, ref)
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("warm rootfs from image %q: %w", ref, err)
+	}
+	status = backend.WarmupStatusPrepared
+	if prepared.Hit {
+		status = backend.WarmupStatusCached
+	}
+	return prepared.Path, prepared.Ref, prepared.Digest, status, nil
+}
+
 func (a *Adapter) SuspendSandbox(ctx context.Context, sandboxID string) error {
 	instance, err := a.lifecycleSandboxInstance(sandboxID)
 	if err != nil {

--- a/internal/backend/darwinvz/warmup_darwin_test.go
+++ b/internal/backend/darwinvz/warmup_darwin_test.go
@@ -1,0 +1,148 @@
+//go:build darwin
+
+package darwinvz
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/cleanroom/internal/backend"
+)
+
+func TestWarmupUsesConfiguredRootFS(t *testing.T) {
+	t.Parallel()
+
+	kernelPath := writeWarmupTestFile(t, "kernel")
+	rootFSPath := writeWarmupTestFile(t, "rootfs.ext4")
+	snapshotBaseDir := t.TempDir()
+
+	adapter := New()
+	adapter.newImageManager = func() (imageEnsurer, error) {
+		t.Fatal("configured rootfs warmup should not initialise image manager")
+		return nil, nil
+	}
+
+	result, err := adapter.Warmup(context.Background(), backend.WarmupRequest{
+		FirecrackerConfig: backend.FirecrackerConfig{
+			KernelImagePath: kernelPath,
+			RootFSPath:      rootFSPath,
+			Snapshots: backend.SnapshotConfig{
+				Driver:  "file",
+				BaseDir: snapshotBaseDir,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Warmup returned error: %v", err)
+	}
+
+	if got, want := result.Backend, "darwin-vz"; got != want {
+		t.Fatalf("unexpected backend: got %q want %q", got, want)
+	}
+	if got, want := result.KernelPath, kernelPath; got != want {
+		t.Fatalf("unexpected kernel path: got %q want %q", got, want)
+	}
+	if got, want := result.KernelStatus, backend.WarmupStatusConfigured; got != want {
+		t.Fatalf("unexpected kernel status: got %q want %q", got, want)
+	}
+	if got, want := result.RootFSPath, rootFSPath; got != want {
+		t.Fatalf("unexpected rootfs path: got %q want %q", got, want)
+	}
+	if got, want := result.RootFSStatus, backend.WarmupStatusConfigured; got != want {
+		t.Fatalf("unexpected rootfs status: got %q want %q", got, want)
+	}
+	if got, want := result.BaseRootFSRef, rootFSPath; got != want {
+		t.Fatalf("unexpected base rootfs ref: got %q want %q", got, want)
+	}
+	if result.ImageRef != "" || result.ImageDigest != "" {
+		t.Fatalf("configured rootfs warmup should not report derived image metadata, got ref=%q digest=%q", result.ImageRef, result.ImageDigest)
+	}
+}
+
+func TestWarmupPreparesImageDerivedRootFS(t *testing.T) {
+	t.Parallel()
+
+	kernelPath := writeWarmupTestFile(t, "kernel")
+	preparedPath := writeWarmupTestFile(t, "prepared.ext4")
+	snapshotBaseDir := t.TempDir()
+
+	const imageRef = "ghcr.io/buildkite/cleanroom-base/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	adapter := New()
+	adapter.ensurePreparedRootFSFn = func(_ context.Context, ref string) (preparedRootFS, error) {
+		if got, want := ref, imageRef; got != want {
+			t.Fatalf("unexpected image ref: got %q want %q", got, want)
+		}
+		return preparedRootFS{
+			Ref:    imageRef,
+			Digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Path:   preparedPath,
+			Hit:    true,
+		}, nil
+	}
+
+	result, err := adapter.Warmup(context.Background(), backend.WarmupRequest{
+		ImageRef: imageRef,
+		FirecrackerConfig: backend.FirecrackerConfig{
+			KernelImagePath: kernelPath,
+			Snapshots: backend.SnapshotConfig{
+				Driver:  "file",
+				BaseDir: snapshotBaseDir,
+			},
+			MinimumRootFSBytes: 8 << 30,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Warmup returned error: %v", err)
+	}
+
+	if got, want := result.RootFSPath, preparedPath; got != want {
+		t.Fatalf("unexpected rootfs path: got %q want %q", got, want)
+	}
+	if got, want := result.RootFSStatus, backend.WarmupStatusCached; got != want {
+		t.Fatalf("unexpected rootfs status: got %q want %q", got, want)
+	}
+	if got, want := result.BaseRootFSRef, preparedPath; got != want {
+		t.Fatalf("unexpected base rootfs ref: got %q want %q", got, want)
+	}
+	if got, want := result.ImageRef, imageRef; got != want {
+		t.Fatalf("unexpected image ref: got %q want %q", got, want)
+	}
+	if got, want := result.ImageDigest, "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"; got != want {
+		t.Fatalf("unexpected image digest: got %q want %q", got, want)
+	}
+	if got, want := result.MinimumRootFSBytes, int64(8<<30); got != want {
+		t.Fatalf("unexpected minimum rootfs bytes: got %d want %d", got, want)
+	}
+}
+
+func TestWarmupRejectsMissingRootFSAndImageRef(t *testing.T) {
+	t.Parallel()
+
+	kernelPath := writeWarmupTestFile(t, "kernel")
+	adapter := New()
+
+	_, err := adapter.Warmup(context.Background(), backend.WarmupRequest{
+		FirecrackerConfig: backend.FirecrackerConfig{
+			KernelImagePath: kernelPath,
+			Snapshots: backend.SnapshotConfig{
+				Driver:  "file",
+				BaseDir: t.TempDir(),
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected missing image ref error")
+	}
+}
+
+func writeWarmupTestFile(t *testing.T, name string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("test"), 0o644); err != nil {
+		t.Fatalf("write warmup test file: %v", err)
+	}
+	return path
+}

--- a/internal/backend/warmup.go
+++ b/internal/backend/warmup.go
@@ -1,0 +1,36 @@
+package backend
+
+import "context"
+
+const (
+	WarmupStatusConfigured = "configured"
+	WarmupStatusCached     = "cached"
+	WarmupStatusFetched    = "fetched"
+	WarmupStatusPrepared   = "prepared"
+	WarmupStatusReady      = "ready"
+)
+
+// WarmupAdapter prepares backend-managed assets that are normally created
+// lazily on the first sandbox launch.
+type WarmupAdapter interface {
+	Adapter
+	Warmup(context.Context, WarmupRequest) (*WarmupResult, error)
+}
+
+type WarmupRequest struct {
+	FirecrackerConfig FirecrackerConfig
+	ImageRef          string
+}
+
+type WarmupResult struct {
+	Backend            string `json:"backend"`
+	KernelPath         string `json:"kernel_path,omitempty"`
+	KernelStatus       string `json:"kernel_status,omitempty"`
+	RootFSPath         string `json:"rootfs_path,omitempty"`
+	RootFSStatus       string `json:"rootfs_status,omitempty"`
+	BaseRootFSRef      string `json:"base_rootfs_ref,omitempty"`
+	BaseRootFSStatus   string `json:"base_rootfs_status,omitempty"`
+	ImageRef           string `json:"image_ref,omitempty"`
+	ImageDigest        string `json:"image_digest,omitempty"`
+	MinimumRootFSBytes int64  `json:"minimum_rootfs_bytes,omitempty"`
+}

--- a/internal/cli/cli_parse_test.go
+++ b/internal/cli/cli_parse_test.go
@@ -253,6 +253,18 @@ func TestSystemCommandsParse(t *testing.T) {
 	if got, want := c.System.Prune.OlderThan, "7d"; got != want {
 		t.Fatalf("unexpected older-than: got %q want %q", got, want)
 	}
+
+	c = &CLI{}
+	parser = newParserForTest(t, c)
+	if _, err := parser.Parse([]string{"system", "warmup", "--backend", "darwin-vz", "--json"}); err != nil {
+		t.Fatalf("parse system warmup returned error: %v", err)
+	}
+	if got, want := c.System.Warmup.Backend, "darwin-vz"; got != want {
+		t.Fatalf("unexpected warmup backend: got %q want %q", got, want)
+	}
+	if !c.System.Warmup.JSON {
+		t.Fatal("expected system warmup --json flag to be set")
+	}
 }
 
 func TestSandboxCreateParsesExposureFlags(t *testing.T) {

--- a/internal/cli/system.go
+++ b/internal/cli/system.go
@@ -15,6 +15,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/buildkite/cleanroom/internal/backend"
 	backendfirecracker "github.com/buildkite/cleanroom/internal/backend/firecracker"
 	cleanroomv1 "github.com/buildkite/cleanroom/internal/gen/cleanroom/v1"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
@@ -24,8 +25,9 @@ import (
 )
 
 type SystemCommand struct {
-	DF    SystemDFCommand    `name:"df" cmd:"" help:"Show cleanroom host storage usage"`
-	Prune SystemPruneCommand `name:"prune" cmd:"" help:"Remove reclaimable cleanroom host storage"`
+	DF     SystemDFCommand     `name:"df" cmd:"" help:"Show cleanroom host storage usage"`
+	Prune  SystemPruneCommand  `name:"prune" cmd:"" help:"Remove reclaimable cleanroom host storage"`
+	Warmup SystemWarmupCommand `name:"warmup" cmd:"" help:"Prepare backend assets used before the first sandbox"`
 }
 
 type SystemDFCommand struct {
@@ -41,6 +43,11 @@ type SystemPruneCommand struct {
 	Table     bool   `help:"Print every prune action as a table"`
 	JSON      bool   `help:"Print prune plan and result as JSON"`
 	OlderThan string `name:"older-than" help:"Include eligible cache entries older than this duration (for example 24h or 7d)"`
+}
+
+type SystemWarmupCommand struct {
+	Backend string `help:"Execution backend to warm (defaults to runtime config or host default)"`
+	JSON    bool   `help:"Print warmup result as JSON"`
 }
 
 var systemInventory = storagegc.Inventory
@@ -121,6 +128,77 @@ func (c *SystemPruneCommand) Run(ctx *runtimeContext) error {
 		return writeSystemPruneTable(stdout(ctx), plan, "reclaimed")
 	}
 	_, err = fmt.Fprintf(stdout(ctx), "reclaimed %s from %d entries\n", formatStorageBytes(result.ReclaimedBytes), result.DeletedEntries)
+	return err
+}
+
+func (c *SystemWarmupCommand) Run(ctx *runtimeContext) error {
+	backendName := resolveBackendName(c.Backend, ctx.Config.DefaultBackend)
+	adapter, ok := ctx.Backends[backendName]
+	if !ok {
+		return fmt.Errorf("unknown backend %q", backendName)
+	}
+	warmer, ok := adapter.(backend.WarmupAdapter)
+	if !ok {
+		return fmt.Errorf("backend %q does not support system warmup", backendName)
+	}
+
+	cfg := runtimeconfig.MergeBackendConfig(ctx.Config, backendName, 0)
+	imageRef, err := resolveSystemWarmupImageRef(context.Background(), cfg)
+	if err != nil {
+		return err
+	}
+	result, err := warmer.Warmup(context.Background(), backend.WarmupRequest{
+		FirecrackerConfig: cfg,
+		ImageRef:          imageRef,
+	})
+	if err != nil {
+		return err
+	}
+	if result == nil {
+		return errors.New("backend warmup returned empty result")
+	}
+	if c.JSON {
+		enc := json.NewEncoder(stdout(ctx))
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+	return writeSystemWarmup(stdout(ctx), *result)
+}
+
+func resolveSystemWarmupImageRef(ctx context.Context, cfg backend.FirecrackerConfig) (string, error) {
+	configuredRootFS := strings.TrimSpace(cfg.RootFSPath)
+	if configuredRootFS != "" {
+		if _, err := os.Stat(configuredRootFS); err == nil {
+			return "", nil
+		}
+	}
+	ref, err := resolveReferenceForPolicyUpdate(ctx, defaultBumpRefSource)
+	if err != nil {
+		return "", fmt.Errorf("resolve default sandbox image %q: %w", defaultBumpRefSource, err)
+	}
+	return ref, nil
+}
+
+func writeSystemWarmup(w io.Writer, result backend.WarmupResult) error {
+	fields := []startupField{
+		{Key: "backend", Value: result.Backend},
+		{Key: "kernel_path", Value: result.KernelPath},
+		{Key: "kernel_status", Value: result.KernelStatus},
+		{Key: "rootfs_path", Value: result.RootFSPath},
+		{Key: "rootfs_status", Value: result.RootFSStatus},
+		{Key: "base_rootfs_ref", Value: result.BaseRootFSRef},
+		{Key: "base_rootfs_status", Value: result.BaseRootFSStatus},
+		{Key: "image_ref", Value: result.ImageRef},
+		{Key: "image_digest", Value: result.ImageDigest},
+	}
+	if result.MinimumRootFSBytes > 0 {
+		fields = append(fields, startupField{Key: "minimum_rootfs_bytes", Value: strconv.FormatInt(result.MinimumRootFSBytes, 10)})
+	}
+	_, err := fmt.Fprint(w, renderSummaryBlock(summaryBlock{
+		Title:      "warmed system",
+		TitleStyle: defaultTerminalPalette().info,
+		Fields:     fields,
+	}, false))
 	return err
 }
 

--- a/internal/cli/system_test.go
+++ b/internal/cli/system_test.go
@@ -3,10 +3,13 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/buildkite/cleanroom/internal/backend"
 	"github.com/buildkite/cleanroom/internal/runtimeconfig"
 	"github.com/buildkite/cleanroom/internal/storagegc"
 )
@@ -90,6 +93,16 @@ func (testSystemZFSImportDatasetStore) DestroyZFSImportDataset(context.Context, 
 	return nil
 }
 
+func writeSystemTestFile(t *testing.T, name string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("test"), 0o644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+	return path
+}
+
 func TestSystemPruneThreadsZFSImportDatasetStore(t *testing.T) {
 	previousListSandboxIDs := systemListSandboxIDs
 	previousInventory := systemInventory
@@ -135,6 +148,213 @@ func TestSystemPruneThreadsZFSImportDatasetStore(t *testing.T) {
 
 	if err := (&SystemPruneCommand{Force: true}).Run(&runtimeContext{Stdout: stdout}); err != nil {
 		t.Fatalf("SystemPruneCommand.Run returned error: %v", err)
+	}
+}
+
+type systemWarmupTestAdapter struct {
+	name    string
+	warmup  func(context.Context, backend.WarmupRequest) (*backend.WarmupResult, error)
+	warmups int
+}
+
+func (a *systemWarmupTestAdapter) Name() string {
+	if a.name != "" {
+		return a.name
+	}
+	return "test"
+}
+
+func (a *systemWarmupTestAdapter) ProvisionSandbox(context.Context, backend.ProvisionRequest) error {
+	return nil
+}
+
+func (a *systemWarmupTestAdapter) RunInSandbox(context.Context, backend.ExecutionRequest, backend.OutputStream) (*backend.ExecutionResult, error) {
+	return &backend.ExecutionResult{}, nil
+}
+
+func (a *systemWarmupTestAdapter) TerminateSandbox(context.Context, string) error {
+	return nil
+}
+
+func (a *systemWarmupTestAdapter) Warmup(ctx context.Context, req backend.WarmupRequest) (*backend.WarmupResult, error) {
+	a.warmups++
+	if a.warmup != nil {
+		return a.warmup(ctx, req)
+	}
+	return &backend.WarmupResult{Backend: a.Name()}, nil
+}
+
+type systemWarmupUnsupportedAdapter struct{}
+
+func (systemWarmupUnsupportedAdapter) Name() string { return "unsupported" }
+
+func (systemWarmupUnsupportedAdapter) ProvisionSandbox(context.Context, backend.ProvisionRequest) error {
+	return nil
+}
+
+func (systemWarmupUnsupportedAdapter) RunInSandbox(context.Context, backend.ExecutionRequest, backend.OutputStream) (*backend.ExecutionResult, error) {
+	return &backend.ExecutionResult{}, nil
+}
+
+func (systemWarmupUnsupportedAdapter) TerminateSandbox(context.Context, string) error {
+	return nil
+}
+
+func TestSystemWarmupUsesConfiguredDefaultBackend(t *testing.T) {
+	rootFS := writeSystemTestFile(t, "rootfs.ext4")
+	adapter := &systemWarmupTestAdapter{name: "darwin-vz"}
+	adapter.warmup = func(_ context.Context, req backend.WarmupRequest) (*backend.WarmupResult, error) {
+		if got, want := req.FirecrackerConfig.RootFSPath, rootFS; got != want {
+			t.Fatalf("unexpected warmup rootfs config: got %q want %q", got, want)
+		}
+		if req.ImageRef != "" {
+			t.Fatalf("expected no image ref for configured rootfs, got %q", req.ImageRef)
+		}
+		return &backend.WarmupResult{
+			Backend:          "darwin-vz",
+			KernelPath:       "/tmp/kernel",
+			KernelStatus:     backend.WarmupStatusConfigured,
+			RootFSPath:       rootFS,
+			RootFSStatus:     backend.WarmupStatusConfigured,
+			BaseRootFSRef:    rootFS,
+			BaseRootFSStatus: backend.WarmupStatusReady,
+		}, nil
+	}
+
+	stdout, readStdout := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := (&SystemWarmupCommand{}).Run(&runtimeContext{
+		Stdout: stdout,
+		Config: runtimeconfig.Config{
+			DefaultBackend: "darwin-vz",
+			Backends: runtimeconfig.Backends{
+				DarwinVZ: runtimeconfig.DarwinVZConfig{RootFS: rootFS},
+			},
+		},
+		Backends: map[string]backend.Adapter{
+			"darwin-vz": adapter,
+		},
+	})
+	if err != nil {
+		t.Fatalf("SystemWarmupCommand.Run returned error: %v", err)
+	}
+	if adapter.warmups != 1 {
+		t.Fatalf("expected one warmup call, got %d", adapter.warmups)
+	}
+	assertContainsAll(t, readStdout(), "warmed system", "backend=darwin-vz", "kernel_path=/tmp/kernel", "rootfs_status=configured", "base_rootfs_status=ready")
+}
+
+func TestSystemWarmupResolvesDefaultImageWhenRootFSMissing(t *testing.T) {
+	previousResolve := resolveReferenceForPolicyUpdate
+	t.Cleanup(func() {
+		resolveReferenceForPolicyUpdate = previousResolve
+	})
+
+	const resolvedRef = "ghcr.io/buildkite/cleanroom-base/alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	var gotSource string
+	resolveReferenceForPolicyUpdate = func(_ context.Context, source string) (string, error) {
+		gotSource = source
+		return resolvedRef, nil
+	}
+
+	adapter := &systemWarmupTestAdapter{name: "darwin-vz"}
+	adapter.warmup = func(_ context.Context, req backend.WarmupRequest) (*backend.WarmupResult, error) {
+		if got, want := req.ImageRef, resolvedRef; got != want {
+			t.Fatalf("unexpected warmup image ref: got %q want %q", got, want)
+		}
+		return &backend.WarmupResult{
+			Backend:      "darwin-vz",
+			RootFSPath:   "/tmp/prepared.ext4",
+			RootFSStatus: backend.WarmupStatusPrepared,
+			ImageRef:     req.ImageRef,
+			ImageDigest:  "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		}, nil
+	}
+
+	stdout, _ := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := (&SystemWarmupCommand{Backend: "darwin-vz"}).Run(&runtimeContext{
+		Stdout: stdout,
+		Config: runtimeconfig.Config{
+			Backends: runtimeconfig.Backends{
+				DarwinVZ: runtimeconfig.DarwinVZConfig{RootFS: "/tmp/missing-cleanroom-rootfs.ext4"},
+			},
+		},
+		Backends: map[string]backend.Adapter{
+			"darwin-vz": adapter,
+		},
+	})
+	if err != nil {
+		t.Fatalf("SystemWarmupCommand.Run returned error: %v", err)
+	}
+	if got, want := gotSource, defaultBumpRefSource; got != want {
+		t.Fatalf("unexpected default image source: got %q want %q", got, want)
+	}
+}
+
+func TestSystemWarmupJSONOutput(t *testing.T) {
+	rootFS := writeSystemTestFile(t, "rootfs.ext4")
+	adapter := &systemWarmupTestAdapter{name: "darwin-vz"}
+	adapter.warmup = func(context.Context, backend.WarmupRequest) (*backend.WarmupResult, error) {
+		return &backend.WarmupResult{
+			Backend:       "darwin-vz",
+			KernelPath:    "/tmp/kernel",
+			KernelStatus:  backend.WarmupStatusConfigured,
+			RootFSPath:    rootFS,
+			RootFSStatus:  backend.WarmupStatusConfigured,
+			BaseRootFSRef: rootFS,
+			ImageRef:      "ghcr.io/buildkite/cleanroom-base/alpine@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			ImageDigest:   "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		}, nil
+	}
+
+	stdout, readStdout := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := (&SystemWarmupCommand{Backend: "darwin-vz", JSON: true}).Run(&runtimeContext{
+		Stdout: stdout,
+		Config: runtimeconfig.Config{
+			Backends: runtimeconfig.Backends{
+				DarwinVZ: runtimeconfig.DarwinVZConfig{RootFS: rootFS},
+			},
+		},
+		Backends: map[string]backend.Adapter{
+			"darwin-vz": adapter,
+		},
+	})
+	if err != nil {
+		t.Fatalf("SystemWarmupCommand.Run returned error: %v", err)
+	}
+
+	var payload backend.WarmupResult
+	if err := json.Unmarshal([]byte(readStdout()), &payload); err != nil {
+		t.Fatalf("unmarshal warmup JSON: %v", err)
+	}
+	if got, want := payload.Backend, "darwin-vz"; got != want {
+		t.Fatalf("unexpected backend: got %q want %q", got, want)
+	}
+	if got, want := payload.RootFSStatus, backend.WarmupStatusConfigured; got != want {
+		t.Fatalf("unexpected rootfs status: got %q want %q", got, want)
+	}
+}
+
+func TestSystemWarmupRejectsUnsupportedBackend(t *testing.T) {
+	stdout, _ := makeStdoutCapture(t)
+	t.Cleanup(func() { _ = stdout.Close() })
+
+	err := (&SystemWarmupCommand{Backend: "firecracker"}).Run(&runtimeContext{
+		Stdout: stdout,
+		Backends: map[string]backend.Adapter{
+			"firecracker": systemWarmupUnsupportedAdapter{},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected unsupported backend error")
+	}
+	if !strings.Contains(err.Error(), `backend "firecracker" does not support system warmup`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Release agents and developers currently pay darwin-vz first-use setup cost during the first sandbox launch: the managed kernel may need to download, and the default OCI rootfs may need to materialize and receive the guest runtime. This adds an explicit warmup path so that setup can happen before release validation or local development.

This adds `cleanroom system warmup --backend darwin-vz`, with optional `--json`, and routes it through a backend `WarmupAdapter` capability. The darwin-vz implementation resolves the managed kernel, prepares the default image-derived runtime rootfs when no configured rootfs is available, and asks the rootfs volume driver to prepare the base volume without creating a retained sandbox.

Example output:

```text
warmed system
backend=darwin-vz
kernel_status=cached
rootfs_status=prepared
base_rootfs_status=ready
```

Unsupported backends fail clearly instead of silently doing nothing, and normal sandbox creation still performs the same lazy setup if warmup was not run first.