### PR TITLE
chore: add v1 release notes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,19 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+release:
+  header: |
+    {{- if eq .Tag "v1.0.0" }}
+    ## Breaking SporeVM redesign
+
+    Cleanroom v1.0.0 replaces the old runtime/control-plane surface with a focused bake surface: `policy validate`, `compile`, `stamp`, `bake`, `verify`, `gateway serve`, and `version`.
+
+    - Old runtime/control-plane commands were removed.
+    - Existing spores and artifacts must be rebaked because the bake key moved to keyVersion 2.
+    - `scripts/install.sh` and the installer now refuse to install without release checksums.
+
+    {{- end }}
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Summary

This makes the v1.0.0 GoReleaser notes explicitly call out the SporeVM redesign before we cut the tag.

The header is guarded to `v1.0.0`, so later releases keep the normal generated changelog without repeating the breaking-release copy.

## Notes covered

- New bake surface: `policy validate`, `compile`, `stamp`, `bake`, `verify`, `gateway serve`, and `version`
- Old runtime/control-plane commands were removed
- Existing spores and artifacts need a rebake because the bake key moved to `keyVersion 2`
- The installer now refuses to install without release checksums

## Verification

- `mise exec -- goreleaser check`
- `mise exec -- goreleaser release --snapshot --clean --skip=publish`
- `go build ./...`
- `go vet ./internal/... ./cmd/... ./scripts/`
- `go test ./internal/... ./cmd/... ./scripts/`
- `mise exec -- bash scripts/ci-bake-smoke.sh`

## Rollback

Revert this PR. It only changes release-note text generation for the upcoming v1.0.0 release.
