### PR TITLE
Lower policy blocks into warmup

### DIFF
--- a/docs/plans/sporevm-layer.md
+++ b/docs/plans/sporevm-layer.md
@@ -1,8 +1,8 @@
 # Cleanroom Bakes Repeatable Warm Spores
 
 **Status:** Active
-**Last reviewed:** 2026-07-03
-**Related code:** `internal/cli/vm.go`, `internal/gateway/`, `internal/policy/`
+**Last reviewed:** 2026-07-05
+**Related code:** `internal/cli/`, `internal/bake/`, `internal/mediation/`, `internal/policy/`
 **Related upstream:** `~/Develop/sporevm` `origin/main` spore CLI, spore format, named lifecycle
 
 ## Summary
@@ -357,6 +357,45 @@ works end to end on a repo with dependencies, and rebaking without input
 changes is a no-op. Met in full on 2026-07-04, including the
 network-fetching warmup variant.
 
+### Slice 3A: BLOCKS→WARMUP Lowering
+
+Status: implemented as a policy-compiler follow-up to Slice 3, not as a
+change to SporeVM's runtime model.
+
+- `sandbox.dependencies` and `sandbox.services` blocks lower to effective
+  `sandbox.warmup` shell steps. The effective order is explicit
+  `sandbox.warmup` first, then dependency blocks in declaration order, then
+  service blocks in declaration order. Explicit warmup runs first so policies
+  can install toolchains before dependency commands; dependency blocks run
+  before service blocks because services may depend on installed dependencies.
+- Each block lowers to one warmup step. Bake still executes each step through
+  the existing `cd /workspace && <step>` prefix, so generated commands do not
+  `cd` themselves and are always workspace-relative unless the policy command
+  uses absolute paths. Block environment maps are sorted by key and emitted as
+  shell-quoted `KEY=value` assignments before the command line.
+- Under the checkpoint model, declared block outputs are honoured by the whole
+  spore captured at suspend time: everything present in the VM is captured, not
+  a per-output file set. Existing output path and overlap validation remains
+  important because it prevents ambiguous declarations. Inputs remain validated
+  and hash-covered declaration metadata; content freshness still comes from the
+  conservative commit/dirty bake key.
+- `sandbox.dependencies.reuse: exact` (and the default) are accepted because the
+  whole checkpoint captures outputs and the existing commit/dirty key is
+  conservative. `reuse: portable` remains fail-closed at bake compile because
+  input-only portable block-cache semantics are not implemented. `Reuse` is not
+  hash-covered today (`json:"-"`); this is safe only while portable bakes are
+  rejected. Implementing portable reuse later must add reuse semantics to the
+  policy hash and bake key, likely with a bake key-version bump.
+- The fail-closed set is unchanged for unsupported SporeVM semantics:
+  `sandbox.docker.required`, stage-scoped network, `resources.disk`, and
+  `run.before` still reject during `bake.Compile` rather than being ignored.
+
+Deferred follow-ups remain: signed provenance/origin attestation, Kubernetes
+admission and gateway wiring, docker-in-guest support, stage-scoped network,
+`resources.disk`, IPv6 host encoding for provenance and SporeVM arguments,
+hashing the staged file set for non-git workspace cache freshness, and submodule
+staging support.
+
 ### Slice 4: Verify
 
 Status: done, verified live on 2026-07-04.
@@ -509,9 +548,8 @@ cleanroom bake . --out cr-test.spore   # must no-op
 
 ## Open Questions
 
-- Warmup schema shape: a flat command list under `sandbox.warmup`, or named
-  steps with per-step network scope? Default: flat list first; per-step scope
-  only when a concrete policy needs it.
+- Richer block semantics: per-step network scope and portable block caches are
+  deferred until a concrete policy needs them and SporeVM can enforce them.
 - Should bake refuse a dirty worktree by default (record-and-warn vs fail)?
   Default: warn and record `workspace.git.dirty=true`; `--require-clean` for
   CI.

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -66,7 +66,7 @@ Sizes use decimal units (`1gb` = 10^9 bytes); compile rounds memory up to
 SporeVM's 16KiB page alignment. `resources.disk` is not yet translated and
 fails compile.
 
