### PR TITLE
ci: Use mise task for schema publish

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -160,13 +160,7 @@ steps:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
           install_args: buf
-    command: |
-      set -eu
-      if [ -z "${BUF_TOKEN:-}" ]; then
-        echo "BUF_TOKEN is required to publish schema to buf.build/buildkite/cleanroom" >&2
-        exit 1
-      fi
-      buf push --git-metadata
+    command: mise run proto:push
     secrets:
       - BUF_TOKEN
     cache:

--- a/scripts/buildkite_pipeline_test.go
+++ b/scripts/buildkite_pipeline_test.go
@@ -46,6 +46,33 @@ func TestBuildkitePreCommandHookMintsTestEngineOIDCToken(t *testing.T) {
 	}
 }
 
+func TestBuildkitePublishSchemaUsesMiseTask(t *testing.T) {
+	t.Parallel()
+
+	content, err := os.ReadFile("../.buildkite/pipeline.yml")
+	if err != nil {
+		t.Fatalf("read .buildkite/pipeline.yml: %v", err)
+	}
+
+	pipeline := string(content)
+	if !strings.Contains(pipeline, `secrets:
+      - BUF_TOKEN`) {
+		t.Fatalf("expected publish schema step to request BUF_TOKEN as a secret")
+	}
+	if !strings.Contains(pipeline, `command: mise run proto:push`) {
+		t.Fatalf("expected publish schema step to use the proto:push mise task")
+	}
+	for _, needle := range []string{
+		`${BUF_TOKEN`,
+		`$${BUF_TOKEN`,
+		`buf push --git-metadata`,
+	} {
+		if strings.Contains(pipeline, needle) {
+			t.Fatalf("expected publish schema step not to inline %q in the pipeline command", needle)
+		}
+	}
+}
+
 func TestBuildkiteAuthOIDCSmokeUsesRealBuildkiteToken(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Build #2203 showed the publish-schema job receiving `BUF_TOKEN` from cluster secrets, but the inline pipeline command evaluated the token check during pipeline upload. That left the job command with an empty token check and kept the release target red even though the secret existed.

This changes the publish-schema step to call the existing `proto:push` mise task while preserving the `BUF_TOKEN` secret request. The pipeline stays declarative, and Buf receives the token at job runtime. The pipeline regression test now guards that the step uses the mise task instead of inlining token handling or `buf push` in `.buildkite/pipeline.yml`.