### PR TITLE
Keep breaking releases pre-1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,10 +36,10 @@ checksum:
 
 release:
   header: |
-    {{- if eq .Tag "v1.0.0" }}
+    {{- if eq .Tag "v0.12.0" }}
     ## Breaking SporeVM redesign
 
-    Cleanroom v1.0.0 replaces the old runtime/control-plane surface with a focused bake surface: `policy validate`, `compile`, `stamp`, `bake`, `verify`, `gateway serve`, and `version`.
+    Cleanroom v0.12.0 replaces the old runtime/control-plane surface with a focused bake surface: `policy validate`, `compile`, `stamp`, `bake`, `verify`, `gateway serve`, and `version`.
 
     - Old runtime/control-plane commands were removed.
     - Existing spores and artifacts must be rebaked because the bake key moved to keyVersion 2.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NEXT=$(svu next)
 CURRENT=$(svu current)
+NEXT=$(svu next)
+
+# While Cleanroom is pre-1.0, breaking product redesigns are represented as
+# the next 0.x minor release rather than v1.0.0.
+if [[ "$CURRENT" == v0.* && "$NEXT" == v1.* ]]; then
+  NEXT=$(svu minor)
+fi
+
 if [ "$NEXT" = "$CURRENT" ]; then
   echo "No version bump detected (current: $CURRENT). Use conventional commits (feat:, fix:, etc.)."
   exit 1


### PR DESCRIPTION
## Summary
- cap release script breaking bumps at the next 0.x minor while Cleanroom remains pre-1.0
- move the breaking SporeVM redesign release header from v1.0.0 to v0.12.0

## Validation
- bash -n scripts/release.sh
- simulated release calculation: v0.11.0 -> v0.12.0
- mise exec -- goreleaser check