-## Warmup
+## Warmup And Blocks
 
 Warmup commands run once inside the builder VM during `cleanroom bake`, after
 the workspace is copied in. Use them to install dependencies and warm caches
@@ -79,8 +79,62 @@ sandbox:
     - go mod download
 ```
 
-Each entry is a shell command run in the workspace. A failing warmup step
-aborts the bake and destroys the builder.
+Each explicit `warmup` entry is a shell command run in the workspace. A failing
+warmup step aborts the bake and destroys the builder.
+
+`dependencies` and `services` blocks are lowered into effective warmup steps.
+The execution order is:
+
+1. explicit `sandbox.warmup` entries, in declaration order;
+2. `sandbox.dependencies` blocks, in declaration order;
+3. `sandbox.services` blocks, in declaration order.
+
+Explicit warmup runs first so policies can install toolchains before dependency
+commands. Dependency blocks run before service blocks because service setup may
+need those dependencies. Bake executes every effective step as
+`cd /workspace && <step>`, so generated block commands do not change directory
+themselves.
+
+```yaml
+sandbox:
+  warmup:
+    - apk add --no-progress go
+  dependencies:
+    reuse: exact # default; may also omit the object wrapper and declare a list
+    blocks:
+      - name: go-modules
+        command: go mod download          # strings run as: sh -lc <script>
+        inputs:
+          files: [go.mod, go.sum]
+        env:
+          GOPROXY: https://proxy.golang.org,direct
+        outputs:
+          dirs: ["${HOME}/go/pkg/mod"]
+  services:
+    - name: cache
+      command: [sh, -lc, bin/start-cache-service]
+      inputs:
+        files: [service-config.yml]
+      outputs:
+        dirs: [/var/lib/cleanroom/services/cache]
+```
+
+A block lowers to one shell step: sorted `env` assignments with shell-quoted
+values, followed by the command with argv shell-quoted. String commands are
+normalised to `sh -lc <script>`; sequence commands are treated as argv. Do not
+put credentials in block `env`: values are part of the baked policy, appear in
+warmup logs, and may be captured in the spore. Use mediation for credentials.
+
+Block `inputs.files` and `outputs` are declaration metadata. Inputs are
+validated and hash-covered as policy metadata; content freshness comes from the
+commit/dirty bake key. Outputs are honoured by the whole checkpoint: everything
+present in the VM when `spore suspend` runs is captured, while output
+path/overlap validation prevents ambiguous declarations.
+
+`dependencies.reuse: exact` and the default are accepted because the whole
+checkpoint captures block outputs and the commit/dirty bake key is conservative.
+`dependencies.reuse: portable` fails `compile`; input-only portable block-cache
+semantics are not implemented and would require a bake key/hash scheme change.
 
 ## Mediation
 
@@ -106,9 +160,10 @@ These policy fields still parse (so `policy validate` accepts them) but fail
 
 - `sandbox.resources.disk`
 - stage-scoped network policy (per-stage allowlists)
-- `sandbox.docker`
-- `sandbox.dependencies` and `sandbox.services` blocks (use `warmup`)
+- `sandbox.docker.required` (docker-in-guest is deferred)
+- `sandbox.dependencies.reuse: portable`
 - `sandbox.run.before`
+
 ## Removed Fields
 
 Top-level `repository:` and `expose:` blocks belonged to the old runtime and are no longer part of the policy schema. Strict parsing rejects policies that still declare them.

--- a/internal/bake/bake_test.go
+++ b/internal/bake/bake_test.go
@@ -167,6 +167,29 @@ func TestRunBakesEndToEnd(t *testing.T) {
 	}
 }
 
+func TestRunExecutesEffectiveWarmupInWorkspace(t *testing.T) {
+	compiled := &policy.CompiledPolicy{
+		ImageRef: testImageRef,
+		Hash:     "policy-hash",
+		Warmup:   []string{"ALPHA='two words' 'go' 'mod' 'download'"},
+	}
+	runner := &fakeRunner{version: "0.3.1"}
+	options := testOptions(t, runner)
+	key := Key(compiled, CollectGitFacts(options.Dir))
+	runner.annotations = map[string]string{
+		AnnotationPrefix + "provenance.version": "1",
+		AnnotationPrefix + "bake.key":           key,
+	}
+
+	if _, err := Run(compiled, options); err != nil {
+		t.Fatalf("bake: %v", err)
+	}
+	want := "cd " + GuestWorkspaceDir + " && ALPHA='two words' 'go' 'mod' 'download'"
+	if len(runner.execs) != 1 || runner.execs[0] != want {
+		t.Fatalf("execs = %v, want [%q]", runner.execs, want)
+	}
+}
+
 func TestRunDestroysBuilderOnWarmupFailure(t *testing.T) {
 	compiled := testPolicy()
 	runner := &fakeRunner{version: "0.3.1", execErr: errors.New("guest command failed")}

--- a/internal/bake/compile.go
+++ b/internal/bake/compile.go
@@ -70,13 +70,14 @@ func Compile(compiled *policy.CompiledPolicy) (CreateInputs, error) {
 	}
 	inputs.NetworkRules = rules
 	if compiled.RequiresDockerService() {
-		return CreateInputs{}, errors.New("cleanroom compile does not yet translate docker service policy to SporeVM")
+		return CreateInputs{}, errors.New("cleanroom compile does not yet translate sandbox.docker.required to SporeVM (docker-in-guest is deferred)")
 	}
-	if len(compiled.Services.Blocks) > 0 || len(compiled.Services.Command) > 0 {
-		return CreateInputs{}, errors.New("cleanroom compile does not yet translate service stages to SporeVM")
-	}
-	if len(compiled.Dependencies.Blocks) > 0 || len(compiled.Dependencies.Command) > 0 {
-		return CreateInputs{}, errors.New("cleanroom compile does not yet translate dependency stages to SporeVM")
+	if compiled.Dependencies.Reuse == policy.DependencyReusePortable {
+		// Dependencies.Reuse is currently json:"-" in policy.CompiledPolicy, so it
+		// is not covered by the policy hash or bake key. That is safe only because
+		// portable bakes fail closed here; implementing portable reuse must add the
+		// reuse mode and input-only block-cache semantics to the hash/key scheme.
+		return CreateInputs{}, errors.New("cleanroom compile does not yet support sandbox.dependencies.reuse=portable; portable block cache semantics are not implemented")
 	}
 	if len(compiled.Run.Before) > 0 {
 		return CreateInputs{}, errors.New("cleanroom compile does not yet translate run.before hooks to SporeVM")

--- a/internal/bake/compile_test.go
+++ b/internal/bake/compile_test.go
@@ -53,6 +53,29 @@ func TestCompileTranslatesResourcesAndNetwork(t *testing.T) {
 	}
 }
 
+func TestCompileAllowsLoweredDependencyAndServiceBlocks(t *testing.T) {
+	_, err := Compile(&policy.CompiledPolicy{
+		ImageRef:       testImageRef,
+		NetworkDefault: "deny",
+		Warmup:         []string{"'go' 'mod' 'download'", "'sh' '-lc' 'docker compose up -d postgres'"},
+		Dependencies: policy.Dependencies{Blocks: []policy.StageBlock{{
+			Name:    "go-modules",
+			Command: []string{"go", "mod", "download"},
+			Inputs:  policy.StageBlockInputs{Files: []string{"go.mod"}},
+			Outputs: policy.StageBlockOutputs{Dirs: []string{"/workspace/.cache/go"}},
+		}}},
+		Services: policy.Services{Blocks: []policy.StageBlock{{
+			Name:    "postgres",
+			Command: []string{"sh", "-lc", "docker compose up -d postgres"},
+			Inputs:  policy.StageBlockInputs{Files: []string{"docker-compose.yml"}},
+			Outputs: policy.StageBlockOutputs{Dirs: []string{"/var/lib/cleanroom/services/postgres"}},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("compile with lowered blocks: %v", err)
+	}
+}
+
 func TestCompileRejectsUntranslatedFeatures(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -87,7 +110,15 @@ func TestCompileRejectsUntranslatedFeatures(t *testing.T) {
 				ImageRef: testImageRef,
 				Docker:   policy.DockerService{Required: true},
 			},
-			contains: "docker service",
+			contains: "sandbox.docker.required",
+		},
+		{
+			name: "portable dependency reuse",
+			policy: &policy.CompiledPolicy{
+				ImageRef:     testImageRef,
+				Dependencies: policy.Dependencies{Reuse: policy.DependencyReusePortable},
+			},
+			contains: "sandbox.dependencies.reuse=portable",
 		},
 		{
 			name: "stage scoped network",
@@ -98,6 +129,14 @@ func TestCompileRejectsUntranslatedFeatures(t *testing.T) {
 				},
 			},
 			contains: "stage-scoped network",
+		},
+		{
+			name: "run before",
+			policy: &policy.CompiledPolicy{
+				ImageRef: testImageRef,
+				Run:      policy.Run{Before: []string{"sh", "-lc", "true"}},
+			},
+			contains: "run.before",
 		},
 	}
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -141,7 +141,10 @@ type Dependencies struct {
 	Blocks   []StageBlock `json:"blocks,omitempty"`
 	Command  []string     `json:"-"`
 	KeyFiles []string     `json:"-"`
-	Reuse    string       `json:"-"`
+	// Reuse is currently not hash-covered because it is omitted from JSON. This
+	// is safe only while bake rejects portable reuse; implementing portable
+	// block-cache semantics must add reuse to the policy hash and bake key scheme.
+	Reuse string `json:"-"`
 }
 
 type Run struct {
@@ -394,6 +397,7 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 	if err != nil {
 		return nil, err
 	}
+	effectiveWarmup := lowerEffectiveWarmup(warmup, dependencies.Blocks, services.Blocks)
 	mediation, err := normalizeMediation(raw.Sandbox.Mediation)
 	if err != nil {
 		return nil, err
@@ -411,7 +415,7 @@ func Compile(raw rawPolicy) (*CompiledPolicy, error) {
 		Dependencies:   dependencies,
 		Run:            run,
 		Resources:      resources,
-		Warmup:         warmup,
+		Warmup:         effectiveWarmup,
 		Mediation:      mediation,
 	}
 
@@ -1405,6 +1409,40 @@ func combinedStageBlockCommand(blocks []StageBlock) []string {
 		script.WriteString(")\n")
 	}
 	return []string{"sh", "-lc", script.String()}
+}
+
+func lowerEffectiveWarmup(explicit []string, dependencyBlocks, serviceBlocks []StageBlock) []string {
+	if len(explicit) == 0 && len(dependencyBlocks) == 0 && len(serviceBlocks) == 0 {
+		return nil
+	}
+	steps := make([]string, 0, len(explicit)+len(dependencyBlocks)+len(serviceBlocks))
+	steps = append(steps, explicit...)
+	steps = lowerStageBlocksIntoWarmup(steps, dependencyBlocks)
+	steps = lowerStageBlocksIntoWarmup(steps, serviceBlocks)
+	return steps
+}
+
+func lowerStageBlocksIntoWarmup(steps []string, blocks []StageBlock) []string {
+	for _, block := range blocks {
+		steps = append(steps, stageBlockWarmupStep(block))
+	}
+	return steps
+}
+
+func stageBlockWarmupStep(block StageBlock) string {
+	parts := make([]string, 0, len(block.Env)+1)
+	if len(block.Env) > 0 {
+		keys := make([]string, 0, len(block.Env))
+		for key := range block.Env {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			parts = append(parts, key+"="+shellQuote(block.Env[key]))
+		}
+	}
+	parts = append(parts, commandShellLine(block.Command))
+	return strings.Join(parts, " ")
 }
 
 func commandShellLine(command []string) string {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -159,6 +159,120 @@ func TestCompileHashStable(t *testing.T) {
 	}
 }
 
+func TestCompileLowersBlocksIntoEffectiveWarmupOrder(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Warmup = []string{"apk add go ruby"}
+	raw.Sandbox.Dependencies = rawDependencyBlocks(
+		rawBlock("go-modules", []string{"go", "mod", "download"}, []string{"go.mod"}, rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go/pkg/mod"}}),
+		rawBlock("gems", []string{"bundle", "install"}, []string{"Gemfile.lock"}, rawPolicyBlockOutputs{Dirs: []string{"vendor/bundle"}}),
+	)
+	raw.Sandbox.Services = rawPolicyBlocks{
+		rawBlock("postgres", []string{"sh", "-lc", "docker compose up -d postgres"}, []string{"docker-compose.yml"}, rawPolicyBlockOutputs{Dirs: []string{"/var/lib/cleanroom/services/postgres"}}),
+	}
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	want := []string{
+		"apk add go ruby",
+		"'go' 'mod' 'download'",
+		"'bundle' 'install'",
+		"'sh' '-lc' 'docker compose up -d postgres'",
+	}
+	if got := compiled.Warmup; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("effective warmup = %v, want %v", got, want)
+	}
+}
+
+func TestCompileLowersBlockEnvDeterministicallyAndShellQuotes(t *testing.T) {
+	t.Parallel()
+
+	raw := baseRawPolicy()
+	raw.Sandbox.Dependencies = rawDependencyBlocks(
+		rawPolicyBlock{
+			Name:    "deps",
+			Command: rawDependencyCommandSpec{"sh", "-lc", "echo \"$THING\""},
+			Inputs:  rawPolicyBlockInputs{Files: []string{"go.mod"}},
+			Env: map[string]string{
+				"ZED":   "has 'quote",
+				"ALPHA": "two words",
+			},
+			Outputs: rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go/pkg/mod"}},
+		},
+	)
+
+	compiled, err := Compile(raw)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	want := "ALPHA='two words' ZED='has '\"'\"'quote' 'sh' '-lc' 'echo \"$THING\"'"
+	if len(compiled.Warmup) != 1 || compiled.Warmup[0] != want {
+		t.Fatalf("effective warmup = %v, want [%q]", compiled.Warmup, want)
+	}
+}
+
+func TestCompileHashCoversLoweredBlockWarmup(t *testing.T) {
+	t.Parallel()
+
+	makePolicy := func(command []string, env map[string]string) rawPolicy {
+		raw := baseRawPolicy()
+		raw.Sandbox.Dependencies = rawDependencyBlocks(
+			rawPolicyBlock{
+				Name:    "deps",
+				Command: rawDependencyCommandSpec(command),
+				Inputs:  rawPolicyBlockInputs{Files: []string{"go.mod"}},
+				Env:     env,
+				Outputs: rawPolicyBlockOutputs{Dirs: []string{"${HOME}/go/pkg/mod"}},
+			},
+		)
+		return raw
+	}
+
+	base := makePolicy([]string{"go", "mod", "download"}, map[string]string{"GOPROXY": "https://proxy.golang.org,direct"})
+	compiledA, err := Compile(base)
+	if err != nil {
+		t.Fatalf("compile A: %v", err)
+	}
+	compiledB, err := Compile(base)
+	if err != nil {
+		t.Fatalf("compile B: %v", err)
+	}
+	if compiledA.Hash != compiledB.Hash {
+		t.Fatalf("hash mismatch: %s != %s", compiledA.Hash, compiledB.Hash)
+	}
+
+	clone := *compiledA
+	clone.Warmup = nil
+	hashWithoutWarmup, err := hashPolicy(&clone)
+	if err != nil {
+		t.Fatalf("hash without warmup: %v", err)
+	}
+	if hashWithoutWarmup == compiledA.Hash {
+		t.Fatal("expected removing effective warmup to change policy hash")
+	}
+
+	commandChanged, err := Compile(makePolicy([]string{"go", "mod", "download", "-x"}, map[string]string{"GOPROXY": "https://proxy.golang.org,direct"}))
+	if err != nil {
+		t.Fatalf("compile command changed: %v", err)
+	}
+	if commandChanged.Hash == compiledA.Hash {
+		t.Fatal("expected command change to change policy hash")
+	}
+
+	envChanged, err := Compile(makePolicy([]string{"go", "mod", "download"}, map[string]string{"GOPROXY": "direct"}))
+	if err != nil {
+		t.Fatalf("compile env changed: %v", err)
+	}
+	if envChanged.Hash == compiledA.Hash {
+		t.Fatal("expected env change to change policy hash")
+	}
+}
+
 func TestCompileNormalizesNetworkAllowShorthand(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- lower explicit policy dependency/service blocks into effective bake warmup steps
- keep unsupported semantics fail-closed, including docker.required, stage-scoped network, disk, run.before, and portable dependency reuse
- document the BLOCKS→WARMUP design, bake-key implications, and policy author guidance

## Validation
- go build ./...
- go vet ./internal/... ./cmd/... ./scripts/
- go test ./internal/... ./cmd/... ./scripts/
- mise exec -- bash scripts/ci-bake-smoke.sh